### PR TITLE
Improve README readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,40 +30,14 @@ This doesn't install freetype, but I don't think it's required for this project
 
 ## How to Use
 Try running the following:
-
+```sh
 python extract_scene.py -p example_scenes.py SquareToCircle
+```
 
--p gives a preview of an animation, -w will write it to a file, and -s will show/save the final image in the animation.
+`-p` gives a preview of an animation, `-w` will write it to a file, and `-s` will show/save the final image in the animation.
 
 Look through the old_projects folder to see the code for previous 3b1b videos.  
 
-While developing a scene, the -s flag is helpful to just see what things look like at the end without having to generate the full animation.  It can also be helpful to put self.force_skipping() at the top of the construct method, and self.revert_to_original_skipping_status() before the portion of the scene that you want to test, and run with the -p flag to just see a preview of one part of the scene.
+While developing a scene, the `-s` flag is helpful to just see what things look like at the end without having to generate the full animation.  It can also be helpful to put `self.force_skipping()` at the top of the construct method, and `self.revert_to_original_skipping_status()` before the portion of the scene that you want to test, and run with the `-p` flag to just see a preview of one part of the scene.
 
-Scene with PiCreatures are somewhat 3b1b specific, so the specific designs for various expressions are not part of the public repo.  You should still be able to run them, but they will fall back on using the "plain" expression for the creature.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+Scene with `PiCreatures` are somewhat 3b1b specific, so the specific designs for various expressions are not part of the public repo.  You should still be able to run them, but they will fall back on using the "plain" expression for the creature.


### PR DESCRIPTION
Typesetting the code differently from the plain words makes it stand out and makes the README slightly easier to read.