### PR TITLE
Add Continuous Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ playground.py
 special_animations.py
 prettiness_hall_of_fame.py
 files/
+out/
 ben_playground.py
 ben_cairo_test.py
 .floo
@@ -14,5 +15,4 @@ ben_cairo_test.py
 *.iml
 manim.sublime-project
 manim.sublime-workspace
-
 primes.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+matrix:
+  include:
+    - os: osx
+  fast_finish: true
+
+install:
+  - brew install sox
+  - brew install ffmpeg
+  - brew cask install mactex
+  - pip2 install -r requirements.txt
+
+script:
+  # just run a simple demo scenario to test that we don't crash
+  # TODO: this should be replaced by tests in future
+  - python2 extract_scene.py example_scenes.py SquareToCircle -p
+
+# timeout uploading cache after 6 minutes (360 seconds)
+cache:
+  timeout: 360
+  directories:
+    - $HOME/Library/Caches/Homebrew

--- a/constants.py
+++ b/constants.py
@@ -1,11 +1,10 @@
 import os
 import numpy as np
 
-# Things anyone wishing to use this repository for their
-# own use will want to change this
-MEDIA_DIR = os.path.join(os.path.expanduser('~'), "Dropbox (3Blue1Brown)/3Blue1Brown Team Folder")
+# Change this to point to where you want 
+# animation files to output
+MEDIA_DIR = 'out'
 #
-
 
 DEFAULT_PIXEL_HEIGHT = 1080
 DEFAULT_PIXEL_WIDTH  = 1920

--- a/out/README.md
+++ b/out/README.md
@@ -1,0 +1,4 @@
+This is the default output directory for manim.
+You can change it by alternating `MEDIA_DIR` in `constants.py`
+
+TODO: make it configurable without code changes https://github.com/3b1b/manim/issues/161


### PR DESCRIPTION
This PR is a follow-up for #160 and contains of 2 parts:

1) `.travis.yml` that's ready to be used for macOS CI, see https://travis-ci.org/vors/manim to get a sense of how it will look like (and also a proof that it works)
2) Necessary changes to make the build in CI possible (put some reasonable-ish default value for `MEDIA_DIR`). I also opened an issue #161 to follow-up it with a better fix eventually.