### PR TITLE
Factorial base counting

### DIFF
--- a/hanoi.py
+++ b/hanoi.py
@@ -147,7 +147,7 @@ class CountingScene(Scene):
         self.number += 1
         new_number_mob = self.get_number_mob(self.number)
         new_number_mob.move_to(self.number_mob, RIGHT)
-        if self.is_perfect_power():
+        if self.is_next_digit():
             self.add_configuration()
             place = len(new_number_mob.split())-1
             result.append(FadeIn(self.dot_templates[place]))
@@ -179,7 +179,11 @@ class CountingScene(Scene):
             place += 1
         return result
 
-    def is_perfect_power(self):
+    def is_next_digit(self):
+        return False
+
+class PowerCounter(CountingScene):
+    def is_next_digit(self):
         number = self.number
         while number > 1:
             if number%self.base != 0:
@@ -187,8 +191,7 @@ class CountingScene(Scene):
             number /= self.base
         return True
 
-
-class CountInDecimal(CountingScene):
+class CountInDecimal(PowerCounter):
     def construct(self):
         for x in range(11):
             self.increment()
@@ -197,7 +200,7 @@ class CountInDecimal(CountingScene):
         for x in range(20):
             self.increment()
 
-class CountInTernary(CountingScene):
+class CountInTernary(PowerCounter):
     CONFIG = {
         "base" : 3,
         "dot_configuration_height" : 1,
@@ -209,7 +212,7 @@ class CountInTernary(CountingScene):
     # def get_template_configuration(self):
     #     return [ORIGIN, UP]
 
-class CountInBinaryTo256(CountingScene):
+class CountInBinaryTo256(PowerCounter):
     CONFIG = {
         "base" : 2,
         "dot_configuration_height" : 1,

--- a/hanoi.py
+++ b/hanoi.py
@@ -49,7 +49,7 @@ class CountingScene(Scene):
 
         self.add(self.number_mob)
 
-    def get_template_configuration(self, pos):
+    def get_template_configuration(self, place):
         #This should probably be replaced for non-base-10 counting scenes
         down_right = (0.5)*RIGHT + (np.sqrt(3)/2)*DOWN
         result = []
@@ -58,9 +58,9 @@ class CountingScene(Scene):
                 result.append(
                     down_right_steps*down_right + left_steps*LEFT
                 )
-        return reversed(result[:self.get_digit_boxes(pos)])
+        return reversed(result[:self.get_place_max(place)])
 
-    def get_dot_template(self, pos):
+    def get_dot_template(self, place):
         #This should be replaced for non-base-10 counting scenes
         down_right = (0.5)*RIGHT + (np.sqrt(3)/2)*DOWN
         dots = VGroup(*[
@@ -71,13 +71,13 @@ class CountingScene(Scene):
                 stroke_width = 2,
                 stroke_color = WHITE,
             )
-            for point in self.get_template_configuration(pos)
+            for point in self.get_template_configuration(place)
         ])
         dots.scale_to_fit_height(self.dot_configuration_height)
         return dots
 
     def add_configuration(self):
-        new_template = self.get_dot_template(len(self.dot_templates) + 1)
+        new_template = self.get_dot_template(len(self.dot_templates))
         new_template.move_to(self.ones_configuration_location)
         left_vect = (new_template.get_width()+LARGE_BUFF)*LEFT
         new_template.shift(
@@ -181,8 +181,6 @@ class CountingScene(Scene):
             place += 1
         return result
 
-    def get_digit_boxes(self, pos):
-        return 1
     def is_next_digit(self):
         return False
     def get_place_num(self, num, place):
@@ -198,8 +196,6 @@ class PowerCounter(CountingScene):
                 return False
             number /= self.base
         return True
-    def get_digit_boxes(self, pos):
-        return self.base
     def get_place_max(self, place):
         return self.base
     def get_place_num(self, num, place):

--- a/hanoi.py
+++ b/hanoi.py
@@ -237,6 +237,22 @@ class CountInBinaryTo256(PowerCounter):
     def get_template_configuration(self):
         return [ORIGIN, UP]
 
+class FactorialBase(CountingScene):
+    CONFIG = {
+        "dot_configuration_height" : 1,
+        "ones_configuration_location" : UP+4*RIGHT
+    }
+    def construct(self):
+        self.count(30, 0.4)
+    def is_next_digit(self):
+        return self.number == self.factorial(self.max_place + 1)
+    def get_place_max(self, place):
+        return place + 2
+    def get_place_num(self, num, place):
+        return (num / self.factorial(place + 1)) % self.get_place_max(place)
+    def factorial(self, n):
+        if (n == 1): return 1
+        else: return n * self.factorial(n - 1)
 
 class TowersOfHanoiScene(Scene):
     CONFIG = {

--- a/hanoi.py
+++ b/hanoi.py
@@ -26,7 +26,7 @@ from mobject.tex_mobject import *
 class CountingScene(Scene):
     CONFIG = {
         "base" : 10,
-        "power_colors" : [YELLOW, MAROON_B, RED, GREEN, BLUE, PURPLE_D],
+        "digit_place_colors" : [YELLOW, MAROON_B, RED, GREEN, BLUE, PURPLE_D],
         "counting_dot_starting_position" : (SPACE_WIDTH-1)*RIGHT + (SPACE_HEIGHT-1)*UP,
         "count_dot_starting_radius" : 0.5,
         "dot_configuration_height" : 2,
@@ -100,7 +100,7 @@ class CountingScene(Scene):
         moving_dot = Dot(
             self.counting_dot_starting_position,
             radius = self.count_dot_starting_radius,
-            color = self.power_colors[0],
+            color = self.digit_place_colors[0],
         )
         moving_dot.generate_target()
         moving_dot.set_fill(opacity = 0)
@@ -135,7 +135,7 @@ class CountingScene(Scene):
                 circle = Circle(
                     radius = radius,
                     stroke_width = 0,
-                    fill_color = self.power_colors[place],
+                    fill_color = self.digit_place_colors[place],
                     fill_opacity = 0.5,
                 )
                 circle.move_to(center)
@@ -157,7 +157,7 @@ class CountingScene(Scene):
             arrow = Arrow(
                 new_number_mob[place].get_top(),
                 self.dot_templates[place].get_bottom(),
-                color = self.power_colors[place]
+                color = self.digit_place_colors[place]
             )
             self.arrows.add(arrow)
             result.append(ShowCreation(arrow))
@@ -172,9 +172,9 @@ class CountingScene(Scene):
         place = 0
         while num > 0:
             digit = TexMobject(str(num % self.base))
-            if place >= len(self.power_colors):
-                self.power_colors += self.power_colors
-            digit.highlight(self.power_colors[place])
+            if place >= len(self.digit_place_colors):
+                self.digit_place_colors += self.digit_place_colors
+            digit.highlight(self.digit_place_colors[place])
             digit.scale(self.num_scale_factor)
             digit.next_to(result, LEFT, buff = SMALL_BUFF, aligned_edge = DOWN)
             result.add(digit)

--- a/hanoi.py
+++ b/hanoi.py
@@ -58,7 +58,7 @@ class CountingScene(Scene):
                 result.append(
                     down_right_steps*down_right + left_steps*LEFT
                 )
-        return reversed(result[:self.base])
+        return reversed(result[:self.get_digit_boxes(pos)])
 
     def get_dot_template(self):
         #This should be replaced for non-base-10 counting scenes
@@ -179,6 +179,8 @@ class CountingScene(Scene):
             place += 1
         return result
 
+    def get_digit_boxes(self, pos):
+        return 1
     def is_next_digit(self):
         return False
 
@@ -190,6 +192,8 @@ class PowerCounter(CountingScene):
                 return False
             number /= self.base
         return True
+    def get_digit_boxes(self, pos):
+        return self.base
 
 class CountInDecimal(PowerCounter):
     def construct(self):

--- a/hanoi.py
+++ b/hanoi.py
@@ -41,7 +41,9 @@ class CountingScene(Scene):
         self.number_mob.scale(self.num_scale_factor)
         self.number_mob.shift(self.num_start_location)
 
-        self.initialize_configurations()
+        self.dot_templates = []
+        self.dot_template_iterators = []
+        self.curr_configurations = []
 
         self.arrows = VGroup()
 
@@ -73,11 +75,6 @@ class CountingScene(Scene):
         ])
         dots.scale_to_fit_height(self.dot_configuration_height)
         return dots
-
-    def initialize_configurations(self):
-        self.dot_templates = []
-        self.dot_template_iterators = []
-        self.curr_configurations = []
 
     def add_configuration(self):
         new_template = self.get_dot_template()


### PR DESCRIPTION
* Adjusts the existing `CountingScene` so it is not specific to fixed base number systems.
* Create a new `PowerCounter` for fixed base counters.
* Add a base factorial counter `FactorialBase`.

#### Base Factorial

`2021` in base factorial equals `2 * 4! + 0 * 3! + 2 * 2! + 1 * 1!`.

To run the factorial counter:

```
python extract_scene.py -p  hanoi.py FactorialBase
```