### PR TITLE
Improved stability for Windows NT OS

### DIFF
--- a/mobject/tex_mobject.py
+++ b/mobject/tex_mobject.py
@@ -294,6 +294,11 @@ def generate_tex_file(expression, template_tex_file):
             outfile.write(body)
     return result
 
+def get_null():
+    if os.name == "nt":
+        return "NUL"
+    return "/dev/null"
+
 def tex_to_dvi(tex_file):
     result = tex_file.replace(".tex", ".dvi")
     if not os.path.exists(result):
@@ -303,7 +308,8 @@ def tex_to_dvi(tex_file):
             "-halt-on-error",
             "-output-directory=" + TEX_DIR,
             tex_file,
-            "> /dev/null"
+            ">",
+            get_null()
         ]
         exit_code = os.system(" ".join(commands))
         if exit_code != 0:
@@ -334,7 +340,8 @@ def dvi_to_svg(dvi_file, regen_if_exists = False):
             "0",
             "-o",
             result,
-            "> /dev/null"
+            ">",
+            get_null()
         ]
         os.system(" ".join(commands))
     return result

--- a/scene/scene.py
+++ b/scene/scene.py
@@ -5,6 +5,7 @@ import itertools as it
 import warnings
 import time
 import os
+import shutil
 import copy
 from tqdm import tqdm as ProgressDisplay
 import inspect
@@ -497,7 +498,10 @@ class Scene(object):
     def close_movie_pipe(self):
         self.writing_process.stdin.close()
         self.writing_process.wait()
-        os.rename(*self.args_to_rename_file)
+        if os.name == 'nt':
+            shutil.move(*self.args_to_rename_file)
+        else:
+            os.rename(*self.args_to_rename_file)
 
 
 


### PR DESCRIPTION
1. Added `get_null` function in `mobject/tex_mobject.py` to obtain the correct "blackhole directory". Hopefully `tex_to_dvi` and `dvi_to_svg` functions will now work properly on multiple platforms including Windows.
2. Replaced `os.rename` with `shutil.move` to avoid [WindowsError 183].