### PR TITLE
Fixed ApplyMethod animation going in reverse for nested objects

### DIFF
--- a/animation/transform.py
+++ b/animation/transform.py
@@ -137,7 +137,7 @@ class ApplyMethod(Transform):
         )
         assert(isinstance(method.im_self, Mobject))
         method_kwargs = kwargs.get("method_kwargs", {})
-        target = method.im_self.copy()
+        target = method.im_self.deepcopy()
         method.im_func(target, *args, **method_kwargs)
         Transform.__init__(self, method.im_self, target, **kwargs)
 


### PR DESCRIPTION
The apply method animation plays in reverse for nested VMobjects. See the following code as an example. The square should move from left to right, but actually moves from right to left:

```
class Test(Scene):
    def construct(self):
        o = NestedObject()
        self.add(o)
        self.dither()
        self.play(ApplyMethod(o.update))
        self.dither()

class NestedObject(VMobject):
    def __init__(self, **kwargs):
        VMobject.__init__(self, **kwargs)
        self.square = Square();
        self.square.move_to(LEFT_SIDE)
        self.add(self.square)

    def update(self):
        self.square.move_to(RIGHT_SIDE,RIGHT_SIDE)
        return self 
```

I believe this is caused by the ApplyMethod function creating only a shallow copy of the original object. So the method is applied to the original nested VMObject, instead of a copy.

I'm not totally confident about this explanation, because I would expect no animation if this were the case. Either way, creating a deep copy solves the problem, so I figured I'd at least submit it and get some other opinions.