### PR TITLE
A few improvements on TexMobject

### DIFF
--- a/mobject/tex_mobject.py
+++ b/mobject/tex_mobject.py
@@ -87,7 +87,7 @@ class TexMobject(SVGMobject):
             should_replace = reduce(op.and_, [
                 t1 in tex,
                 t2 not in tex,
-                len(tex) > len(t1) and tex[len(t1)] in "()[]|\\"
+                len(tex) > len(t1) and tex[len(t1)] in "()[]<>|.\\"
             ])
             if should_replace:
                 tex = tex.replace(t1, "\\big")
@@ -166,9 +166,16 @@ class TexMobject(SVGMobject):
             part.highlight(color)
         return self
 
-    def highlight_by_tex_to_color_map(self, tex_to_color_map):
-        for tex, color in tex_to_color_map.items():
-            self.highlight_by_tex(tex, color)
+    def highlight_by_tex_to_color_map(self, texs_to_color_map, **kwargs):
+        for texs, color in texs_to_color_map.items():
+            try:
+                # If the given key behaves like strings
+                texs + ''
+                self.highlight_by_tex(texs, color, **kwargs)
+            except TypeError:
+                # If the given key is a tuple
+                for tex in texs:
+                    self.highlight_by_tex(tex, color, **kwargs)
         return self
 
     def index_of_part(self, part):


### PR DESCRIPTION
1. Modified `highlight_by_tex_to_color_map()` so that it's able to accept a dictionary with both string and tuple as keys.
For example, the following color_map is now valid:
`{"x": BLUE, ("y", "z"): YELLOW}`
2. Also, the keyword argument `substring` should work properly in `highlight_by_tex_to_color_map()`.
3. Added some special characters in `modify_special_strings()`.
