### PR TITLE
Resolve undefined names in Python 2 and 3

### DIFF
--- a/old_projects/nn/network.py
+++ b/old_projects/nn/network.py
@@ -29,6 +29,12 @@ IMAGE_MAP_DATA_FILE = os.path.join(NN_DIRECTORY, "image_map")
 # DEFAULT_LAYER_SIZES = [28**2, 80, 10]
 DEFAULT_LAYER_SIZES = [28**2, 16, 16, 10]
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 class Network(object):
     def __init__(self, sizes, non_linearity = "sigmoid"):
         """The list ``sizes`` contains the number of neurons in the

--- a/old_projects/number_line_scene.py
+++ b/old_projects/number_line_scene.py
@@ -1,6 +1,10 @@
 import numpy as np
-from animation.transform import Transform
+from animation.transform import ApplyMethod, Transform
+from constants import RIGHT, SPACE_WIDTH, UP
+from helpers import counterclockwise_path, straight_path
 from point_cloud_mobject import Point
+from scene import Scene
+from topics.geometry import Line
 from topics.number_line import NumberLine
 
 class NumberLineScene(Scene):
@@ -23,7 +27,7 @@ class NumberLineScene(Scene):
             number_at_center = number
         )
         new_displayed_numbers = new_number_line.default_numbers_to_display()
-        new_number_mobs = new_number_line.get_number_mobjects(*new_displayed_numbers)        
+        new_number_mobs = new_number_line.get_number_mobjects(*new_displayed_numbers)
 
         transforms = []
         additional_mobjects = []
@@ -78,11 +82,3 @@ class NumberLineScene(Scene):
             ApplyMethod(mob.shift, (num-1)*mob.get_center()[0]*RIGHT, **kwargs)
             for mob in self.number_mobs
         ])
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Fixes #96

These are the minimal changes required to fix #96 and define __xrange()__ for Python 3.