### PR TITLE
Added support for Chinese and Japanese characters

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -1,7 +1,7 @@
 \documentclass[preview]{standalone}
 
 \usepackage[english]{babel}
-\usepackage[utf8x]{inputenc}
+% \usepackage[utf8x]{inputenc}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{dsfont}
@@ -11,6 +11,7 @@
 \usepackage{mathrsfs}
 \usepackage{calligra}
 \usepackage{wasysym}
+\usepackage[UTF8]{ctex}
 
 \begin{document}
 \centering

--- a/text_template.tex
+++ b/text_template.tex
@@ -1,7 +1,7 @@
 \documentclass[preview]{standalone}
 
 \usepackage[english]{babel}
-\usepackage[utf8x]{inputenc}
+% \usepackage[utf8x]{inputenc}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{dsfont}
@@ -15,7 +15,7 @@
 \usepackage{ragged2e}
 \usepackage{physics}
 \usepackage{xcolor}
-
+\usepackage[UTF8]{ctex}
 
 \begin{document}
 


### PR DESCRIPTION
Simple modifications to tex templates.
I tested all 6 available fonts in `ctex` package, and they work pretty fine with CJ characters in both `TextMobject` (plain text) and `TexMobject` (formula).

P.S.: I should've say "CJK characters", but for some reason, Korean characters aren't able to display normally on my computer, so I dropped them for now.