### PR TITLE
[WRITE] Fix the write of video output file

### DIFF
--- a/scene/scene.py
+++ b/scene/scene.py
@@ -516,8 +516,7 @@ class Scene(object):
             '-loglevel', 'error',
             temp_file_path,
         ]
-        
-        self.writing_process = sp.Popen(command, stdin=sp.PIPE, shell=True)
+        self.writing_process = sp.Popen(command, stdin=sp.PIPE)
 
     def close_movie_pipe(self):
         self.writing_process.stdin.close()


### PR DESCRIPTION
This is a tiny modification. I can't justify it right now "why does this modification fix the writing of video file (on my computer)", but I can say that, with the option `shell = True`, I get the following error message in my terminal:
```bash
~/wk/manim $ python extract_scene.py -w example_scenes.py SquareToCircle
Writing to /home/frozar/Dropbox/3b1b_videos/animations/example_scenes/SquareToCircleTemp.mp4
  0%|                                                                                                                                                                                       | 0/60 [00:00<?, ?it/s]ffmpeg version 2.8.11-0ubuntu0.16.04.1 Copyright (c) 2000-2017 the FFmpeg developers
  built with gcc 5.4.0 (Ubuntu 5.4.0-6ubuntu1~16.04.4) 20160609
  configuration: --prefix=/usr --extra-version=0ubuntu0.16.04.1 --build-suffix=-ffmpeg --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --cc=cc --cxx=g++ --enable-gpl --enable-shared --disable-stripping --disable-decoder=libopenjpeg --disable-decoder=libschroedinger --enable-avresample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libmodplug --enable-libmp3lame --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-librtmp --enable-libschroedinger --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxvid --enable-libzvbi --enable-openal --enable-opengl --enable-x11grab --enable-libdc1394 --enable-libiec61883 --enable-libzmq --enable-frei0r --enable-libx264 --enable-libopencv
  libavutil      54. 31.100 / 54. 31.100
  libavcodec     56. 60.100 / 56. 60.100
  libavformat    56. 40.101 / 56. 40.101
  libavdevice    56.  4.100 / 56.  4.100
  libavfilter     5. 40.101 /  5. 40.101
  libavresample   2.  1.  0 /  2.  1.  0
  libswscale      3.  1.101 /  3.  1.101
  libswresample   1.  2.101 /  1.  2.101
  libpostproc    53.  3.100 / 53.  3.100
Hyper fast Audio and Video encoder
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...

Use -h to get full help or, even better, run 'man ffmpeg'
```

It seems like the ffmpeg program is not call correctly. Maybe because it is waiting for some image in the input PIPE and it's possible that this behavior is not compatible with the Popen option `shell = True`. It should be check. Also, I think that this option has been introduce recently and I don't check the reason why it was introduced. Finally, if I remember well, the official python documentation say that this option has some security issue and is depreacated.

So in this PR, I propose to remove this `shell = True` option to bring back the great feature: write video output file.