### PR TITLE
Winding number

### DIFF
--- a/animation/simple_animations.py
+++ b/animation/simple_animations.py
@@ -491,16 +491,14 @@ class AnimationGroup(Animation):
         "rate_func" : None
     }
     def __init__(self, *sub_anims, **kwargs):
-        digest_config(self, kwargs, locals())
         sub_anims = filter (lambda x : not(x.empty), sub_anims)
+        digest_config(self, locals())
+        self.update_config(**kwargs) # Handles propagation to self.sub_anims
+
         if len(sub_anims) == 0:
             self.empty = True
             self.run_time = 0
         else:
-            for anim in sub_anims:
-                # If AnimationGroup is called with any configuration,
-                # it is propagated to the sub_animations
-                anim.update_config(**kwargs)
             self.run_time = max([a.run_time for a in sub_anims])
         everything = Mobject(*[a.mobject for a in sub_anims])
         Animation.__init__(self, everything, **kwargs)
@@ -512,6 +510,14 @@ class AnimationGroup(Animation):
     def clean_up(self, *args, **kwargs):
         for anim in self.sub_anims:
             anim.clean_up(*args, **kwargs)
+
+    def update_config(self, **kwargs):
+        Animation.update_config(self, **kwargs)
+        
+        # If AnimationGroup is called with any configuration,
+        # it is propagated to the sub_animations
+        for anim in self.sub_anims:
+            anim.update_config(**kwargs)
 
 class EmptyAnimation(Animation):
     CONFIG = {

--- a/animation/simple_animations.py
+++ b/animation/simple_animations.py
@@ -443,13 +443,12 @@ class Succession(Animation):
 
     # Beware: This does NOT take care of calling update(0) on the subanimation.
     # This was important to avoid a pernicious possibility in which subanimations were called
-    # with update(0) twice, which could in turn call a sub-Succession with update(0) four times,
+    # with update twice, which could in turn call a sub-Succession with update four times,
     # continuing exponentially.
     def jump_to_start_of_anim(self, index):
         if index != self.current_anim_index:
             self.mobject.remove(*self.mobject.submobjects) # Should probably have a cleaner "remove_all" method...
-            for m in self.scene_mobjects_at_time[index].submobjects:
-                self.mobject.add(m)
+            self.mobject.add(*self.scene_mobjects_at_time[index].submobjects)
             self.mobject.add(self.animations[index].mobject)
 
         for i in range(index):
@@ -459,10 +458,9 @@ class Succession(Animation):
         self.current_alpha = self.critical_alphas[index]
 
     def update_mobject(self, alpha):
-        if alpha == self.current_alpha:
-            return
-
         if self.num_anims == 0:
+            # This probably doesn't matter for anything, but just in case,
+            # we want it in the future, we set current_alpha even in this case
             self.current_alpha = alpha
             return
 


### PR DESCRIPTION
Fixed bug where AnimationGroups did not propagate configs correctly under update_config (in particular, this was a problem when nested AnimationGroups were initializing).

Fixed bug where AnimationGroups did not filter out empty animations correctly from their initialization of self.sub_anims (as they digested their configurations before doing this filtering).