### PR TITLE
Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:2.7.12
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -y \
+    git
+
+RUN apt-get -t jessie-backports install -y "ffmpeg"
+
+
+RUN cd /tmp \
+    && git clone https://github.com/jakul/aggdraw.git \
+    && cd aggdraw \
+    && /usr/local/bin/python setup.py install
+
+
+COPY requirements.txt /tmp
+RUN pip install --no-cache-dir --requirement /tmp/requirements.txt
+
+RUN mkdir /app
+COPY . /app
+WORKDIR /app
+
+ENTRYPOINT ["python", "extract_scene.py"]

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ Try running the following:
 python extract_scene.py -p example_scenes.py SquareToCircle
 
 -p gives a preview of an animation, -w will write it to a file, and -s will show/save the final image in the animation.
+
+## Docker Method
+Since its a bit tricky to get all the dependencies set up just right, there is
+a Dockerfile provided.
+
+1. [Install Docker](https://www.docker.com/products/overview)
+2. Build docker image. `docker build -t manim .`
+3. Run it! `docker run --rm -v "$PWD/files":/app/files manim example_scenes.py WarpSquare`
+
+You'll find the output images in `./files` as usual.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colour==0.1.2
 numpy==1.11.0
-Pillow==1.7.8
+Pillow==3.2.0
 progressbar==2.3
 scipy==0.17.1
 tqdm==4.7.1


### PR DESCRIPTION
It seems that getting the dependencies installed just right for this project is quite tricky, so I decided to write a Dockerfile to eliminate/standardize that headache.

It ended up being fairly straightforward with the final usage going from:
`python extract_scenes.py example_scenes.py WarpSquare`
to
`docker run --rm -v "$PWD"/files:/app/files manim example_scenes.py WarpSquare`
which, while longer, doesn't add any more work for the user and could be hidden behind an alias or shell script if desired.

Any thoughts on if this is something you'd be interested in?

Also, I had to revert the requirements.txt changes to using my version of aggdraw and pillow, I couldn't get it to work using your versions.

How do you setup aggdraw and pillow? I can try to make it work with your versions.

Keep up the great work!
