### PR TITLE
Make pip to install aggdraw from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,22 @@ For 9/10 math animation needs, you'd probably be better off using a more well-ma
 
 
 ## Install requirements
+
+Manim dependencies rely on system libraries you will need to install on your
+operating system:
+* ffmpeg
+* latex
+
+Then you can install the python dependencies:
 ```sh
 pip install -r requirements.txt
 ```
 
-Requirements to be installed outside of pip:
-aggdraw (try it from scottopell/aggdraw-64bits@c95aac4)
-ffmpeg
-latex
-
-Here are directions that should work on any 64 bit platform (tested on osx
-10.11.4)
+Note: pip will install the python module `aggdraw` from
+https://github.com/scottopell/aggdraw-64bits/ and it might requires additional
+dependencies.
 
 This doesn't install freetype, but I don't think it's required for this project
-
-```
-cd $TMPDIR
-git clone https://github.com/scottopell/aggdraw-64bits
-cd aggdraw-64bits
-/usr/local/bin/python setup.py build_ext -i
-/usr/local/bin/python setup.py install
-```
 
 ## How to Use
 Try running the following:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pillow==3.4.2
 progressbar==2.3
 scipy==0.17.1
 tqdm==4.7.1
+git+https://github.com/scottopell/aggdraw-64bits@c95aac4369038706943fd0effb7d888683860e5a#egg=aggdraw


### PR DESCRIPTION
pip is able to install a python module straight from a git repository
and supports pinning a specific commit.

Add scottopell/aggdraw-64bits to requirements.txt

Adjust README.md to drop the manual install step now covered by pip
install.

Test plan

I have created an empty virtual env on Debian GNU/Linux and ran the demo
command:
    python extract_scene.py -p example_scenes.py SquareToCircle

Signed-off-by: Antoine Musso <hashar@free.fr>