### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/active_projects/eop/bayes.py
+++ b/active_projects/eop/bayes.py
@@ -113,7 +113,7 @@ class IntroducePokerHand(PiCreatureScene, SampleSpaceScene):
             card.generate_target()
 
         straight_cards = VGroup(*it.chain(
-            you.hand.target, 
+            you.hand.target,
             [c.target for c in selected_community_cards]
         ))
         straight_cards.submobjects.sort(card_cmp)
@@ -214,7 +214,7 @@ class IntroducePokerHand(PiCreatureScene, SampleSpaceScene):
     def compute_flush_probability(self):
         you, her = self.you, self.her
         equation = TexMobject(
-            "{ {10 \\choose 2}", "\\over", "{45 \\choose 2} }", 
+            "{ {10 \\choose 2}", "\\over", "{45 \\choose 2} }",
             "=", "{45 \\over 990}", "\\approx", "4.5\\%"
         )
         equation.next_to(self.community_cards, UP, buff = LARGE_BUFF)
@@ -247,19 +247,19 @@ class IntroducePokerHand(PiCreatureScene, SampleSpaceScene):
         self.play(LaggedStart(FadeIn, equation))
         self.wait(2)
         self.play(
-            FadeIn(num_hearts), 
+            FadeIn(num_hearts),
             ShowCreation(num_hearts_arrow),
             ten.set_color, RED,
         )
         self.play(
-            FadeIn(num_cards), 
+            FadeIn(num_cards),
             ShowCreation(num_cards_arrow),
             fourty_five.set_color, BLUE
         )
         self.wait(3)
         equation.remove(percentage)
         self.play(*map(FadeOut, [
-            equation, 
+            equation,
             num_hearts, num_hearts_arrow,
             num_cards, num_cards_arrow,
         ]))
@@ -308,7 +308,7 @@ class IntroducePokerHand(PiCreatureScene, SampleSpaceScene):
                 [("3H", "8H"), ("4H", "5H"), ("JH", "KH")],
                 [("AC", "6D"), ("3D", "6S"), ("JH", "4C")],
             ]
-        ]   
+        ]
         for hand_list, part in zip(hand_lists, [top_part, bottom_part]):
             self.play(Indicate(part, scale_factor = 1))
             for hand in hand_list:
@@ -456,12 +456,12 @@ class IntroducePokerHand(PiCreatureScene, SampleSpaceScene):
         card2.move_to(card1)
         card2.shift(MED_SMALL_BUFF*RIGHT + SMALL_BUFF*DOWN)
         hand.next_to(
-            pi_creature, vect, 
+            pi_creature, vect,
             buff = MED_LARGE_BUFF,
             aligned_edge = UP
         )
         return hand
-    
+
 class HowDoesPokerWork(TeacherStudentsScene):
     def construct(self):
         self.student_says(
@@ -564,13 +564,13 @@ class UpdatePokerPrior(SampleSpaceScene):
         self.play(FadeIn(her))
         self.play(glasses.restore)
         self.play(
-            her.change_mode, "happy", 
+            her.change_mode, "happy",
             Animation(glasses)
         )
         self.wait(2)
 
         self.her = her
-        
+
     def add_bottom_conditionals(self):
         her = self.her
         bottom_part = self.sample_space.horizontal_parts[1]
@@ -635,14 +635,14 @@ class UpdatePokerPrior(SampleSpaceScene):
         bubble.add_content(words)
 
         numbers = VGroup(
-            self.top_conditional_rhs, 
+            self.top_conditional_rhs,
             self.bottom_conditional_rhs
         )
         numbers.save_state()
         arrows = VGroup(*[
             Arrow(
-                numbers_word.get_left(), 
-                num.get_right(), 
+                numbers_word.get_left(),
+                num.get_right(),
                 buff = 2*SMALL_BUFF
             )
             for num in numbers
@@ -758,7 +758,7 @@ class UpdatePokerPrior(SampleSpaceScene):
 
     def write_P_flush_given_bet(self):
         posterior_tex = TexMobject(
-            "P(", self.double_heart_template, 
+            "P(", self.double_heart_template,
             "|", self.cash_string, ")"
         )
         posterior_tex.scale(0.7)
@@ -957,7 +957,7 @@ class UpdatePokerPrior(SampleSpaceScene):
         prior_rhs_group = self.get_prior_rhs_group()
 
         fraction = TexMobject(
-            "{(0.045)", "(0.97)", "\\over", 
+            "{(0.045)", "(0.97)", "\\over",
             "(0.995)", "(0.3)", "+", "(0.045)", "(0.97)}"
         )
         products = [
@@ -1044,7 +1044,7 @@ class UpdatePokerPrior(SampleSpaceScene):
                 "P(", s, self.double_heart_template, ")",
                 "= ", num
             )
-            for s, num in ("", p_str), ("\\text{not }", q_str)
+            for s, num in (("", p_str), ("\\text{not }", q_str))
         ]
         for label in labels:
             label.scale(0.7)
@@ -1058,7 +1058,7 @@ class UpdatePokerPrior(SampleSpaceScene):
 
     def get_conditional_label(self, value, given_flush = True):
         label = TexMobject(
-            "P(", self.cash_string, "|", 
+            "P(", self.cash_string, "|",
             "" if given_flush else "\\text{not }",
             self.double_heart_template, ")",
             "=", str(value)
@@ -1110,8 +1110,8 @@ class BayesRuleInMemory(Scene):
         B = "\\text{Belief}"
         D = "\\text{Data}"
         rule = TexMobject(
-            "P(", B, "|", D, ")", "=", 
-            "P(", "B", ")", 
+            "P(", B, "|", D, ")", "=",
+            "P(", "B", ")",
             "{P(", D, "|", B, ")", "\\over", "P(", D, ")}"
         )
         rule.set_color_by_tex(B, RED)
@@ -1187,7 +1187,7 @@ class BayesianNetworkPreview(Scene):
         nodes = VGroup(*[
             node.copy().shift(x*RIGHT + y*UP)
             for x, y in [
-                (-1, 0),  
+                (-1, 0),
                 (1, 0),
                 (-2, 2),
                 (0, 2),
@@ -1212,7 +1212,7 @@ class BayesianNetworkPreview(Scene):
         for i1, i2 in edge_index_pairs:
             n1, n2 = nodes[i1], nodes[i2]
             edge = Arrow(
-                n1.get_center(), 
+                n1.get_center(),
                 n2.get_center(),
                 buff = radius,
                 color = WHITE,
@@ -1417,10 +1417,10 @@ class GeneralizeBayesRule(SampleSpaceScene):
         )
 
         self.play(
-            Write(prior_word), 
-            ShowCreation(prior_arrow), 
+            Write(prior_word),
+            ShowCreation(prior_arrow),
             ShowCreation(prior_rect),
-        ) 
+        )
         self.wait()
         self.play(Transform(
             prior.copy(), prior_target,
@@ -1440,13 +1440,13 @@ class GeneralizeBayesRule(SampleSpaceScene):
         self.play(FocusOn(self.sample_space[0][0]))
         for i in range(2):
             self.play(Indicate(
-                self.sample_space[i][0], 
+                self.sample_space[i][0],
                 scale_factor = 1
             ))
         self.wait()
         self.play(
-            Write(posterior_word), 
-            ShowCreation(posterior_arrow), 
+            Write(posterior_word),
+            ShowCreation(posterior_arrow),
             ShowCreation(posterior_rect),
         )
 
@@ -1468,7 +1468,7 @@ class GeneralizeBayesRule(SampleSpaceScene):
         name.next_to(self.posterior_tex, UP, 1.5*LARGE_BUFF)
         arrows = [
             Arrow(
-                name, rect.get_edge_center(vect), 
+                name, rect.get_edge_center(vect),
                 tip_length = 0.15
             )
             for rect, vect in zip(rects, [RIGHT, UP])
@@ -1555,7 +1555,7 @@ class GeneralizeBayesRule(SampleSpaceScene):
         self.wait()
         self.play(*it.chain(
             self.get_division_change_animations(
-                self.sample_space, 
+                self.sample_space,
                 self.sample_space.horizontal_parts,
                 0.1
             ),
@@ -1663,7 +1663,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         randy = self.pi_creature
         friends = VGroup(*[
             PiCreature(mode = "happy", color = color).flip()
-            for color in BLUE_B, GREY_BROWN, MAROON_E
+            for color in (BLUE_B, GREY_BROWN, MAROON_E)
         ])
         friends.scale(0.6)
         friends.arrange_submobjects(RIGHT)
@@ -1677,7 +1677,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         self.play(FadeIn(friends))
         self.pi_creatures.add(*friends)
         self.play(
-            FadeIn(headphones), 
+            FadeIn(headphones),
             Animation(friends)
         )
         self.play_notes(randy.guitar)
@@ -1714,7 +1714,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         bubble.add_content(content)
         VGroup(bubble, content).next_to(friends, LEFT, SMALL_BUFF)
         VGroup(bubble, content).to_edge(UP, SMALL_BUFF)
-    
+
         self.play(LaggedStart(
             ApplyMethod, friends,
             lambda pi : (pi.change_mode, "conniving")
@@ -1789,7 +1789,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         self.change_pi_creature_with_guitar(
             "soulful_musician",
             LaggedStart(
-                ApplyMethod, friends, 
+                ApplyMethod, friends,
                 lambda pi : (pi.change, "happy"),
                 run_time = 1,
             )
@@ -1887,14 +1887,14 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         rhs.scale(0.7)
         rhs.next_to(post_tex, RIGHT)
         ratio = TexMobject(
-            "{(0.8)(0.9)", "\\over", 
+            "{(0.8)(0.9)", "\\over",
             "(0.8)(0.9)", "+", "(0.2)(0.99)}"
         )
         ratio.scale(0.6)
         ratio.next_to(VGroup(post_tex, rhs), DOWN, LARGE_BUFF)
         ratio.to_edge(RIGHT)
         arrow_kwargs = {
-            "tip_length" : 0.15, 
+            "tip_length" : 0.15,
             "color" : WHITE,
             "buff" : 2*SMALL_BUFF,
         }
@@ -1966,16 +1966,16 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         for value in 0.5, 0.1, 0.9:
             label = self.get_conditional_label(value)
             self.play(*self.get_top_conditional_change_anims(
-                value, post_rects, 
+                value, post_rects,
                 new_label_kwargs = {"labels" : [label]},
             ), run_time = 2)
             self.wait(2)
 
     def fade_out_post_rect(self):
         self.play(*map(FadeOut, [
-            self.post_rects, 
-            self.post_rects.braces, 
-            self.post_rects.labels, 
+            self.post_rects,
+            self.post_rects.braces,
+            self.post_rects.labels,
         ]))
         self.play(self.negative_space.restore)
 
@@ -2006,7 +2006,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         self.wait()
         self.play(ReplacementTransform(
             new_prior_rects.copy(), post_rects,
-            run_time = 2            
+            run_time = 2
         ))
         self.play(GrowFromCenter(brace))
         self.wait(2)
@@ -2060,7 +2060,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
     def get_conditional_label(self, value, given_suck = True):
         positive_str = "\\checkmark"
         label = TexMobject(
-            "P(", positive_str, "|", 
+            "P(", positive_str, "|",
             "" if given_suck else "\\text{not }",
             "S", ")",
             "=", str(value)
@@ -2096,7 +2096,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
             sine_wave.point_from_proportion(0)
         )
         self.play(LaggedStart(
-            MoveAlongPath, notes, 
+            MoveAlongPath, notes,
             lambda n : (n, sine_wave),
             path_arc = np.pi/2,
             run_time = 4,
@@ -2161,7 +2161,7 @@ class FinalWordsOnRule(SampleSpaceScene):
 
     def add_uses(self):
         uses = TextMobject(
-            "Machine learning, ", 
+            "Machine learning, ",
             "scientific inference, $\\dots$",
         )
         uses.to_edge(UP)
@@ -2276,16 +2276,3 @@ class Thumbnail(SampleSpaceScene):
 
         VGroup(sample_space, post_rects).next_to(title, DOWN, LARGE_BUFF)
         self.add(sample_space, post_rects)
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/active_projects/eop/bayes_footnote.py
+++ b/active_projects/eop/bayes_footnote.py
@@ -138,7 +138,7 @@ class Introduction(TeacherStudentsScene):
             )
         )
         self.change_student_modes(
-            *["pondering"]*3, 
+            *["pondering"]*3,
             look_at_arg = disease_group
         )
 
@@ -174,7 +174,7 @@ class Introduction(TeacherStudentsScene):
         )
 
         self.play(
-            disease_group.next_to, 
+            disease_group.next_to,
                 self.teacher.get_corner(UP+LEFT), UP,
             disease_group.shift, LEFT,
             intuitive_examples.scale, 0.7,
@@ -189,7 +189,7 @@ class Introduction(TeacherStudentsScene):
         something_else.scale_to_fit_height(bayes.get_height())
         something_else.move_to(bayes, RIGHT)
         new_group = VGroup(
-            something_else, 
+            something_else,
             *self.bayes_to_intuition[1:]
         )
 
@@ -314,7 +314,7 @@ class TestScene(PiCreatureScene):
 
     def get_test_arrow(self):
         arrow = Arrow(
-            LEFT, RIGHT, 
+            LEFT, RIGHT,
             color = WHITE,
         )
         word = TextMobject("Test")
@@ -515,7 +515,7 @@ class TryUnitSquareVisual(SampleSpaceScene):
                 TexMobject("P(\\text{Disease})", s1),
                 TexMobject("P(\\text{Not disease})", s2),
             ).scale(0.7)
-            for s1, s2 in ("", ""), ("= 0.001", "= 0.999")
+            for s1, s2 in (("", ""), ("= 0.001", "= 0.999"))
         ]
         sample_space.get_side_braces_and_labels(initial_labels)
         sample_space.add_braces_and_labels()
@@ -629,7 +629,7 @@ class ShowRestrictedSpace(Scene):
 
     def show_accurate_positive_result(self):
         equation = TexMobject(
-            "P(", "\\text{Test positive }", "|", 
+            "P(", "\\text{Test positive }", "|",
             "\\text{ sick}", ")", "=", "100\\%"
         )
         equation.set_color_by_tex("positive", YELLOW)
@@ -643,7 +643,7 @@ class ShowRestrictedSpace(Scene):
 
     def show_false_positive_conditional(self):
         equation = TexMobject(
-            "P(", "\\text{Test positive }", "|", 
+            "P(", "\\text{Test positive }", "|",
             "\\text{ healthy}", ")", "=", "1\\%"
         )
         equation.set_color_by_tex("positive", YELLOW)
@@ -701,7 +701,7 @@ class ShowRestrictedSpace(Scene):
         words.to_edge(UP)
         arrows = [
             Arrow(words.get_bottom(), movers.target[i].get_top())
-            for i in 0, -1
+            for i in (0, -1)
         ]
 
         self.play(FadeOut(to_fade))
@@ -723,7 +723,7 @@ class ShowRestrictedSpace(Scene):
 
     def show_posterior_probability(self):
         posterior = TexMobject(
-            "P(", "\\text{Sick }", "|", 
+            "P(", "\\text{Sick }", "|",
             "\\text{ Positive test result}", ")",
             "\\approx \\frac{1}{11}", "\\approx 9\\%"
         )
@@ -984,7 +984,7 @@ class ShowTheFormula(TeacherStudentsScene):
         lhs_copy = lhs.copy()
         self.play(
             LaggedStart(
-                FadeIn, initial_formula, 
+                FadeIn, initial_formula,
                 lag_ratio = 0.7
             ),
             Animation(lhs_copy, remover = True),
@@ -1074,8 +1074,8 @@ class SourceOfConfusion(Scene):
         words = self.bayes_rule_words
         words_rect = SurroundingRectangle(words)
         rule = TexMobject(
-            "P(", "S", "|", "+", ")", "=", 
-            "P(", "S", ")", 
+            "P(", "S", "|", "+", ")", "=",
+            "P(", "S", ")",
             "{P(", "+", "|", "S", ")", "\\over",
             "P(", "+", ")}"
         )
@@ -1127,7 +1127,7 @@ class StatisticsVsEmpathy(PiCreatureScene):
         prior.save_state()
 
         self.play(PiCreatureSays(
-            morty, 
+            morty,
             "1 in 1{,}000 people \\\\ have this disease.",
             look_at_arg = randy.eyes
         ))
@@ -1202,12 +1202,12 @@ class LessMedicalExample(Scene):
 class PlaneCrashProbability(Scene):
     def construct(self):
         plane_prob = TexMobject(
-            "P(\\text{Dying in a }", "\\text{plane}", "\\text{ crash})", 
+            "P(\\text{Dying in a }", "\\text{plane}", "\\text{ crash})",
             "\\approx", "1/", "11{,}000{,}000"
         )
         plane_prob.set_color_by_tex("plane", BLUE)
         car_prob = TexMobject(
-            "P(\\text{Dying in a }", "\\text{car}", "\\text{ crash})", 
+            "P(\\text{Dying in a }", "\\text{car}", "\\text{ crash})",
             "\\approx", "1/", "5{,}000"
         )
         car_prob.set_color_by_tex("car", YELLOW)
@@ -1280,7 +1280,7 @@ class IntroduceTelepathyExample(StatisticsVsEmpathy):
         self.play(
             ShowCreation(bubble),
             number.move_to, bubble.get_bubble_center(), DOWN+LEFT,
-            morty.change, "pondering", 
+            morty.change, "pondering",
         )
         self.wait()
 
@@ -1326,7 +1326,7 @@ class IntroduceTelepathyExample(StatisticsVsEmpathy):
                 bubble_kwargs = {"height" : 3, "width" : 4}
             ),
             RemovePiCreatureBubble(
-                randy, 
+                randy,
                 target_mode = "plain",
                 look_at_arg = morty.eyes,
             )
@@ -1383,15 +1383,15 @@ class CompareNumbersInBothExamples(Scene):
             TexMobject(
                 "P(", "\\text{%s}"%s, ")", "= 1/1{,}000}"
             )
-            for s in "Sick", "Powers"
+            for s in ("Sick", "Powers")
         ])
         likelihoods = VGroup(*[
             TexMobject(
-                "P(", "\\text{%s}"%s1, "|", 
+                "P(", "\\text{%s}"%s1, "|",
                 "\\text{Not }", "\\text{%s}"%s2, ")",
                 "=", "1/100"
             )
-            for s1, s2 in ("+", "Sick"), ("Correct", "Powers")
+            for s1, s2 in (("+", "Sick"), ("Correct", "Powers"))
         ])
         priors.next_to(likelihoods, UP, LARGE_BUFF)
         for group in priors, likelihoods:
@@ -1481,7 +1481,7 @@ class ExampleMeasuresDisbeliefInStatistics(Introduction):
     def either_way(self):
         b_to_i = self.bayes_to_intuition
         s_to_b = self.statistics_to_belief
-        
+
         self.play(FadeOut(self.example))
         self.play(
             self.teacher.change_mode, "raise_left_hand",
@@ -1531,31 +1531,3 @@ class Thumbnail(Scene):
         prob.next_to(randy, RIGHT)
 
         self.add(title, randy, prob)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/active_projects/eop/combinations.py
+++ b/active_projects/eop/combinations.py
@@ -207,7 +207,7 @@ class ExperienceProblemSolver(PiCreatureScene):
                     last_row.copy(), VGroup(*mobs),
                     remover = True
                 )
-                for mobs in curr_row[1:], curr_row[:-1]
+                for mobs in (curr_row[1:], curr_row[:-1])
             ])
             self.add(curr_row)
         self.wait(3)
@@ -1808,7 +1808,7 @@ class IntroducePascalsTriangle(Scene):
                     last_row.copy(), VGroup(*mobs),
                     remover = True
                 )
-                for mobs in curr_row[1:], curr_row[:-1]
+                for mobs in (curr_row[1:], curr_row[:-1])
             ])
             self.add(curr_row)
         self.wait()
@@ -2147,7 +2147,7 @@ class StacksApproachBellCurve(Scene):
 
             self.play(*[
                 MoveToTarget(mob, submobject_mode = "lagged_start")
-                for mob in bars_copy, numbers, numbers_copy
+                for mob in (bars_copy, numbers, numbers_copy)
             ])
             self.remove(numbers, numbers_copy)
             numbers = VGroup(numbers[0])
@@ -2439,7 +2439,7 @@ class ChooseThreeFromFive(InitialFiveChooseThreeExample, PiCreatureScene):
             self.wait()
             word_arrow_groups.submobjects = [
                 word_arrow_groups[j]
-                for j in 1, 2, 0
+                for j in (1, 2, 0)
             ]
         self.play(*map(FadeOut, [line, odm_words]))
 
@@ -2489,7 +2489,7 @@ class ChooseThreeFromFive(InitialFiveChooseThreeExample, PiCreatureScene):
     def get_names(self, people):
         names = VGroup(*[
             TextMobject(name + ",")
-            for name in "Ali", "Ben", "Cam", "Denis", "Evan"
+            for name in ("Ali", "Ben", "Cam", "Denis", "Evan")
         ])
         for name, pi in zip(names, people):
             name[-1].set_fill(opacity = 0)
@@ -2700,7 +2700,7 @@ class StudentsGetConfused(PiCreatureScene):
     def create_pi_creatures(self):
         pis = VGroup(*[
             Randolph(color = color)
-            for color in BLUE_D, BLUE_B
+            for color in (BLUE_D, BLUE_B)
         ])
         pis[1].flip()
         pis.arrange_submobjects(RIGHT, buff = 5)

--- a/active_projects/eop/independence.py
+++ b/active_projects/eop/independence.py
@@ -234,7 +234,7 @@ class MeaningOfIndependence(SampleSpaceScene):
                 self.sample_space.get_corner(vect+RIGHT),
                 0.7
             )
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ])
         line.set_stroke(RED, 8)
         word = TextMobject("Independence")
@@ -954,7 +954,7 @@ class ThousandPossibleQuizzes(Scene):
                 include_qs = False,
                 buff = SMALL_BUFF
             )
-            for b in True, False
+            for b in (True, False)
         ])
         question = VGroup(
             TextMobject("Where are"), sg1,
@@ -1514,7 +1514,7 @@ class ShowAllEightConditionals(Scene):
                 "P(", filler_tex, "|", filler_tex, ")",
             )
             sub_bool_lists = [
-                bool_list[:n] for n in 3, 1, 2, 1, 3, 2
+                bool_list[:n] for n in (3, 1, 2, 1, 3, 2)
             ]
             parts = equation.get_parts_by_tex(filler_tex)
             for part, sub_list in zip(parts, sub_bool_lists):
@@ -2334,7 +2334,7 @@ class NameBinomial(Scene):
         flip_indices = self.flip_indices
         flipped_arrows, faded_crosses, full_checks = [
             VGroup(*[group[i] for i in flip_indices])
-            for group in arrows, crosses, checkmarks
+            for group in (arrows, crosses, checkmarks)
         ]
         faded_checkmarks = VGroup(*filter(
             lambda m : m not in full_checks,
@@ -2558,7 +2558,7 @@ class CycleThroughPatterns(NameBinomial):
                     getattr(new_pattern, attr),
                     path_arc = np.pi
                 )
-                for attr in "boys", "girls"
+                for attr in ("boys", "girls")
             ])
 
     ####
@@ -3094,7 +3094,7 @@ class CorrectForDependence(NameBinomial):
                 for i in range(len(group))
                 if i in indices
             ])
-            for group in self.checkmarks, self.arrows, self.crosses
+            for group in (self.checkmarks, self.arrows, self.crosses)
         ]
         for arrow in arrows:
             arrow.target = arrow.deepcopy()
@@ -3291,7 +3291,7 @@ class CompareTwoSituations(PiCreatureScene):
         randy = self.randy
         top_left, top_right = screens = [
             ScreenRectangle(height = 3).to_corner(vect)
-            for vect in UP+LEFT, UP+RIGHT
+            for vect in (UP+LEFT, UP+RIGHT)
         ]
         arrow = DoubleArrow(*screens, buff = SMALL_BUFF)
         arrow.set_color(BLUE)
@@ -3419,7 +3419,7 @@ class SkepticalOfDistributions(TeacherStudentsScene):
         k_range = range(11)
         dists = [
             get_binomial_distribution(10, p)
-            for p in 0.2, 0.8, 0.5
+            for p in (0.2, 0.8, 0.5)
         ]
         values_list = [
             map(dist, k_range)

--- a/animation/compositions.py
+++ b/animation/compositions.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 
@@ -8,7 +10,7 @@ from mobject.mobject import Mobject, Group
 from mobject.vectorized_mobject import VMobject
 from mobject.tex_mobject import TextMobject
 from .animation import Animation
-from transform import Transform
+from .transform import Transform
 from utils.bezier import inverse_interpolate
 from utils.config_ops import digest_config
 from utils.rate_functions import squish_rate_func
@@ -178,7 +180,7 @@ class Succession(Animation):
                     "Rounding error not near alpha=1 in Succession.update_mobject," + \
                     "instead alpha = %f"%alpha
                 )
-                print self.critical_alphas, alpha
+                print(self.critical_alphas, alpha)
             i = self.num_anims - 1
 
         # At this point, we should have self.critical_alphas[i] <= alpha <= self.critical_alphas[i +1]

--- a/animation/continual_animation.py
+++ b/animation/continual_animation.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from constants import *
 from mobject.mobject import Mobject, Group
-from simple_animations import MaintainPositionRelativeTo
+from .simple_animations import MaintainPositionRelativeTo
 import copy
 from utils.config_ops import instantiate
 from utils.config_ops import digest_config

--- a/animation/playground.py
+++ b/animation/playground.py
@@ -1,14 +1,16 @@
+from __future__ import absolute_import
 import numpy as np
 import operator as op
 
 from .animation import Animation
-from transform import Transform
+from .transform import Transform
 from mobject.mobject import Mobject
 from mobject.point_cloud_mobject import Mobject1D
 from topics.geometry import Line
 from utils.paths import path_along_arc
 
 from constants import *
+from functools import reduce
 
 class Vibrate(Animation):
     CONFIG = {
@@ -44,7 +46,7 @@ class Vibrate(Animation):
         )
         for mob, start in zip(*families):
             mob.points = np.apply_along_axis(
-                lambda (x, y, z) : (x, y + self.wave_function(x, time), z),
+                lambda x_y_z : (x_y_z[0], x_y_z[1] + self.wave_function(x_y_z[0], time), x_y_z[2]),
                 1, start.points
             )
 

--- a/animation/simple_animations.py
+++ b/animation/simple_animations.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 
@@ -8,7 +9,7 @@ from mobject.mobject import Mobject, Group
 from mobject.vectorized_mobject import VMobject
 from mobject.tex_mobject import TextMobject
 from .animation import Animation
-from transform import Transform
+from .transform import Transform
 from utils.bezier import interpolate
 from utils.config_ops import digest_config
 from utils.rate_functions import smooth, double_smooth, there_and_back, wiggle

--- a/animation/transform.py
+++ b/animation/transform.py
@@ -34,7 +34,7 @@ class Transform(Animation):
         self.init_path_func()
 
         Animation.__init__(self, mobject, **kwargs)
-        self.name += "To" + str(target_mobject)  
+        self.name += "To" + str(target_mobject)
 
     def update_config(self, **kwargs):
         Animation.update_config(self, **kwargs)
@@ -155,7 +155,7 @@ class ApplyMethod(Transform):
             "Whoops, looks like you accidentally invoked " + \
             "the method you want to animate"
         )
-        assert(isinstance(method.im_self, Mobject))
+        assert(isinstance(method.__self__, Mobject))
         args = list(args) #So that args.pop() works
         if "method_kwargs" in kwargs:
             method_kwargs = kwargs["method_kwargs"]
@@ -163,13 +163,13 @@ class ApplyMethod(Transform):
             method_kwargs = args.pop()
         else:
             method_kwargs = {}
-        target = method.im_self.copy()
-        method.im_func(target, *args, **method_kwargs)
-        Transform.__init__(self, method.im_self, target, **kwargs)
+        target = method.__self__.copy()
+        method.__func__(target, *args, **method_kwargs)
+        Transform.__init__(self, method.__self__, target, **kwargs)
 
 class FadeOut(Transform):
     CONFIG = {
-        "remover" : True, 
+        "remover" : True,
     }
     def __init__(self, mobject, **kwargs):
         target = mobject.copy()
@@ -249,7 +249,7 @@ class Rotate(ApplyMethod):
         if self.in_place:
             self.about_point = mobject.get_center()
         target.rotate(
-            angle, 
+            angle,
             axis = axis,
             about_point = self.about_point,
         )
@@ -278,8 +278,8 @@ class ApplyFunction(Transform):
     }
     def __init__(self, function, mobject, **kwargs):
         Transform.__init__(
-            self, 
-            mobject, 
+            self,
+            mobject,
             function(mobject.copy()),
             **kwargs
         )
@@ -294,7 +294,7 @@ class ApplyMatrix(ApplyPointwiseFunction):
             new_matrix[:2, :2] = matrix
             matrix = new_matrix
         elif matrix.shape != (3, 3):
-            raise "Matrix has bad dimensions"
+            raise Exception("Matrix has bad dimensions")
         transpose = np.transpose(matrix)
         def func(p):
             return np.dot(p, transpose)
@@ -313,7 +313,7 @@ class TransformAnimations(Transform):
             self.run_time = max(start_anim.run_time, end_anim.run_time)
         for anim in start_anim, end_anim:
             anim.set_run_time(self.run_time)
-            
+
         if start_anim.starting_mobject.get_num_points() != end_anim.starting_mobject.get_num_points():
             start_anim.starting_mobject.align_data(end_anim.starting_mobject)
             for anim in start_anim, end_anim:
@@ -329,6 +329,3 @@ class TransformAnimations(Transform):
         self.start_anim.update(alpha)
         self.end_anim.update(alpha)
         Transform.update(self, alpha)
-
-
-

--- a/big_ol_pile_of_manim_imports.py
+++ b/big_ol_pile_of_manim_imports.py
@@ -12,63 +12,64 @@ addressible by changing this file.
 Note: One should NOT import from this file for main library code, it is meant only
 as a convenience for scripts createing scenes for videos
 """
+from __future__ import absolute_import
 
-from constants import *
+from .constants import *
 
-from animation.animation import *
-from animation.compositions import *
-from animation.continual_animation import *
-from animation.playground import *
-from animation.simple_animations import *
-from animation.transform import *
+from .animation.animation import *
+from .animation.compositions import *
+from .animation.continual_animation import *
+from .animation.playground import *
+from .animation.simple_animations import *
+from .animation.transform import *
 
-from camera.camera import *
+from .camera.camera import *
 
-from mobject.image_mobject import *
-from mobject.mobject import *
-from mobject.point_cloud_mobject import *
-from mobject.svg_mobject import *
-from mobject.tex_mobject import *
-from mobject.vectorized_mobject import *
+from .mobject.image_mobject import *
+from .mobject.mobject import *
+from .mobject.point_cloud_mobject import *
+from .mobject.svg_mobject import *
+from .mobject.tex_mobject import *
+from .mobject.vectorized_mobject import *
 
-from scene.moving_camera_scene import *
-from scene.reconfigurable_scene import *
-from scene.scene import *
-from scene.scene_from_video import *
-from scene.tk_scene import *
-from scene.zoomed_scene import *
+from .scene.moving_camera_scene import *
+from .scene.reconfigurable_scene import *
+from .scene.scene import *
+from .scene.scene_from_video import *
+from .scene.tk_scene import *
+from .scene.zoomed_scene import *
 
-from topics.arithmetic import *
-from topics.characters import *
-from topics.combinatorics import *
-from topics.common_scenes import *
-from topics.complex_numbers import *
-from topics.counting import *
-from topics.fractals import *
-from topics.functions import *
-from topics.geometry import *
-from topics.graph_scene import *
-from topics.graph_theory import *
-from topics.light import *
-from topics.matrix import *
-from topics.number_line import *
-from topics.numerals import *
-from topics.objects import *
-from topics.probability import *
-from topics.three_dimensions import *
-from topics.vector_space_scene import *
+from .topics.arithmetic import *
+from .topics.characters import *
+from .topics.combinatorics import *
+from .topics.common_scenes import *
+from .topics.complex_numbers import *
+from .topics.counting import *
+from .topics.fractals import *
+from .topics.functions import *
+from .topics.geometry import *
+from .topics.graph_scene import *
+from .topics.graph_theory import *
+from .topics.light import *
+from .topics.matrix import *
+from .topics.number_line import *
+from .topics.numerals import *
+from .topics.objects import *
+from .topics.probability import *
+from .topics.three_dimensions import *
+from .topics.vector_space_scene import *
 
-from utils.bezier import *
-from utils.color import *
-from utils.config_ops import *
-from utils.images import *
-from utils.iterables import *
-from utils.paths import *
-from utils.rate_functions import *
-from utils.simple_functions import *
-from utils.sounds import *
-from utils.space_ops import *
-from utils.strings import *
+from .utils.bezier import *
+from .utils.color import *
+from .utils.config_ops import *
+from .utils.images import *
+from .utils.iterables import *
+from .utils.paths import *
+from .utils.rate_functions import *
+from .utils.simple_functions import *
+from .utils.sounds import *
+from .utils.space_ops import *
+from .utils.strings import *
 
 from special_animations import *
 

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from big_ol_pile_of_manim_imports import *
+from __future__ import absolute_import
+from .big_ol_pile_of_manim_imports import *
 
 # To watch one of these scenes, run the following:
 # python extract_scene.py file_name <SceneName> -p
@@ -26,7 +27,7 @@ class WarpSquare(Scene):
     def construct(self):
         square = Square()
         self.play(ApplyPointwiseFunction(
-            lambda (x, y, z) : complex_to_R3(np.exp(complex(x, y))),
+            lambda x_y_z : complex_to_R3(np.exp(complex(x_y_z[0], x_y_z[1]))),
             square
         ))
         self.wait()

--- a/extract_scene.py
+++ b/extract_scene.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
 # import getopt
 import argparse
@@ -11,10 +13,10 @@ import imp
 import os
 import subprocess as sp
 
-from constants import *
-from scene.scene import Scene
-from camera.camera import Camera
-from utils.sounds import play_error_sound, play_finish_sound
+from .constants import *
+from .scene.scene import Scene
+from .camera.camera import Camera
+from .utils.sounds import play_error_sound, play_finish_sound
 
 HELP_MESSAGE = """
    Usage:
@@ -73,7 +75,7 @@ def get_configuration():
          output_name_root, output_name_ext = os.path.splitext(args.output_name)
          expected_ext = '.png' if args.show_last_frame else '.mp4'
          if not output_name_ext in ['', expected_ext]:
-            print "WARNING: The output will be to (doubly-dotted) %s%s"%output_name_root%expected_ext
+            print("WARNING: The output will be to (doubly-dotted) %s%s"%output_name_root%expected_ext)
             output_name = args.output_name
          else:
             # If anyone wants .mp4.mp4 and is surprised to only get .mp4, or such... Well, too bad.
@@ -245,7 +247,7 @@ def main():
    
    scene_kwargs["name"] = config["output_name"]
    if config["save_pngs"]:
-      print "We are going to save a PNG sequence as well..."
+      print("We are going to save a PNG sequence as well...")
       scene_kwargs["save_pngs"] = True
       scene_kwargs["pngs_mode"] = config["saved_image_mode"]
       

--- a/mobject/image_mobject.py
+++ b/mobject/image_mobject.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 import os
@@ -6,7 +7,7 @@ from random import random
 
 from constants import *
 from .mobject import Mobject
-from point_cloud_mobject import PMobject
+from .point_cloud_mobject import PMobject
 from utils.bezier import interpolate
 from utils.color import color_to_int_rgb
 from utils.color import interpolate_color

--- a/mobject/mobject.py
+++ b/mobject/mobject.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import operator as op
 import itertools as it
@@ -15,6 +16,7 @@ from utils.iterables import remove_list_redundancies, list_update
 from utils.paths import straight_path
 from utils.space_ops import rotation_matrix, angle_of_vector
 from utils.space_ops import complex_to_R3, R3_to_complex
+from functools import reduce
 
 
 #TODO: Explain array_attrs
@@ -209,7 +211,7 @@ class Mobject(Container):
 
     def apply_complex_function(self, function, **kwargs):
         return self.apply_function(
-            lambda (x, y, z) : complex_to_R3(function(complex(x, y))),
+            lambda x_y_z : complex_to_R3(function(complex(x_y_z[0], x_y_z[1]))),
             **kwargs
         )
 
@@ -760,7 +762,7 @@ class Mobject(Container):
 
     def print_submobject_family(self, n_tabs = 0):
         """For debugging purposes"""
-        print "\t"*n_tabs, self, id(self)
+        print("\t"*n_tabs, self, id(self))
         for submob in self.submobjects:
             submob.print_mobject_family(n_tabs + 1)
 
@@ -796,7 +798,7 @@ class Mobject(Container):
         #push it into its submobject list
         self_has_points, mob_has_points = [
             mob.get_num_points() > 0
-            for mob in self, mobject
+            for mob in (self, mobject)
         ]
         if self_has_points and not mob_has_points:
             mobject.null_point_align(self)

--- a/mobject/point_cloud_mobject.py
+++ b/mobject/point_cloud_mobject.py
@@ -156,7 +156,7 @@ class PMobject(Mobject):
     def pointwise_become_partial(self, mobject, a, b):
         lower_index, upper_index = [
             int(x * mobject.get_num_points())
-            for x in a, b
+            for x in (a, b)
         ]
         for attr in self.get_array_attrs():
             full_array = getattr(mobject, attr)

--- a/mobject/region.py
+++ b/mobject/region.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from PIL import Image
 from copy import deepcopy
 
-from mobject.mobject import Mobject
+from .mobject.mobject import Mobject
 from utils.iterables import adjacent_pairs
 
 from constants import *

--- a/mobject/svg_mobject.py
+++ b/mobject/svg_mobject.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from xml.dom import minidom
 import itertools as it
 import re
@@ -5,7 +6,7 @@ import warnings
 import string
 
 from constants import *
-from vectorized_mobject import VMobject, VGroup
+from .vectorized_mobject import VMobject, VGroup
 from topics.geometry import Rectangle, Circle
 from utils.bezier import is_closed
 from utils.config_ops import digest_config, digest_locals
@@ -131,7 +132,7 @@ class SVGMobject(VMobject):
             float(circle_element.getAttribute(key))
             if circle_element.hasAttribute(key)
             else 0.0
-            for key in "cx", "cy", "r"
+            for key in ("cx", "cy", "r")
         ]
         return Circle(radius = r).shift(x*RIGHT+y*DOWN)
 
@@ -140,7 +141,7 @@ class SVGMobject(VMobject):
             float(circle_element.getAttribute(key))
             if circle_element.hasAttribute(key)
             else 0.0
-            for key in "cx", "cy", "rx", "ry"
+            for key in ("cx", "cy", "rx", "ry")
         ]
         return Circle().scale(rx*RIGHT + ry*UP).shift(x*RIGHT+y*DOWN)
 

--- a/mobject/tex_mobject.py
+++ b/mobject/tex_mobject.py
@@ -1,13 +1,16 @@
+from __future__ import print_function
+from __future__ import absolute_import
 from constants import *
 
-from vectorized_mobject import VMobject, VGroup, VectorizedPoint
-from svg_mobject import SVGMobject, VMobjectFromSVGPathstring
+from .vectorized_mobject import VMobject, VGroup, VectorizedPoint
+from .svg_mobject import SVGMobject, VMobjectFromSVGPathstring
 from topics.geometry import BackgroundRectangle
 from utils.config_ops import digest_config
 
 import collections
 import sys
 import operator as op
+from functools import reduce
 
 TEX_MOB_SCALE_FACTOR = 0.05
 
@@ -206,7 +209,7 @@ class TexMobject(SVGMobject):
 
     def sort_submobjects_alphabetically(self):
         def alphabetical_cmp(m1, m2):
-            if not all([isinstance(m, TexMobject) for m in m1, m2]):
+            if not all([isinstance(m, TexMobject) for m in (m1, m2)]):
                 return 0
             return cmp(m1.get_tex_string(), m2.get_tex_string())
         self.submobjects.sort(alphabetical_cmp)

--- a/mobject/vectorized_mobject.py
+++ b/mobject/vectorized_mobject.py
@@ -206,7 +206,7 @@ class VMobject(Mobject):
         points = np.array(points)
         self.set_anchors_and_handles(points, *[
             interpolate(points[:-1], points[1:], alpha)
-            for alpha in 1./3, 2./3
+            for alpha in (1./3, 2./3)
         ])
         return self
 

--- a/old_projects/WindingNumber.py
+++ b/old_projects/WindingNumber.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 import time
@@ -60,16 +61,18 @@ def rev_to_rgba(alpha):
 def rev_to_color(alpha):
     return rgba_to_color(rev_to_rgba(alpha))
 
-def point_to_rev((x, y), allow_origin = False):
+def point_to_rev(xxx_todo_changeme6, allow_origin = False):
     # Warning: np.arctan2 would happily discontinuously returns the value 0 for (0, 0), due to 
     # design choices in the underlying atan2 library call, but for our purposes, this is 
     # illegitimate, and all winding number calculations must be set up to avoid this
+    (x, y) = xxx_todo_changeme6
     if not(allow_origin) and (x, y) == (0, 0):
-        print "Error! Angle of (0, 0) computed!"
+        print("Error! Angle of (0, 0) computed!")
         return
     return fdiv(np.arctan2(y, x), TAU)
 
-def point_to_size((x, y)):
+def point_to_size(xxx_todo_changeme7):
+    (x, y) = xxx_todo_changeme7
     return np.sqrt(x**2 + y**2)
 
 # rescaled_size goes from 0 to 1 as size goes from 0 to infinity
@@ -137,8 +140,8 @@ class EquationSolver1d(GraphScene, ZoomedScene):
         if self.show_target_line:
             self.play(FadeOut(target_line_label)) # Reduce clutter
 
-        print "For reference, graphOrigin: ", self.coords_to_point(0, 0)
-        print "targetYPoint: ", self.coords_to_point(0, self.targetY)
+        print("For reference, graphOrigin: ", self.coords_to_point(0, 0))
+        print("targetYPoint: ", self.coords_to_point(0, self.targetY))
 
     # This is a mess right now (first major animation coded), 
     # but it works; can be refactored later or never
@@ -439,10 +442,11 @@ def complex_to_pair(c):
     return np.array((c.real, c.imag))
 
 def plane_func_from_complex_func(f):
-    return lambda (x, y) : complex_to_pair(f(complex(x,y)))
+    return lambda x_y4 : complex_to_pair(f(complex(x_y4[0],x_y4[1])))
 
 def point3d_func_from_plane_func(f):
-    def g((x, y, z)):
+    def g(xxx_todo_changeme):
+        (x, y, z) = xxx_todo_changeme
         f_val = f((x, y))
         return np.array((f_val[0], f_val[1], 0))
     return g
@@ -450,7 +454,8 @@ def point3d_func_from_plane_func(f):
 def point3d_func_from_complex_func(f):
     return point3d_func_from_plane_func(plane_func_from_complex_func(f))
 
-def plane_zeta((x, y)):
+def plane_zeta(xxx_todo_changeme8):
+    (x, y) = xxx_todo_changeme8
     CLAMP_SIZE = 1000
     z = complex(x, y)
     try:
@@ -461,7 +466,8 @@ def plane_zeta((x, y)):
         answer = answer/abs(answer) * CLAMP_SIZE
     return (float(answer.real), float(answer.imag))
 
-def rescaled_plane_zeta((x, y)):
+def rescaled_plane_zeta(xxx_todo_changeme9):
+    (x, y) = xxx_todo_changeme9
     return plane_zeta((x/FRAME_X_RADIUS, 8*y))
 
 # Returns a function from 2-ples to 2-ples
@@ -476,13 +482,13 @@ def plane_func_by_wind_spec(*specs):
         elif len(p) == 2:
             return (p[0], p[1], 1)
         else:
-            print "Error in plane_func_by_wind_spec embiggen!"
+            print("Error in plane_func_by_wind_spec embiggen!")
     specs = map(embiggen, specs)
 
-    pos_specs = filter(lambda (x, y, z) : z > 0, specs)
-    neg_specs = filter(lambda (x, y, z) : z < 0, specs)
+    pos_specs = filter(lambda x_y_z : x_y_z[2] > 0, specs)
+    neg_specs = filter(lambda x_y_z1 : x_y_z1[2] < 0, specs)
 
-    neg_specs_made_pos = map (lambda (x, y, z) : (x, y, -z), neg_specs)
+    neg_specs_made_pos = map (lambda x_y_z2 : (x_y_z2[0], x_y_z2[1], -x_y_z2[2]), neg_specs)
 
     def poly(c, root_specs):
         return np.prod([(c - complex(x, y))**z for (x, y, z) in root_specs])
@@ -651,8 +657,8 @@ class ColorMappedByFuncScene(Scene):
             self.input_to_pos_func = lambda p : p
             self.pos_to_color_func = self.func
 
-        self.pixel_pos_to_color_func = lambda (x, y) : self.pos_to_color_func(
-            self.num_plane.point_to_coords_cheap(np.array([x, y, 0]))
+        self.pixel_pos_to_color_func = lambda x_y3 : self.pos_to_color_func(
+            self.num_plane.point_to_coords_cheap(np.array([x_y3[0], x_y3[1], 0]))
         )
 
         jitter_val = 0.1
@@ -661,7 +667,7 @@ class ColorMappedByFuncScene(Scene):
         def mini_hasher(p):
             rgba = point_to_rgba(self.pixel_pos_to_color_func(p))
             if rgba[3] != 1.0:
-                print "Warning! point_to_rgba assigns fractional alpha", rgba[3]
+                print("Warning! point_to_rgba assigns fractional alpha", rgba[3])
             return tuple(rgba)
         to_hash = tuple(mini_hasher(p) for p in func_hash_points)
         func_hash = hash(to_hash)
@@ -674,18 +680,18 @@ class ColorMappedByFuncScene(Scene):
         )
         self.in_background_pass = not os.path.exists(self.background_image_file)
 
-        print "Background file: " + self.background_image_file
+        print("Background file: " + self.background_image_file)
         if self.in_background_pass:
-            print "The background file does not exist yet; this will be a background creation + video pass"
+            print("The background file does not exist yet; this will be a background creation + video pass")
         else:
-            print "The background file already exists; this will only be a video pass"
+            print("The background file already exists; this will only be a video pass")
 
     def construct(self):
         if self.in_background_pass:
             self.camera.set_background_from_func(
-                lambda (x, y): point_to_rgba(
+                lambda x_y: point_to_rgba(
                     self.pixel_pos_to_color_func(
-                        (x, y)
+                        (x_y[0], x_y[1])
                     )
                 )
             )
@@ -863,7 +869,8 @@ class PiWalkerCircle(PiWalker):
         self.walk_coords = [r * np.array((np.cos(i * TAU/N), np.sin(i * TAU/N))) for i in range(N)]
         PiWalker.setup(self)
 
-def split_interval((a, b)):
+def split_interval(xxx_todo_changeme10):
+    (a, b) = xxx_todo_changeme10
     mid = (a + b)/2.0
     return ((a, mid), (mid, b))
 
@@ -915,7 +922,7 @@ class RectangleData():
         elif dim == 1:
             return_data = [RectangleData(x_interval, new_interval) for new_interval in split_interval(y_interval)[::-1]]        
         else: 
-            print "RectangleData.splits_on_dim passed illegitimate dimension!"
+            print("RectangleData.splits_on_dim passed illegitimate dimension!")
 
         return tuple(return_data)
 
@@ -928,7 +935,7 @@ class RectangleData():
         elif dim == 1:
             sides = (self.get_left(), self.get_right())
         else:
-            print "RectangleData.split_line_on_dim passed illegitimate dimension!"
+            print("RectangleData.split_line_on_dim passed illegitimate dimension!")
 
         return tuple([mid(x, y) for (x, y) in sides])
 
@@ -973,10 +980,10 @@ class EquationSolver2dNode(object):
 
     def play_in_bfs(self, scene, border_anim):
         bfs_nodes = self.hacky_bfs()
-        print "Number of nodes: ", len(bfs_nodes)
+        print("Number of nodes: ", len(bfs_nodes))
 
         if len(bfs_nodes) < 1:
-            print "Less than 1 node! Aborting!"
+            print("Less than 1 node! Aborting!")
             return
 
         scene.play(bfs_nodes[0].first_anim, border_anim)
@@ -1029,7 +1036,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
 
     def construct(self):
         if self.num_iterations == 0:
-            print "You forgot to set num_iterations (maybe you meant to subclass something other than EquationSolver2d directly?)"
+            print("You forgot to set num_iterations (maybe you meant to subclass something other than EquationSolver2d directly?)")
             return
 
         ColorMappedObjectsScene.construct(self)
@@ -1071,7 +1078,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
         def Animate2dSolver(cur_depth, rect, dim_to_split, 
             sides_to_draw = [0, 1, 2, 3], 
             manual_wind_override = None):
-            print "Solver at depth: " + str(cur_depth)
+            print("Solver at depth: " + str(cur_depth))
 
             if cur_depth >= self.num_iterations:
                 return EquationSolver2dNode(empty_animation)
@@ -1195,7 +1202,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
 
         rect = RectangleData(x_interval, y_interval)
 
-        print "Starting to compute anim"
+        print("Starting to compute anim")
 
         node = Animate2dSolver(
             cur_depth = 0, 
@@ -1205,7 +1212,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
             manual_wind_override = self.manual_wind_override
         )
 
-        print "Done computing anim"
+        print("Done computing anim")
 
         if self.display_in_parallel:
             anim = node.display_in_parallel()
@@ -1241,14 +1248,14 @@ class EquationSolver2d(ColorMappedObjectsScene):
             rate_func = rect_rate
         )
 
-        print "About to do the big Play; for reference, the current time is ", time.strftime("%H:%M:%S")
+        print("About to do the big Play; for reference, the current time is ", time.strftime("%H:%M:%S"))
 
         if self.use_separate_plays:
             node.play_in_bfs(self, border_anim)
         else:
             self.play(anim, border_anim)
 
-        print "All done; for reference, the current time is ", time.strftime("%H:%M:%S")
+        print("All done; for reference, the current time is ", time.strftime("%H:%M:%S"))
 
         self.wait()
 
@@ -1712,7 +1719,7 @@ class Initial2dFuncSceneBase(Scene):
     }
 
     def show_planes(self):
-        print "Error! Unimplemented (pure virtual) show_planes"
+        print("Error! Unimplemented (pure virtual) show_planes")
 
     def shared_construct(self):
         points = [LEFT + DOWN, RIGHT + DOWN, LEFT + UP, RIGHT + UP]
@@ -2414,7 +2421,7 @@ class BorderOf2dRegionScene(Scene):
         border = Polygon(*points, color = negative_color, stroke_width = border_stroke_width)
         self.play(ShowCreation(border))
 
-big_loop_no_zeros_func = lambda (x, y) : complex_to_pair(np.exp(complex(10, y * np.pi)))
+big_loop_no_zeros_func = lambda x_y5 : complex_to_pair(np.exp(complex(10, x_y5[1] * np.pi)))
 
 class BigLoopNoZeros(ColorMappedObjectsScene):
     CONFIG = {
@@ -2539,7 +2546,8 @@ class TinyLoopOfBasicallySameColor(PureColorMap):
         self.play(ShowCreation(circle))
         self.wait()
 
-def uhOhFunc((x, y)):
+def uhOhFunc(xxx_todo_changeme11):
+    (x, y) = xxx_todo_changeme11
     x = -np.clip(x, -5, 5)/5
     y = -np.clip(y, -3, 3)/3
 
@@ -2648,7 +2656,8 @@ class UhOhSalientStill(ColorMappedObjectsScene):
 
 # Random test scenes and test functions go here:
 
-def rect_to_circle((x, y, z)):
+def rect_to_circle(xxx_todo_changeme12):
+    (x, y, z) = xxx_todo_changeme12
     size = np.sqrt(x**2 + y**2)
     max_abs_size = max(abs(x), abs(y))
     return fdiv(np.array((x, y, z)) * max_abs_size, size)
@@ -2725,7 +2734,7 @@ class SpecifiedWinder(PiWalker):
             cur_pos += (self.step_size, 0)
             mid_rev = rev_func(cur_pos)
 
-        print "Reached ", cur_pos, ", with rev ", mid_rev - start_rev
+        print("Reached ", cur_pos, ", with rev ", mid_rev - start_rev)
         mid_pos = cur_pos.copy()
 
         end_rev = mid_rev
@@ -2735,10 +2744,10 @@ class SpecifiedWinder(PiWalker):
 
         end_pos = cur_pos.copy()
 
-        print "Reached ", cur_pos, ", with rev ", end_rev - mid_rev
+        print("Reached ", cur_pos, ", with rev ", end_rev - mid_rev)
 
         self.walk_coords = [start_pos, mid_pos, end_pos]
-        print "Walk coords: ", self.walk_coords
+        print("Walk coords: ", self.walk_coords)
         PiWalker.setup(self)
 
 class OneFifthTwoFifthWinder(SpecifiedWinder):

--- a/old_projects/WindingNumber_G.py
+++ b/old_projects/WindingNumber_G.py
@@ -85,7 +85,7 @@ class IntroSceneWrapper(PiCreatureScene):
             \\left[\\begin{array}{c}
                 ye^x \\\\
                 \\sin(|xy|)
-            \\end{array}\\right] = 
+            \\end{array}\\right] =
             \\left[\\begin{array}{c}
                 y^2 \\\\
                 3y
@@ -236,7 +236,7 @@ class Introduce1DFunctionCase(Scene):
                 axes.coords_to_point(x, 0),
                 axes.coords_to_point(x, f_graph.underlying_function(solution)),
             )
-            for x in axes.x_min, axes.x_max, solution
+            for x in (axes.x_min, axes.x_max, solution)
         ]
 
         equation = TexMobject("f(x)", "=", "g(x)")
@@ -346,9 +346,9 @@ class Introduce1DFunctionCase(Scene):
     ##
 
     def binary_search(
-        self, 
-        f_graph, g_graph, 
-        x0, x1, 
+        self,
+        f_graph, g_graph,
+        x0, x1,
         n_iterations,
         n_iterations_with_sign_mention = 0,
         zoom = False,
@@ -405,7 +405,7 @@ class Introduce1DFunctionCase(Scene):
         kwargs = {
             "mention_signs" : False,
             "show_decimal" : zoom,
-        } 
+        }
         for x in range(n_iterations - 1):
             x_mid = np.mean(end_points)
             leftovers_mid = self.compare_graphs_at_x(f_graph, g_graph, x_mid, **kwargs)
@@ -448,14 +448,14 @@ class Introduce1DFunctionCase(Scene):
                 everything.target[midpoint_line_index].scale(1./factor)
                 if factor > 1:
                     self.play(
-                        everything.scale, factor, 
+                        everything.scale, factor,
                         {"about_point" : rect.get_center()}
                     )
             else:
                 self.wait()
 
     def compare_graphs_at_x(
-        self, f_graph, g_graph, x, 
+        self, f_graph, g_graph, x,
         mention_signs = False,
         show_decimal = False,
         ):
@@ -648,7 +648,7 @@ class RewriteEquationWithTeacher(AltTeacherStudentsScene):
         self.teacher_holds_up(root_two_equations[0])
         self.wait()
         self.play(Transform(
-            *root_two_equations, 
+            *root_two_equations,
             run_time = 1.5,
             path_arc = TAU/2
         ))
@@ -667,7 +667,7 @@ class RewriteEquationWithTeacher(AltTeacherStudentsScene):
             \\left[\\begin{array}{c}
                 ye^x \\\\
                 \\sin(xy)
-            \\end{array}\\right] = 
+            \\end{array}\\right] =
             \\left[\\begin{array}{c}
                 y^2 + x^3 \\\\
                 3y - x
@@ -712,8 +712,8 @@ class InputOutputScene(Scene):
         "y_shift" : MED_LARGE_BUFF,
         "output_scalar" : 10,
         "non_renormalized_func" : plane_func_by_wind_spec(
-            (-2, -1, 2), 
-            (1, 1, 1), 
+            (-2, -1, 2),
+            (1, 1, 1),
             (2, -2, -1),
         ),
     }
@@ -857,7 +857,7 @@ class IntroduceInputOutputScene(InputOutputScene):
         for mob in input_label, input_label_arrow:
             mob.match_color(in_dot)
         input_label.add_background_rectangle()
-        
+
         output_label_arrow = Vector(DOWN+LEFT)
         output_label_arrow.next_to(out_dot, UP+RIGHT, SMALL_BUFF)
         output_label = TextMobject("Output point")
@@ -964,7 +964,7 @@ class IntroduceInputOutputScene(InputOutputScene):
 
     def get_output_dot_continual_update(self, input_dot, output_dot):
         return ContinualUpdateFromFunc(
-            output_dot, 
+            output_dot,
             lambda od : od.move_to(self.point_function(input_dot.get_center()))
         )
 
@@ -987,7 +987,7 @@ class IntroduceVectorField(IntroduceInputOutputScene):
         out_dot.set_color(PINK)
 
         out_vector = Arrow(
-            LEFT, RIGHT, 
+            LEFT, RIGHT,
             color = out_dot.get_color(),
         )
         out_vector.set_stroke(BLACK, 1)
@@ -1008,7 +1008,7 @@ class IntroduceVectorField(IntroduceInputOutputScene):
         )
         continual_updates = [
             out_dot_continual_update,
-            continual_out_vector_update, 
+            continual_out_vector_update,
             continual_in_vector_update
         ]
 
@@ -1077,7 +1077,7 @@ class TwoDScreenInOurThreeDWorld(AltTeacherStudentsScene, ThreeDScene):
         out_plane.add(out_text)
 
         arrow = Arrow(
-            LEFT, RIGHT, 
+            LEFT, RIGHT,
             path_arc = -TAU/4,
             use_rectangular_stem = False,
             color = WHITE
@@ -1184,7 +1184,7 @@ class EveryOutputPointHasAColor(ColorMappedObjectsScene):
                 dots.add(dot)
         random.shuffle(dots.submobjects)
 
-        m = 3 #exponential factor        
+        m = 3 #exponential factor
         n = 1
         dot_groups = VGroup()
         while n <= len(dots):
@@ -1221,7 +1221,7 @@ class DotsHoppingToColor(InputOutputScene):
         #Introduce parts
         self.add(input_plane, output_plane, v_line)
         self.play(
-            FadeIn(output_coloring), 
+            FadeIn(output_coloring),
             Animation(output_plane),
             output_plane.white_parts.set_color, BLACK,
             output_plane.lines_to_fade.set_stroke, {"width" : 0},
@@ -1232,7 +1232,7 @@ class DotsHoppingToColor(InputOutputScene):
 
         #Hop over and back
         self.play(LaggedStart(
-            MoveToTarget, dots, 
+            MoveToTarget, dots,
             path_arc = -TAU/4,
             run_time = 3,
         ))
@@ -1309,7 +1309,7 @@ class DotsHoppingToColor(InputOutputScene):
         ))
         self.play(
             ApplyMethod(
-                inspector.move_to, 
+                inspector.move_to,
                 input_plane.coords_to_point(-2, 0),
                 path_arc = -TAU/8,
                 run_time = 3,
@@ -1318,7 +1318,7 @@ class DotsHoppingToColor(InputOutputScene):
         )
         self.play(
             ApplyMethod(
-                inspector.move_to, 
+                inspector.move_to,
                 input_plane.coords_to_point(-2.75, 2.75),
                 path_arc = TAU/8,
                 run_time = 3,
@@ -1335,7 +1335,7 @@ class DotsHoppingToColor(InputOutputScene):
             for zero in zeros:
                 path = ParametricFunction(
                     bezier([
-                        inspector.get_center(), 
+                        inspector.get_center(),
                         input_plane.coords_to_point(0, 0),
                         zero
                     ]),
@@ -1408,7 +1408,7 @@ class Rearrange2DEquation(AltTeacherStudentsScene):
     def construct(self):
         f_tex, g_tex, h_tex = [
             "%s(\\text{2d point})"%char
-            for char in "f", "g", "h" 
+            for char in ("f", "g", "h")
         ]
         zero_tex = "\\vec{\\textbf{0}}"
         equations = VGroup(
@@ -1487,7 +1487,7 @@ class OneDRegionBoundary(Scene):
         "region_rect_height" : 0.1,
     }
     def construct(self):
-        x0 = self.x0 = 3 
+        x0 = self.x0 = 3
         x1 = self.x1 = 6
         fx0 = self.fx0 = -2
         fx1 = self.fx1 = 2
@@ -1540,7 +1540,7 @@ class OneDRegionBoundary(Scene):
                 color = color,
                 buff = 0
             )
-            for x, fx, color in (x0, fx0, RED), (x1, fx1, GREEN)
+            for x, fx, color in ((x0, fx0, RED), (x1, fx1, GREEN))
         ])
         minus = TexMobject("-")
         minus.match_color(x0_arrow)
@@ -1562,7 +1562,7 @@ class OneDRegionBoundary(Scene):
         ))
         self.wait()
         self.play(
-            ShowCreation(graph), 
+            ShowCreation(graph),
             FadeOut(region_words),
         )
         self.wait()
@@ -1693,7 +1693,7 @@ class AskAboutHowToGeneralizeSigns(AltTeacherStudentsScene):
             "Wait...what would \\\\ positive and negative \\\\ be in 2d?",
         )
         # question.set_color_by_tex_to_color_map({
-        #     "+" : "green", 
+        #     "+" : "green",
         #     "textminus" : "red"
         # })
 
@@ -1729,8 +1729,8 @@ class HypothesisAboutFullyColoredBoundary(ColorMappedObjectsScene):
         square.color_using_background_image(self.background_image_file)
         hypothesis = TextMobject(
            "Working Hypothesis: \\\\",
-           "If a 2d function hits outputs of all possible colors \\\\" + 
-           "on the boundary of a 2d region,", 
+           "If a 2d function hits outputs of all possible colors \\\\" +
+           "on the boundary of a 2d region,",
            "that region \\\\ contains a zero.",
            alignment = "",
         )
@@ -1818,8 +1818,8 @@ class ForeverNarrowingLoop(InputOutputScene):
             circle.move_to(input_plane.coords_to_point(*self.target_coords))
         else:
             circle.next_to(
-                input_coloring.get_corner(self.input_plane_corner), 
-                -self.input_plane_corner, 
+                input_coloring.get_corner(self.input_plane_corner),
+                -self.input_plane_corner,
                 SMALL_BUFF
             )
         circle.set_stroke(width = 5)
@@ -1913,7 +1913,7 @@ class ConfusedPiCreature(PiCreatureScene):
 class FailureOfComposition(ColorMappedObjectsScene):
     CONFIG = {
         "func" : lambda p : (
-            np.cos(TAU*p[1]/3.5), 
+            np.cos(TAU*p[1]/3.5),
             np.sin(TAU*p[1]/3.5)
         )
     }
@@ -2079,7 +2079,7 @@ class PathContainingZero(InputOutputScene, PiCreatureScene):
         )
         path.match_background_image_file(self.input_coloring)
         path.set_points_smoothly(list(it.starmap(
-            self.input_plane.coords_to_point, 
+            self.input_plane.coords_to_point,
             [(1, 2.5), (2.5, 2.5), (2, 0.5), (1, 1), (0.5, 1), (0.5, 2), (1, 2.5)]
         )))
 
@@ -2100,7 +2100,7 @@ class PathContainingZero(InputOutputScene, PiCreatureScene):
             morty.change, "pondering",
             *[
                 ShowCreation(mob, rate_func = bezier([0, 0, 1, 1]))
-                for mob in path, out_path
+                for mob in (path, out_path)
             ],
             run_time = 5
         )
@@ -2225,7 +2225,7 @@ class TransitionFromPathsToBoundaries(ColorMappedObjectsScene):
         #Add regions
         self.play(
             FadeOut(paths),
-            FadeOut(joint_path.brace), 
+            FadeOut(joint_path.brace),
             dot.move_to, path1.get_start()
         )
         for square in squares:
@@ -2272,7 +2272,7 @@ class TransitionFromPathsToBoundaries(ColorMappedObjectsScene):
     def get_squares_and_joint_rect(self):
         squares = VGroup(*[
             Square(side_length = 4).next_to(ORIGIN, vect, buff = 0)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         joint_rect = SurroundingRectangle(squares, buff = 0)
         for mob in it.chain(squares, [joint_rect]):
@@ -2293,7 +2293,7 @@ class TransitionFromPathsToBoundaries(ColorMappedObjectsScene):
             rev = (get_output_rev() - self.start_rev)%1
             possible_windings = [
                 np.floor(self.curr_winding)+k+rev
-                for k in -1, 0, 1
+                for k in (-1, 0, 1)
             ]
             i = np.argmin([abs(pw - self.curr_winding) for pw in possible_windings])
             self.curr_winding = possible_windings[i]
@@ -2369,7 +2369,7 @@ class BreakDownLoopWithNonzeroWinding(TransitionFromPathsToBoundaries):
         both_cannot_be_zero.to_edge(UP)
         arrows = VGroup(*[
             Arrow(both_cannot_be_zero.get_bottom(), var.get_top(), buff = SMALL_BUFF)
-            for var in x, y
+            for var in (x, y)
         ])
 
         self.position_dot(joint_rect.points[0])
@@ -2579,11 +2579,11 @@ class PolynomialTerms(MonomialTerm):
                 background_image_file = self.input_coloring.background_image_file ,
                 stroke_width = 4,
             )
-            for u in -1, 1
+            for u in (-1, 1)
         ]
         out_line = line.copy()
         update_out_line = UpdateFromFunc(
-            out_line, 
+            out_line,
             lambda m : m.set_points(line.points).apply_function(self.point_function),
         )
 
@@ -2706,8 +2706,8 @@ class PiCreatureInAwe(Scene):
         self.play(Blink(randy))
         self.play(randy.look, UP, run_time = 2)
         self.play(
-            randy.look, RIGHT, 
-            run_time = 4, 
+            randy.look, RIGHT,
+            run_time = 4,
             rate_func = there_and_back,
             path_arc = -TAU/4
         )
@@ -2807,7 +2807,7 @@ class WindingNumbersInInputOutputContext(PathContainingZero):
 
         out_arrow = Arrow(LEFT, RIGHT)
         update_out_arrow = ContinualUpdateFromFunc(
-            out_arrow, 
+            out_arrow,
             lambda a : a.put_start_and_end_on(
                 self.output_plane.coords_to_point(0, 0),
                 out_loop.point_from_proportion(1)
@@ -2975,7 +2975,7 @@ class TickingClock(Scene):
 
         run_time = self.run_time
         self.play(ClockPassesTime(
-            clock, 
+            clock,
             run_time = run_time,
             hours_passed = 0.1*run_time
         ))
@@ -3245,35 +3245,3 @@ class Thumbnail(SearchSpacePerimeterVsArea):
 
         self.clear()
         self.add(lines)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/basel/basel.py
+++ b/old_projects/basel/basel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from constants import *
 
 from mobject.tex_mobject import TexMobject
@@ -170,7 +171,7 @@ class LightIndicator(VMobject):
 
     def continual_update(self):
         if self.light_source == None:
-            print "Indicator cannot update, reason: no light source found"
+            print("Indicator cannot update, reason: no light source found")
         self.set_intensity(self.measured_intensity())
 
         
@@ -199,9 +200,9 @@ class ContinualLightIndicatorUpdate(ContinualAnimation):
 
 def copy_func(f):
     """Based on http://stackoverflow.com/a/6528148/190597 (Glenn Maynard)"""
-    g = types.FunctionType(f.func_code, f.func_globals, name=f.func_name,
-                           argdefs=f.func_defaults,
-                           closure=f.func_closure)
+    g = types.FunctionType(f.__code__, f.__globals__, name=f.__name__,
+                           argdefs=f.__defaults__,
+                           closure=f.__closure__)
     g = functools.update_wrapper(g, f)
     return g
 
@@ -2575,7 +2576,7 @@ class InscribedAngleScene(ThreeDScene):
             show_animation = (onscreen_old or onscreen_1 or onscreen_2)
 
             if show_animation:
-                print "animating (", i, ",", step, ")"
+                print("animating (", i, ",", step, ")")
                 self.play(
                     ApplyMethod(ls1.move_source_to,ls_new_loc1, run_time = run_time),
                     ApplyMethod(ls2.move_source_to,ls_new_loc2, run_time = run_time),
@@ -3356,7 +3357,7 @@ class PondScene(ThreeDScene):
             show_animation = (onscreen_old or onscreen_1 or onscreen_2)
 
             if show_animation or animate:
-                print "animating (", i, ",", step, ")"
+                print("animating (", i, ",", step, ")")
                 self.play(
                     ApplyMethod(ls1.move_source_to,ls_new_loc1, run_time = run_time),
                     ApplyMethod(ls2.move_source_to,ls_new_loc2, run_time = run_time),
@@ -3694,7 +3695,7 @@ class PondScene(ThreeDScene):
         self.play(FadeOut(self.inner_lake))
 
         for n in range(3,max_it + 1):
-            print "working on n = ", n, "..."
+            print("working on n = ", n, "...")
             new_lake = self.outer_lake.copy().scale(2,about_point = self.obs_dot.get_center())
             for (i,ls) in enumerate(self.light_sources_array[:2**n]):
                 #print i
@@ -3725,14 +3726,14 @@ class PondScene(ThreeDScene):
                 onscreen_2 = np.all(np.abs(pos2[:2]) < 10 * 2**2)
                 
                 if onscreen_old or onscreen_1:
-                    print "anim1 for step", n, "part", i
-                    print "------------------ moving from", ls_old_loc[:2], "to", pos1[:2]
+                    print("anim1 for step", n, "part", i)
+                    print("------------------ moving from", ls_old_loc[:2], "to", pos1[:2])
                     shift_list.append(ApplyMethod(ls1.move_source_to, pos1, run_time = STEP_RUN_TIME))
                 else:
                     ls1.move_source_to(pos1)
                 if onscreen_old or onscreen_2:
-                    print "anim2 for step", n, "part", i
-                    print "------------------ moving from", ls_old_loc[:2], "to", pos2[:2]
+                    print("anim2 for step", n, "part", i)
+                    print("------------------ moving from", ls_old_loc[:2], "to", pos2[:2])
                     shift_list.append(ApplyMethod(ls2.move_source_to, pos2, run_time = STEP_RUN_TIME))
                 else:
                     ls2.move_source_to(pos2)
@@ -3741,7 +3742,7 @@ class PondScene(ThreeDScene):
                 #print shift_list
 
             self.play(*shift_list)
-            print "...done"
+            print("...done")
 
 
         #self.revert_to_original_skipping_status()
@@ -3768,9 +3769,9 @@ class PondScene(ThreeDScene):
             label_direction = UP,
         ).shift(origin_point - self.number_line.number_to_point(0)) # .shift(scale * 2.5 * DOWN)
 
-        print "scale ", scale
-        print "number line at", self.number_line.get_center()
-        print "should be at", origin_point, "or", OBSERVER_POINT
+        print("scale ", scale)
+        print("number line at", self.number_line.get_center())
+        print("should be at", origin_point, "or", OBSERVER_POINT)
 
         self.number_line.tick_marks.fade(1)
         self.number_line_labels = self.number_line.get_number_mobjects()

--- a/old_projects/basel/basel2.py
+++ b/old_projects/basel/basel2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 import types
@@ -127,7 +128,7 @@ class LightIndicator(Mobject):
 
     def continual_update(self):
         if self.light_source == None:
-            print "Indicator cannot update, reason: no light source found"
+            print("Indicator cannot update, reason: no light source found")
         self.set_intensity(self.measured_intensity())
 
 class UpdateLightIndicator(AnimationGroup):
@@ -151,9 +152,9 @@ class ContinualLightIndicatorUpdate(ContinualAnimation):
 
 def copy_func(f):
     """Based on http://stackoverflow.com/a/6528148/190597 (Glenn Maynard)"""
-    g = types.FunctionType(f.func_code, f.func_globals, name=f.func_name,
-                           argdefs=f.func_defaults,
-                           closure=f.func_closure)
+    g = types.FunctionType(f.__code__, f.__globals__, name=f.__name__,
+                           argdefs=f.__defaults__,
+                           closure=f.__closure__)
     g = functools.update_wrapper(g, f)
     return g
 
@@ -347,7 +348,7 @@ class IntroScene(PiCreatureScene):
         rect_label_anims = []
 
         for i, t1, t2 in zip(it.count(1), [0]+series_terms, series_terms):
-            color = slab_colors.next()
+            color = next(slab_colors)
             line = Line(*map(number_line.number_to_point, [t1, t2]))
             rect = Rectangle(
                 stroke_width = 0,
@@ -2114,7 +2115,7 @@ class TwoLightSourcesScene(ManipulateLightsourceSetups):
                 buff = SMALL_BUFF,
                 color = WHITE,
             )
-            for ls in lsA, lsB, lsC
+            for ls in (lsA, lsB, lsC)
         ])
 
         #Lines
@@ -3812,7 +3813,7 @@ class ThinkBackToHowAmazingThisIs(ThreeDScene):
                 Dot(number_line.number_to_point(u*x))
                 for x in range(1, int(self.x_radius), 2)
             ])
-            for u in 1, -1
+            for u in (1, -1)
         ]
         dot_pairs = it.starmap(VGroup, zip(positive_dots, negative_dots))
 
@@ -3842,7 +3843,7 @@ class ThinkBackToHowAmazingThisIs(ThreeDScene):
                 TexMobject("+").next_to(
                     number_line.number_to_point(u*n), UP, buff = 1.25,
                 )
-                for u in -1, 1
+                for u in (-1, 1)
             ])
             for n in range(0, self.max_shown_n, 2)
         ])
@@ -3889,7 +3890,7 @@ class ThinkBackToHowAmazingThisIs(ThreeDScene):
         circle = everything.copy()
         circle.move_to(ORIGIN)
         circle.apply_function(
-            lambda (x, y, z) : complex_to_R3(7*np.exp(complex(0, 0.0315*x)))
+            lambda x_y_z : complex_to_R3(7*np.exp(complex(0, 0.0315*x_y_z[0])))
         )
         circle.rotate(-TAU/4, about_point = ORIGIN)
         circle.center()

--- a/old_projects/bell.py
+++ b/old_projects/bell.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
 from big_ol_pile_of_manim_imports import *
 
 from tqdm import tqdm as ProgressDisplay
 
-from waves import *
+from .waves import *
+from functools import reduce
 
 #force_skipping
 #revert_to_original_skipping_status
@@ -103,7 +105,7 @@ class PhotonPassesCompletelyOrNotAtAll(DirectionOfPolarizationScene):
 class PhotonPassesCompletelyOrNotAtAllForWavesVideo(PhotonPassesCompletelyOrNotAtAll):
     CONFIG = {
         "show_M_vects" : False,
-    }    
+    }
 
 class DirectionOfPolarization(DirectionOfPolarizationScene):
     def construct(self):
@@ -193,13 +195,13 @@ class PhotonsThroughPerpendicularFilters(PhotonPassesCompletelyOrNotAtAll):
                 em_wave = self.em_wave.copy(),
                 run_time = 1,
             )
-            for x in -2, 2, 10
+            for x in (-2, 2, 10)
         ]
 
     def get_probability_text(self, prob = 0):
         prob_text = TexMobject(
-            "P(", "\\substack", "{\\text{photons that make it} \\\\ ", 
-            " \\text{here } ", "\\text{make it}", 
+            "P(", "\\substack", "{\\text{photons that make it} \\\\ ",
+            " \\text{here } ", "\\text{make it}",
             " \\text{ here} }", ")", "=", str(int(prob*100)), "\\%",
             arg_separator = ""
         )
@@ -217,7 +219,7 @@ class PhotonsThroughPerpendicularFilters(PhotonPassesCompletelyOrNotAtAll):
                 color = here.get_color(),
                 normal_vector = DOWN+OUT,
             )
-            for here, x in (here1, 0), (here2, 4)
+            for here, x in ((here1, 0), (here2, 4))
         ]
         prob_text.add(*arrows)
 
@@ -235,7 +237,7 @@ class MoreFiltersMoreLight(FilterScene):
         ],
         "ambient_rotation_rate" : 0,
         "arrow_rgb" : (0, 0, 0),
-        "background_rgb" : (245, 245, 245), 
+        "background_rgb" : (245, 245, 245),
     }
     def construct(self):
         self.remove(self.axes)
@@ -338,7 +340,7 @@ class MoreFiltersMoreLight(FilterScene):
 class MoreFiltersMoreLightBlackBackground(MoreFiltersMoreLight):
     CONFIG = {
         "arrow_rgb" : (255, 255, 255),
-        "background_rgb" : (0, 0, 0),    
+        "background_rgb" : (0, 0, 0),
     }
 
 class ConfusedPiCreature(Scene):
@@ -369,7 +371,7 @@ class ShowALittleMath(TeacherStudentsScene):
     def construct(self):
         exp1 = TexMobject(
             "|", "\\psi", "\\rangle = ",
-            "\\alpha", "|\\uparrow\\rangle", 
+            "\\alpha", "|\\uparrow\\rangle",
             "+", "\\beta", "|\\rightarrow\\rangle"
         )
         exp2 = TexMobject(
@@ -590,7 +592,7 @@ class ShowVariousFilterPairsWithPhotonsOverTime(PhotonsThroughPerpendicularFilte
         "filter_x_coordinates" : [-2, 2, 2, 2, 2],
         "pol_filter_configs" : [
             {"filter_angle" : angle}
-            for angle in 0, 0, np.pi/2, np.pi/4, np.pi/8
+            for angle in (0, 0, np.pi/2, np.pi/4, np.pi/8)
         ],
         "apply_filter" : False,
     }
@@ -673,11 +675,11 @@ class ShowVariousFilterPairsWithPhotonsOverTime(PhotonsThroughPerpendicularFilte
             self.play(
                 blocked_photon,
                 first_absorption,
-                photon, 
+                photon,
                 *added_anims
             )
         self.wait()
-        
+
     def change_to_new_filter(self, pol_filter, added_anims = None):
         if added_anims is None:
             added_anims = []
@@ -761,7 +763,7 @@ class ShowVariousFilterPairs(ShowVariousFilterPairsWithPhotonsOverTime):
         self.move_camera(
             0.9*np.pi/2, -0.6*np.pi,
             added_anims = [
-                pf.restore 
+                pf.restore
                 for pf in pair
             ]
         )
@@ -830,7 +832,7 @@ class ShowVariousFilterPairs(ShowVariousFilterPairsWithPhotonsOverTime):
     #####
 
     def get_lines(
-        self, filter1 = None, filter2 = None, 
+        self, filter1 = None, filter2 = None,
         ratio = 1.0,
         remove_from_bottom = False,
         ):
@@ -838,7 +840,7 @@ class ShowVariousFilterPairs(ShowVariousFilterPairsWithPhotonsOverTime):
         n = self.n_lines
         start, end = [
             (f.point_from_proportion(0.75) if f is not None else None)
-            for f in filter1, filter2
+            for f in (filter1, filter2)
         ]
         if start is None:
             start = end + self.line_start_length*LEFT
@@ -878,7 +880,7 @@ class ShowVariousFilterPairsFrom0To45(ShowVariousFilterPairs):
 
         cosines = VGroup(*[
             TexMobject("\\cos^2(%s^\\circ)"%str(x))
-            for x in 45, 22.5
+            for x in (45, 22.5)
         ])
         cosines.scale(0.8)
         # cosines.set_color(BLUE)
@@ -896,7 +898,7 @@ class ForgetPreviousActions(ShowVariousFilterPairs):
         "filter_x_coordinates" : [-6, -2, 2, 2, 2],
         "pol_filter_configs" : [
             {"filter_angle" : angle}
-            for angle in np.pi/4, 0, np.pi/4, np.pi/3, np.pi/6
+            for angle in (np.pi/4, 0, np.pi/4, np.pi/3, np.pi/6)
         ],
         "start_theta" : -0.6*np.pi,
         "EMWave_config" : {
@@ -969,7 +971,7 @@ class ForgetPreviousActions(ShowVariousFilterPairs):
         ignore_words.next_to(rect2, OUT)
 
         self.play(
-            ShowCreation(rect2), 
+            ShowCreation(rect2),
             Write(ignore_words, run_time = 1),
             FadeIn(front_filter),
             run_time = 1.5,
@@ -1048,7 +1050,7 @@ class IntroduceLabeledFilters(ShowVariousFilterPairs):
 
     def reposition_camera(self):
         self.move_camera(
-            theta = self.target_theta, 
+            theta = self.target_theta,
             added_anims = list(it.chain(*[
                 [
                     pf.arrow_label.rotate, np.pi/2, OUT,
@@ -1263,7 +1265,7 @@ class IntroduceLabeledFilters(ShowVariousFilterPairs):
             FadeIn(randy)
         )
         self.play(Transform(
-            randy, blinked, 
+            randy, blinked,
             rate_func = squish_rate_func(there_and_back)
         ))
         self.wait(3)
@@ -1393,7 +1395,7 @@ class VennDiagramProofByContradiction(Scene):
                     "%s \\\\"%start,
                     "through", char + "$\\! \\uparrow$"
                 ).set_color_by_tex(char, circle.get_color())
-                for start in "Would pass", "Pass"
+                for start in ("Would pass", "Pass")
             ]
             for mob in label, alt_label:
                 mob[-1][-1].rotate_in_place(-angle)
@@ -1446,7 +1448,7 @@ class VennDiagramProofByContradiction(Scene):
     def show_100_photons(self):
         photon = FunctionGraph(
             lambda x : -np.cos(3*np.pi*x)*np.exp(-x*x),
-            x_min = -2, 
+            x_min = -2,
             x_max = 2,
             color = YELLOW,
             stroke_width = 2,
@@ -1502,7 +1504,7 @@ class VennDiagramProofByContradiction(Scene):
         })
         bubble = ThoughtBubble()
         bubble.add_content(answers)
-        bubble.resize_to_content() 
+        bubble.resize_to_content()
         answers.shift(SMALL_BUFF*(RIGHT+UP))
         bubble_group = VGroup(bubble, answers)
         bubble_group.scale(0.25)
@@ -1601,7 +1603,7 @@ class VennDiagramProofByContradiction(Scene):
         words1.scale(0.8)
         words1.next_to(A_group, LEFT, LARGE_BUFF).shift(UP)
         arrow1 = Arrow(
-            words1.get_right(), 
+            words1.get_right(),
             in_B.get_corner(UP+LEFT) + MED_LARGE_BUFF*(DOWN+RIGHT)
         )
         arrow1.set_color(GREEN)
@@ -1631,7 +1633,7 @@ class VennDiagramProofByContradiction(Scene):
         self.wait()
         self.play(ApplyMethod(
             VGroup(self.in_A_out_B, out_of_B).shift,
-            MED_LARGE_BUFF*UP, 
+            MED_LARGE_BUFF*UP,
             rate_func = wiggle,
             run_time = 1.5,
         ))
@@ -1741,7 +1743,7 @@ class VennDiagramProofByContradiction(Scene):
         regions = [self.in_A_out_C, self.in_A_in_B_out_C, self.in_A_out_B]
         self.play(*[
             ApplyMethod(
-                m.scale, 0.7, 
+                m.scale, 0.7,
                 method_kwargs = {
                     "about_point" : FRAME_Y_RADIUS*DOWN
                 }
@@ -1752,7 +1754,7 @@ class VennDiagramProofByContradiction(Scene):
         terms = VGroup(
             TexMobject("N(", "A", "\\checkmark", ",", "C", ")", "\\le"),
             TexMobject(
-                "N(", "A", "\\checkmark", ",", 
+                "N(", "A", "\\checkmark", ",",
                 "B", "\\checkmark", ",", "C", ")"
             ),
             TexMobject("+\\, N(", "A", "\\checkmark", ",", "B", ")"),
@@ -1961,7 +1963,7 @@ class VennDiagramProofByContradiction(Scene):
         )
         self.play(photon.eyes.blink_anim())
         self.play(
-            photon.restore, 
+            photon.restore,
             FadeOut(bubble)
         )
 
@@ -1976,7 +1978,7 @@ class VennDiagramProofByContradiction(Scene):
                 fill_opacity = 0.5,
                 fill_color = YELLOW,
             )
-            for s in "in_A_out_B", "in_A_in_B_out_C", "in_A_out_C", "in_A_in_B"
+            for s in ("in_A_out_B", "in_A_in_B_out_C", "in_A_out_C", "in_A_in_B")
         ])
 
         in_A_out_B.scale(2.59)
@@ -2009,7 +2011,7 @@ class VennDiagramProofByContradiction(Scene):
             else:
                 rejected.append((x, y))
         rejected.sort(
-            lambda (x1, y1), (x2, y2) : (x2**2 + y2**2) - (x1**2 + y1**2)
+            lambda xy0, xy1: (xy1[0]**2 + xy1[1]**2) - (xy0[0]**2 + xy0[1]**2)
         )
         for i in range(len(photons) - len(pairs)):
             pairs.append(rejected.pop())
@@ -2218,7 +2220,7 @@ class ReEmphasizeVennDiagram(VennDiagramProofByContradiction):
                 m2.copy(), m1.copy(),
                 VGroup(*self.circles).copy()
             )
-            for m1, m2 in (C0, A1_yellow_copy), (C0, B1), (B0, A1)
+            for m1, m2 in ((C0, A1_yellow_copy), (C0, B1), (B0, A1))
         ])
         for group, vect in zip(groups[1:], [UP, 5*RIGHT+UP]):
             group.scale_in_place(0.5)
@@ -2242,7 +2244,7 @@ class ReEmphasizeVennDiagram(VennDiagramProofByContradiction):
         self.wait()
         self.play(FadeIn(groups[1]))
         self.play(
-            groups[1].restore, 
+            groups[1].restore,
             FadeIn(inequality[1]),
             FadeIn(self.in_B_out_C_words),
             FadeIn(big_plus),
@@ -2309,8 +2311,8 @@ class ReEmphasizeVennDiagram(VennDiagramProofByContradiction):
         words.to_edge(UP)
 
         footnote = TextMobject("""
-            *If you prefer, you can avoid the need for that 
-            assumption by swapping the roles of A and C here 
+            *If you prefer, you can avoid the need for that
+            assumption by swapping the roles of A and C here
             and writing a second inequality for added constraint.
         """)
         footnote.scale(0.5)
@@ -2383,7 +2385,7 @@ class NoFirstMeasurementPreferenceBasedOnDirection(ShowVariousFilterPairs):
         "filter_x_coordinates" : [0, 0, 0],
         "pol_filter_configs" : [
             {"filter_angle" : angle}
-            for angle in 0, np.pi/8, np.pi/4
+            for angle in (0, np.pi/8, np.pi/4)
         ],
         "lines_depth" : 1.2,
         "lines_shift_vect" : SMALL_BUFF*OUT,
@@ -2452,19 +2454,3 @@ class NoFirstMeasurementPreferenceBasedOnDirection(ShowVariousFilterPairs):
         )
         self.add_foreground_mobject(all_pre_lines)
         self.wait(7)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/borsuk.py
+++ b/old_projects/borsuk.py
@@ -1,4 +1,5 @@
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 class Jewel(VMobject):
     CONFIG = {
@@ -943,7 +944,7 @@ class WalkEquatorPostTransform(GraphScene):
                 curve.x_collision_points[i]
                 for curve in gerat_arc_images
             ]
-            for i in 0, 1
+            for i in (0, 1)
         ]))
         full_curve = VMobject(close_new_points = True)
         full_curve.set_points_smoothly(points + [points[0]])
@@ -1818,7 +1819,7 @@ class ChoicesInNecklaceCutting(ReconfigurableScene):
         for group in groups:
             group.target_points = [
                 group.get_center() + self.thief_box_offset*vect
-                for vect in UP, DOWN
+                for vect in (UP, DOWN)
             ]
 
         return groups
@@ -1835,7 +1836,7 @@ class ChoicesInNecklaceCutting(ReconfigurableScene):
 
         boxes = VGroup(*[
             box.copy().shift(self.thief_box_offset*vect)
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ])
         labels = VGroup(*[
             TextMobject(
@@ -2083,7 +2084,7 @@ class NecklaceDivisionSphereAssociation(ChoicesInNecklaceCutting):
                 TexMobject(
                     char, "=", sign, "\\sqrt{\\frac{1}{%d}}"%denom
                 )
-                for sign in "+", "-"
+                for sign in ("+", "-")
             ]
             for choice, color in zip(choices, [GREEN, RED]):
                 # choice[0].set_color(brace.label.get_color())
@@ -2216,7 +2217,7 @@ class TotalLengthOfEachJewelEquals(NecklaceDivisionSphereAssociation, ThreeDScen
                     lambda segment: segment.get_color() == color,
                     segment_group
                 ))
-                for segment_group in top_segments, bottom_segments
+                for segment_group in (top_segments, bottom_segments)
             ]
             labels = VGroup()
             for i, group in enumerate(monochrome_groups):
@@ -2304,7 +2305,7 @@ class ShowFunctionDiagram(TotalLengthOfEachJewelEquals, ReconfigurableScene):
                 skip_animations = True, 
                 thief_number = x
             )
-            for x in 1, 2
+            for x in (1, 2)
         ]
         t1_plane, t2_plane = planes = VGroup(*[
             VGroup(*plane_class.get_top_level_mobjects())

--- a/old_projects/brachistochrone/curves.py
+++ b/old_projects/brachistochrone/curves.py
@@ -353,7 +353,7 @@ class TransitionAwayFromSlide(PathSlidingScene):
         arrow = Arrow(ORIGIN, 2*RIGHT)
         arrows = Mobject(*[
             arrow.copy().shift(vect)
-            for vect in 3*LEFT, ORIGIN, 3*RIGHT
+            for vect in (3*LEFT, ORIGIN, 3*RIGHT)
         ])
         arrows.shift(FRAME_WIDTH*RIGHT)
         self.add(arrows)

--- a/old_projects/brachistochrone/cycloid.py
+++ b/old_projects/brachistochrone/cycloid.py
@@ -36,7 +36,7 @@ class CycloidScene(Scene):
     def grow_parts(self):
         self.play(*[
             ShowCreation(mob)
-            for mob in self.circle, self.ceiling
+            for mob in (self.circle, self.ceiling)
         ])
 
     def generate_cycloid(self):
@@ -295,7 +295,7 @@ class LeviSolution(CycloidScene):
         self.wait()
         self.play(*[
             Transform(mob, d_mob)
-            for mob in brace, diameter_word
+            for mob in (brace, diameter_word)
         ])
         self.remove(brace, diameter_word)
         self.add(d_mob)

--- a/old_projects/brachistochrone/drawing_images.py
+++ b/old_projects/brachistochrone/drawing_images.py
@@ -255,7 +255,7 @@ class NewtonVsJohann(Scene):
     def construct(self):
         newton, johann = [
             ImageMobject(name, invert = False).scale(0.5)
-            for name in "Newton", "Johann_Bernoulli2"
+            for name in ("Newton", "Johann_Bernoulli2")
         ]
         greater_than = TexMobject(">")
         newton.next_to(greater_than, RIGHT)
@@ -277,7 +277,7 @@ class JohannThinksOfFermat(Scene):
     def construct(self):
         johann, fermat = [
             ImageMobject(name, invert = False)
-            for name in "Johann_Bernoulli2", "Pierre_de_Fermat"
+            for name in ("Johann_Bernoulli2", "Pierre_de_Fermat")
         ]
         johann.scale(0.2)
         johann.to_corner(DOWN+LEFT)

--- a/old_projects/brachistochrone/graveyard.py
+++ b/old_projects/brachistochrone/graveyard.py
@@ -69,7 +69,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
         )
         top_rgb, bottom_rgb = [
             np.array(Color(color).get_rgb())
-            for color in self.top_color, self.bottom_color
+            for color in (self.top_color, self.bottom_color)
         ]
         epsilon = 1./(self.num_discrete_layers-1)
         self.layer_colors = [
@@ -239,7 +239,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
     def show_snells(self, index, frame):
         left_text, right_text = [
             "\\dfrac{\\sin(\\theta_%d)}{\\phantom{\\sqrt{y_1}}}"%x
-            for x in index, index+1
+            for x in (index, index+1)
         ]
         left, equals, right = TexMobject(
             [left_text, "=", right_text]
@@ -251,7 +251,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
                 TexMobject(
                     text, size = "\\Large"
                 ).next_to(numerator, DOWN)
-                for text in "v_%d"%x, "\\sqrt{y_%d}"%x
+                for text in ("v_%d"%x, "\\sqrt{y_%d}"%x)
             ]
             vs.append(v)
             sqrt_ys.append(sqrt_y)
@@ -259,7 +259,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
             Mobject(
                 left.copy(), mobs[0], equals.copy(), right.copy(), mobs[1]
             ).replace(frame)
-            for mobs in vs, sqrt_ys
+            for mobs in (vs, sqrt_ys)
         ]
 
         self.add(start)

--- a/old_projects/brachistochrone/light.py
+++ b/old_projects/brachistochrone/light.py
@@ -499,7 +499,7 @@ class GeometryOfGlassSituation(ShowMultiplePathsInWater):
         new_graph.reverse_points()
         pairs_for_end_transform = [
             (mob, mob.copy())
-            for mob in top_line, bottom_line, left_brace, x_mob
+            for mob in (top_line, bottom_line, left_brace, x_mob)
         ]
 
         self.add(glass, point_a, point_b, A, B)
@@ -636,7 +636,7 @@ class SpringSetup(ShowMultiplePathsInWater):
                 Spring(self.start_point, r.get_top()),
                 Spring(self.end_point, r.get_bottom())
             )
-            for r in ring, ring.copy().shift(self.ring_shift_val)
+            for r in (ring, ring.copy().shift(self.ring_shift_val))
         ]
         
     def add_rod_and_ring(self, rod, ring):
@@ -663,7 +663,7 @@ class SpringSetup(ShowMultiplePathsInWater):
     def add_springs(self):
         colors = iter([BLACK, BLUE_E])
         for spring in self.start_springs.split():
-            circle = Circle(color = colors.next())
+            circle = Circle(color = next(colors))
             circle.reverse_points()
             circle.scale(spring.loop_radius)
             circle.shift(spring.points[0])
@@ -725,7 +725,7 @@ class SpringSetup(ShowMultiplePathsInWater):
             arc = Arc(angle, radius = 0.5).rotate(np.pi/2)
             if point is self.end_point:
                 arc.rotate(np.pi)
-            theta = TexMobject("\\theta_%d"%counter.next())
+            theta = TexMobject("\\theta_%d"%next(counter))
             theta.scale(0.5)
             theta.shift(2*arc.get_center())
             arc.shift(ring_center)
@@ -765,7 +765,7 @@ class SpringSetup(ShowMultiplePathsInWater):
         frac1, sin1, equals, frac2, sin2 = equation.split()
         v_air, v_water = [
             TexMobject("v_{\\text{%s}}"%s, size = "\\Large")
-            for s in "air", "water"
+            for s in ("air", "water")
         ]
         v_air.next_to(Point(frac1.get_center()), DOWN)
         v_water.next_to(Point(frac2.get_center()), DOWN)
@@ -773,7 +773,7 @@ class SpringSetup(ShowMultiplePathsInWater):
         frac2.add(v_water)
         f1, f2 = [
             TexMobject("F_%d"%d, size = "\\Large") 
-            for d in 1, 2
+            for d in (1, 2)
         ]
         f1.next_to(sin1, LEFT)
         f2.next_to(equals, RIGHT)
@@ -875,7 +875,7 @@ class StateSnellsLaw(PhotonScene):
             if point is point_b:
                 arc.rotate(np.pi)
                 line.reverse_points()
-            theta = TexMobject("\\theta_%d"%counter.next())
+            theta = TexMobject("\\theta_%d"%next(counter))
             theta.scale(0.5)
             theta.shift(2*arc.get_center())
             arc.shift(midpoint)

--- a/old_projects/brachistochrone/misc.py
+++ b/old_projects/brachistochrone/misc.py
@@ -7,7 +7,8 @@ from brachistochrone.curves import Cycloid
 class PhysicalIntuition(Scene):
     def construct(self):
         n_terms = 4
-        def func((x, y, ignore)):
+        def func(xxx_todo_changeme):
+            (x, y, ignore) = xxx_todo_changeme
             z = complex(x, y)                                    
             if (np.abs(x%1 - 0.5)<0.01 and y < 0.01) or np.abs(z)<0.01:
                 return ORIGIN
@@ -87,7 +88,7 @@ class TimeLine(Scene):
         for point, event in zip(centers[1:], dated_events):
             self.play(ApplyMethod(
                 timeline.shift, -point.get_center(), 
-                run_time = run_times.next()
+                run_time = next(run_times)
             ))
             picture = ImageMobject(event["picture"], invert = False)
             picture.scale_to_fit_width(2)

--- a/old_projects/brachistochrone/multilayered.py
+++ b/old_projects/brachistochrone/multilayered.py
@@ -23,7 +23,7 @@ class MultilayeredScene(Scene):
         height = float(self.total_glass_height)/n_layers
         rgb_pair = [
             np.array(Color(color).get_rgb())
-            for color in self.top_color, self.bottom_color
+            for color in (self.top_color, self.bottom_color)
         ]
         rgb_range = [
             interpolate(*rgb_pair+[x])
@@ -253,7 +253,7 @@ class ShowLayerVariables(MultilayeredScene, PhotonScene):
                 )
                 for mob, start in zip(mobs, starts)
             ]
-            for mobs in start_ys, braces
+            for mobs in (start_ys, braces)
         ]))
         self.wait()
 

--- a/old_projects/complex_multiplication_article.py
+++ b/old_projects/complex_multiplication_article.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import sys
 
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 DEFAULT_PLANE_CONFIG = {
     "stroke_width" : 2*DEFAULT_POINT_THICKNESS

--- a/old_projects/counting_in_binary.py
+++ b/old_projects/counting_in_binary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import numpy as np
 import itertools as it
 from copy import deepcopy

--- a/old_projects/crypto.py
+++ b/old_projects/crypto.py
@@ -110,7 +110,7 @@ class AskQuestion(Scene):
     }
     def construct(self):
         strings = [
-            "What", "does", "it", "mean   ", "to", 
+            "What", "does", "it", "mean   ", "to",
             "have    ", "a", "Bitcoin?"
         ]
         question = TextMobject(*strings)
@@ -140,7 +140,7 @@ class ListOfAttributes(Scene):
                 fill_opacity = 1,
                 stroke_width = 0,
             )
-            for word in "government", "bank"
+            for word in ("government", "bank")
         ]
         attributes = VGroup(digital, *buildings)
         attributes.arrange_submobjects(RIGHT, buff = LARGE_BUFF)
@@ -247,7 +247,7 @@ class DisectQuestion(TeacherStudentsScene):
 class CryptocurrencyEquation(Scene):
     def construct(self):
         parts = TextMobject(
-            "Ledger", 
+            "Ledger",
             "- Trust",
             "+ Cryptography",
             "= Cryptocurrency"
@@ -282,9 +282,9 @@ class ListRecentCurrencies(Scene):
         logos.shift(LEFT)
         logos.to_edge(UP)
         names = map(
-            TextMobject, 
+            TextMobject,
             [
-                "Bitcoin", "Ethereum", "Ripple", 
+                "Bitcoin", "Ethereum", "Ripple",
                 "Litecoin", "Ethereum Classic"
             ],
         )
@@ -419,7 +419,7 @@ class LedgerScene(PiCreatureScene):
     def get_ledger(self):
         title = TextMobject("Ledger")
         rect = Rectangle(
-            width = self.ledger_width, 
+            width = self.ledger_width,
             height = self.ledger_height
         )
         title.next_to(rect.get_top(), DOWN)
@@ -452,8 +452,8 @@ class LedgerScene(PiCreatureScene):
             num.next_to(mob, LEFT, MED_SMALL_BUFF)
             mob.add_to_back(num)
         mob.next_to(
-            items[-1], DOWN, 
-            buff = MED_SMALL_BUFF, 
+            items[-1], DOWN,
+            buff = MED_SMALL_BUFF,
             aligned_edge = LEFT
         )
         if self.enumerate_lines and len(items) == 1:
@@ -468,7 +468,7 @@ class LedgerScene(PiCreatureScene):
         else:
             amount_str += " " + self.denomination
         line_tex_parts = [
-            from_name.capitalize(), 
+            from_name.capitalize(),
             "pays" if from_name.lower() != "you" else "pay",
             to_name.capitalize(),
             amount_str,
@@ -504,7 +504,7 @@ class LedgerScene(PiCreatureScene):
     def animate_payment_addition(self, *args, **kwargs):
         line = self.add_payment_line_to_ledger(*args, **kwargs)
         self.play(LaggedStart(
-            FadeIn, 
+            FadeIn,
             VGroup(*it.chain(*line)),
             run_time = 1
         ))
@@ -704,7 +704,7 @@ class UnderlyingSystemVsUserFacing(Scene):
         self.wait(2)
         self.play(DrawBorderThenFill(phone))
         self.wait(2)
-        
+
 class FromBankToDecentralizedSystemCopy(ExternallyAnimatedScene):
     pass
 
@@ -793,7 +793,7 @@ class IntroduceLedgerSystem(LedgerScene):
         tally_up.add_background_rectangle()
 
         self.play(
-            GrowFromCenter(brace), 
+            GrowFromCenter(brace),
             FadeIn(tally_up)
         )
         self.play(
@@ -809,7 +809,7 @@ class IntroduceLedgerSystem(LedgerScene):
         self.wait()
         debtor_cash, creditor_cash = [
             VGroup(*it.chain(*[pi.cash for pi in group]))
-            for group in debtors, creditors
+            for group in (debtors, creditors)
         ]
         self.play(FadeIn(debtor_cash))
         self.play(
@@ -870,7 +870,7 @@ class AddFraudulentLine(LedgerScene):
         words.to_corner(UP+RIGHT)
         words.set_color(YELLOW)
         arrow = Arrow(
-            words.get_left(), 
+            words.get_left(),
             self.ledger.content.get_center() + DOWN,
         )
 
@@ -1120,8 +1120,8 @@ class DescribeDigitalSignatures(LedgerScene):
         lines.add(ex, signature_line)
 
         rect = SurroundingRectangle(
-            lines, 
-            color = LIGHT_GREY, 
+            lines,
+            color = LIGHT_GREY,
             buff = MED_SMALL_BUFF
         )
         document = VGroup(rect, lines)
@@ -1248,7 +1248,7 @@ class DescribeDigitalSignatures(LedgerScene):
             FadeIn(part)
             for part in verify
             if part not in [
-                verify.message, verify.signature, 
+                verify.message, verify.signature,
                 verify.pk, verify[-1]
             ]
         ])
@@ -1272,7 +1272,7 @@ class DescribeDigitalSignatures(LedgerScene):
 class TryGuessingDigitalSignature(Scene):
     def construct(self):
         verify = TextMobject(
-            "Verify(", "Message", ", ", 
+            "Verify(", "Message", ", ",
             "256 bit Signature", ", ", "pk", ")",
             arg_separator = ""
         )
@@ -1338,7 +1338,7 @@ class FeelConfidentWithVerification(PiCreatureScene):
 
     def show_verification(self):
         verify = TextMobject(
-            "Verify(", "Message", ", ", 
+            "Verify(", "Message", ", ",
             "256 bit Signature", ", ", "pk", ")",
             arg_separator = ""
         )
@@ -1364,7 +1364,7 @@ class FeelConfidentWithVerification(PiCreatureScene):
         lock_box = SurroundingRectangle(sk_group, buff = SMALL_BUFF)
         lock_box.set_color(RED)
         lock = SVGMobject(
-            file_name = "lock", 
+            file_name = "lock",
             fill_color = LIGHT_GREY,
             height = 0.5,
         )
@@ -1547,7 +1547,7 @@ class CharlieRacksUpDebt(SignedLedgerScene):
         ])
 
         self.play(LaggedStart(
-            FadeIn, lines, 
+            FadeIn, lines,
             run_time = 3,
             lag_ratio = 0.25
         ))
@@ -1583,7 +1583,7 @@ class ThinkAboutSettlingUp(Scene):
         randy.to_corner(DOWN+LEFT)
 
         self.play(PiCreatureBubbleIntroduction(
-            randy, 
+            randy,
             "You don't \\emph{actually} \\\\" + \
             "need to settle up $\\dots$",
             bubble_class = ThoughtBubble,
@@ -1646,7 +1646,7 @@ class LedgerWithInitialBuyIn(SignedLedgerScene):
         lines = VGroup()
         for name in self.get_names():
             new_line = TextMobject(
-                name.capitalize(), 
+                name.capitalize(),
                 "get" if name == "you" else "gets",
                 "\\$100"
             )
@@ -1691,7 +1691,7 @@ class LedgerWithInitialBuyIn(SignedLedgerScene):
     def point_out_charlie_is_broke(self):
         charlie_lines = VGroup(*[
             VGroup(*self.ledger.content[i][1:5])
-            for i in 3, 5, 6, 7
+            for i in (3, 5, 6, 7)
         ])
         rects = VGroup(*[
             SurroundingRectangle(line)
@@ -1722,11 +1722,11 @@ class LedgerWithInitialBuyIn(SignedLedgerScene):
     def running_balance(self):
         charlie_lines = VGroup(*[
             VGroup(*self.ledger.content[i][1:5])
-            for i in 3, 5, 6, 7
+            for i in (3, 5, 6, 7)
         ])
         signatures = VGroup(*[
             self.ledger.content[i][5]
-            for i in 5, 6, 7
+            for i in (5, 6, 7)
         ])
         rect = Rectangle(color = WHITE)
         rect.set_fill(BLACK, 0.8)
@@ -1791,7 +1791,7 @@ class RemovedConnectionBetweenLedgerAndCash(TeacherStudentsScene):
             arrow.set_fill, None, 0
         )
         self.play(
-            ledger.shift, LEFT, 
+            ledger.shift, LEFT,
             cash.shift, RIGHT
         )
         self.change_student_modes(
@@ -2079,7 +2079,7 @@ class DistributedLedgerScene(LedgerScene):
 
     def add_large_network_and_distributed_ledger(self):
         self.add(self.get_large_network())
-        self.add(self.get_distributed_ledgers())        
+        self.add(self.get_distributed_ledgers())
 
 class TransitionToDistributedLedger(DistributedLedgerScene):
     CONFIG = {
@@ -2185,7 +2185,7 @@ class TransitionToDistributedLedger(DistributedLedgerScene):
         self.wait()
         self.play(
             ReplacementTransform(
-                VGroup(payment), payment_copies, 
+                VGroup(payment), payment_copies,
                 run_time = 3,
                 rate_func = squish_rate_func(smooth, 0.5, 1)
             ),
@@ -2316,7 +2316,7 @@ class YouListeningToBroadcasts(LedgerScene):
         self.remove(self.ledger)
         corners = [
             FRAME_X_RADIUS*RIGHT*u1 + FRAME_Y_RADIUS*UP*u2
-            for u1, u2 in (-1, 1), (1, 1), (-1, -1)
+            for u1, u2 in ((-1, 1), (1, 1), (-1, -1))
         ]
         you = self.you
         you.scale(2)
@@ -2768,9 +2768,9 @@ class IntroduceNonceOnTrasactions(LedgerScene):
         ))
         bit_iter = iter(digest)
         self.play(LaggedStart(
-            ReplacementTransform, 
+            ReplacementTransform,
             VGroup(*[point.copy() for x in range(256)]),
-            lambda m : (m, bit_iter.next()),
+            lambda m : (m, next(bit_iter)),
         ))
         self.remove(*self.get_mobjects_from_last_animation())
         self.add(digest)
@@ -2829,7 +2829,7 @@ class IntroduceNonceOnTrasactions(LedgerScene):
         self.wait()
         self.play(self.nonce.restore)
         self.play(
-            self.digest.restore, 
+            self.digest.restore,
             submobject_mode = "lagged_start",
             run_time = 2
         )
@@ -2981,7 +2981,7 @@ class IntroduceBlockChain(Scene):
         self.play(
             Write(blocks_word),
             LaggedStart(
-                ShowCreation, arrows, 
+                ShowCreation, arrows,
                 run_time = 1,
                 lag_factor = 0.6,
             )
@@ -3181,7 +3181,7 @@ class IntroduceBlockChain(Scene):
             Line(
                 rect.get_left(), rect.get_right()
             ).shift(0.3*rect.get_height()*vect)
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ]
 
         payments = VGroup()
@@ -3259,7 +3259,7 @@ class DistributedBlockChainScene(DistributedLedgerScene):
 
     def get_block_chain(self):
         blocks = VGroup(*[
-            self.get_block() 
+            self.get_block()
             for x in range(self.n_blocks)
         ])
         blocks.arrange_submobjects(RIGHT, buff = MED_SMALL_BUFF)
@@ -3382,7 +3382,7 @@ class FromBankToDecentralizedSystem(DistributedBlockChainScene):
     def set_aside_everything(self):
         digital_signature = self.digital_signature
         ledger = LedgerScene.get_ledger(self)
-        LedgerScene.add_payment_line_to_ledger(self, 
+        LedgerScene.add_payment_line_to_ledger(self,
             "Alice", "Bob", "40",
         )
         LedgerScene.add_payment_line_to_ledger(self,
@@ -3640,8 +3640,8 @@ class IntroduceBlockCreator(DistributedBlockChainScene):
         for old_chain, new_chain  in zip(old_chains, new_chains):
             for attr in "blocks", "arrows":
                 pairs = zip(
-                    getattr(old_chain, attr), 
-                    getattr(new_chain, attr), 
+                    getattr(old_chain, attr),
+                    getattr(new_chain, attr),
                 )
                 for m1, m2 in pairs:
                     anims.append(Transform(m1, m2))
@@ -3664,7 +3664,7 @@ class IntroduceBlockCreator(DistributedBlockChainScene):
             arrow_creations,
             [
                 ApplyMethod(
-                    pi.change, "hooray", 
+                    pi.change, "hooray",
                     pi.block_chain.get_right()
                 )
                 for pi in self.pi_creatures
@@ -3779,7 +3779,7 @@ class MiningIsALottery(IntroduceBlockCreator):
             winner.change, "hooray",
             *[
                 ApplyMethod(VGroup(
-                    self.blocks[i], self.arrows[i], 
+                    self.blocks[i], self.arrows[i],
                     nonces[i], digests[i]
                 ).fade, 0.7)
                 for i in range(len(self.blocks))
@@ -3856,7 +3856,7 @@ class TwoBlockChains(DistributedBlockChainScene):
                 ),
                 Broadcast(corner, run_time = 3),
                 ShowCreation(
-                    arrow, 
+                    arrow,
                     rate_func = squish_rate_func(smooth, 0.8, 1),
                     run_time = 3,
                 ),
@@ -3918,7 +3918,7 @@ class TwoBlockChains(DistributedBlockChainScene):
         self.wait()
 
         self.to_fade = VGroup(
-            conflicting, arrows, 
+            conflicting, arrows,
             longer_chain_rect, checkmark
         )
         self.block_chains = block_chains
@@ -4096,7 +4096,7 @@ class DoubleSpendingAttack(DistributedBlockChainScene):
         content = VGroup()
 
         tuples = [
-            ("Prev hash", UP, BLUE), 
+            ("Prev hash", UP, BLUE),
             ("Proof of work", DOWN, GREEN),
         ]
         for word, vect, color in tuples:
@@ -4198,7 +4198,7 @@ class AliceRacesOtherMiners(DoubleSpendingAttack):
             for mob, vect in (proof_of_work, DOWN), (prev_hash, UP):
                 mob.scale_to_fit_height(0.1*block.get_height())
                 mob.next_to(
-                    block.get_edge_center(vect), -vect, 
+                    block.get_edge_center(vect), -vect,
                     buff = 0.05*block.get_height()
                 )
                 block.add(mob)
@@ -4223,8 +4223,8 @@ class AliceRacesOtherMiners(DoubleSpendingAttack):
             self.alice.change, "hooray"
         )
         self.wait()
-    
-        block = fraud_block.copy()        
+
+        block = fraud_block.copy()
         block.generate_target()
         block.target.replace(chain.blocks[-1], stretch = True)
         arrow = chain.arrows[-1].copy()
@@ -4274,7 +4274,7 @@ class AliceRacesOtherMiners(DoubleSpendingAttack):
             Broadcast(block),
             *[
                 MoveToTarget(
-                    mover, run_time = 3, 
+                    mover, run_time = 3,
                     rate_func = squish_rate_func(smooth, 0.3, 0.8)
                 )
                 for mover in movers
@@ -4424,7 +4424,7 @@ class WhenToTrustANewBlock(DistributedBlockChainScene):
     def get_block(self):
         block = DistributedBlockChainScene.get_block(self)
         tuples = [
-            ("Prev hash", UP, BLUE), 
+            ("Prev hash", UP, BLUE),
             ("Proof of work", DOWN, GREEN),
         ]
         for word, vect, color in tuples:
@@ -4591,7 +4591,7 @@ class VariableProofOfWork(WhenToTrustANewBlock):
             0.5, about_point = miner.get_right()
         )
         copies = VGroup(*[
-            target.copy() 
+            target.copy()
             for x in range(self.n_miners - 1)
         ])
         everyone = VGroup(target, *copies)
@@ -4649,7 +4649,7 @@ class CompareBlockTimes(Scene):
             TextMobject("LTC: ", "2.5 Minutes"),
         )
         examples.arrange_submobjects(
-            DOWN, 
+            DOWN,
             buff = LARGE_BUFF,
             aligned_edge = LEFT,
         )
@@ -4674,7 +4674,7 @@ class CompareBlockTimes(Scene):
         self.wait()
         self.play(*[
             LaggedStart(FadeIn, VGroup(*group[1:]))
-            for group in examples, logos
+            for group in (examples, logos)
         ])
         self.wait(2)
 
@@ -4712,7 +4712,7 @@ class BlockRewards(Scene):
             TextMobject("Feb 2020$^*$ - Sep 2023$^*$:", "6.25", "BTC"),
         )
         rewards.arrange_submobjects(
-            DOWN, 
+            DOWN,
             buff = MED_LARGE_BUFF,
             aligned_edge = LEFT
         )
@@ -4740,8 +4740,8 @@ class ShowFirstFewBlocks(ExternallyAnimatedScene):
 class ShowGeometricSum(Scene):
     def construct(self):
         equation = TexMobject(
-            "210{,}000", "(", 
-            "50", "+", "25", "+", "12.5", "+", 
+            "210{,}000", "(",
+            "50", "+", "25", "+", "12.5", "+",
             "6.25", "+\\cdots", ")", "=", "21{,}000{,}000"
         )
         numbers = ["50", "25", "12.5", "6.25"]
@@ -4849,7 +4849,7 @@ class ShowBitcoinBlockSize(LedgerScene):
         block.add(payments_rect, payments)
 
         tuples = [
-            ("Prev hash", UP, BLUE_C), 
+            ("Prev hash", UP, BLUE_C),
             ("Proof of work", DOWN, GREEN),
         ]
         for word, vect, color in tuples:
@@ -4863,7 +4863,7 @@ class ShowBitcoinBlockSize(LedgerScene):
             block.add(mob, rect)
 
         title = VGroup(
-            BitcoinLogo(height = 0.75), 
+            BitcoinLogo(height = 0.75),
             TextMobject("Block").scale(1.5)
         )
         title.arrange_submobjects(RIGHT, SMALL_BUFF)
@@ -4871,7 +4871,7 @@ class ShowBitcoinBlockSize(LedgerScene):
 
         brace = Brace(payments_rect, RIGHT)
         limit = brace.get_text(
-            "Limited to\\\\", 
+            "Limited to\\\\",
             "$\\sim 2{,}400$", "transactions"
         )
         limit.set_color_by_tex("2{,}400", RED)
@@ -4915,7 +4915,7 @@ class CurrentAverageFees(Scene):
     def construct(self):
         fees = TextMobject(
             "Current average fees: ",
-            "$\\sim 0.0013$ BTC", 
+            "$\\sim 0.0013$ BTC",
             "$\\approx$", "\\$3.39"
         )
         fees.set_color_by_tex("BTC", YELLOW)
@@ -5017,7 +5017,7 @@ class ShowManyExchanges(Scene):
                 path_arc = np.pi,
                 buff = MED_LARGE_BUFF
             )
-            for p1, p2 in (LEFT, RIGHT), (RIGHT, LEFT)
+            for p1, p2 in ((LEFT, RIGHT), (RIGHT, LEFT))
         ]).set_color(WHITE)
         exchanges = VGroup(*[
             VGroup(*[
@@ -5243,30 +5243,3 @@ class Thumbnail(DistributedBlockChainScene):
         block_chain.scale_to_fit_width(FRAME_WIDTH-1)
         block_chain.set_stroke(width = 12)
         self.add(block_chain)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/domino_play.py
+++ b/old_projects/domino_play.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 
@@ -804,7 +805,7 @@ class ShowAllSteadyStateVelocities(SimpleVelocityGraph):
             )
             self.add(dot)
             self.add(label)
-            print index_str, self.velocities[-1], self.friction
+            print(index_str, self.velocities[-1], self.friction)
 
 class Test(Scene):
     def construct(self):
@@ -871,7 +872,7 @@ class Test(Scene):
             run_time = 3,
         ))
 
-        print arc1.angle, arc2.angle
+        print(arc1.angle, arc2.angle)
 
 
 

--- a/old_projects/efvgt.py
+++ b/old_projects/efvgt.py
@@ -13,7 +13,7 @@ def normalize(vect):
 def get_composite_rotation_angle_and_axis(angles, axes):
     angle1, axis1 = 0, OUT
     for angle2, axis2 in zip(angles, axes):
-        ## Figure out what (angle3, axis3) is the same 
+        ## Figure out what (angle3, axis3) is the same
         ## as first applying (angle1, axis1), then (angle2, axis2)
         axis2 = normalize(axis2)
         dot = np.dot(axis2, axis1)
@@ -47,7 +47,7 @@ class ConfettiSpiril(Animation):
         mobject.next_to(self.x_start*RIGHT + FRAME_Y_RADIUS*UP, UP)
         self.total_vert_shift = \
             FRAME_HEIGHT + mobject.get_height() + 2*MED_SMALL_BUFF
-        
+
         Animation.__init__(self, mobject, **kwargs)
 
     def update_submobject(self, submobject, starting_submobject, alpha):
@@ -149,7 +149,7 @@ class Anniversary(TeacherStudentsScene):
                     rate_func = None
                 ),
                 DrawBorderThenFill(
-                    first_video, 
+                    first_video,
                     run_time = 10,
                     rate_func = squish_rate_func(smooth, 0.5, 0.7)
                 )
@@ -221,7 +221,7 @@ class JustGiveMeAQuickExplanation(TeacherStudentsScene):
         )
         self.play(*it.chain(*[
             [
-                pi.change_mode, "hesitant", 
+                pi.change_mode, "hesitant",
                 pi.look_at, self.get_students()[1].eyes
             ]
             for pi in self.get_students()[::2]
@@ -256,12 +256,12 @@ class QuickExplanation(ComplexTransformationScene):
         )
         equation[0].set_color(self.velocity_color)
         equation[-1].set_color(self.position_color)
-        equation.add_background_rectangle()        
+        equation.add_background_rectangle()
         brace = Brace(equation, UP)
         equation.add(brace)
         brace_text = TextMobject(
-            "Velocity vector", "is a", 
-            "$90^\\circ$ \\\\ rotation", 
+            "Velocity vector", "is a",
+            "$90^\\circ$ \\\\ rotation",
             "of", "position vector"
         )
         brace_text[0].set_color(self.velocity_color)
@@ -293,7 +293,7 @@ class QuickExplanation(ComplexTransformationScene):
         s_vector = Arrow(
             ORIGIN, right,
             tip_length = 0.2,
-            buff = 0,            
+            buff = 0,
             color = self.position_color,
         )
 
@@ -321,7 +321,7 @@ class QuickExplanation(ComplexTransformationScene):
         rotation = Rotating(self.vectors, about_point = ORIGIN, **kwargs)
         self.play(
             ShowCreation(circle, **kwargs),
-            rotation            
+            rotation
         )
         self.play(rotation)
         self.play(rotation)
@@ -503,10 +503,10 @@ class SymmetriesOfSquare(ThreeDScene):
     ##########
 
     def rotate_square(
-        self, 
-        angle = np.pi/2, 
-        axis = OUT, 
-        square = None, 
+        self,
+        angle = np.pi/2,
+        axis = OUT,
+        square = None,
         show_axis = False,
         added_anims = None,
         **kwargs
@@ -516,9 +516,9 @@ class SymmetriesOfSquare(ThreeDScene):
             square = self.square
         added_anims = added_anims or []
         rotation = Rotate(
-            square, 
-            angle = angle, 
-            axis = axis, 
+            square,
+            angle = angle,
+            axis = axis,
             about_point = square.get_center(),
             **kwargs
         )
@@ -541,7 +541,7 @@ class SymmetriesOfSquare(ThreeDScene):
 
     def flip_square(self, axis = UP, **kwargs):
         self.rotate_square(
-            angle = np.pi, 
+            angle = np.pi,
             axis = axis,
             show_axis = True,
             **kwargs
@@ -608,7 +608,7 @@ class CircleSymmetries(Scene):
         "circle_radius" : 2,
     }
     def construct(self):
-        self.add_circle_and_title()        
+        self.add_circle_and_title()
         self.show_range_of_angles()
         self.associate_rotations_with_points()
 
@@ -621,7 +621,7 @@ class CircleSymmetries(Scene):
         self.play(Write(title), ShowCreation(circle, run_time = 2))
         self.wait()
         angles = [
-            np.pi/2, -np.pi/3, 5*np.pi/6, 
+            np.pi/2, -np.pi/3, 5*np.pi/6,
             3*np.pi/2 + 0.1
         ]
         angles.append(-sum(angles))
@@ -692,7 +692,7 @@ class CircleSymmetries(Scene):
                 Rotate(self.circle, angle, run_time = 2),
                 Animation(dot)
             )
-            self.wait()            
+            self.wait()
             self.play(
                 Rotate(self.circle, -angle, run_time = 2),
                 FadeOut(dot),
@@ -714,7 +714,7 @@ class CircleSymmetries(Scene):
 
     def add_radial_line(self):
         radius = Line(
-            self.circle.get_center(), 
+            self.circle.get_center(),
             self.circle.point_from_proportion(0)
         )
         static_radius = radius.copy().set_color(GREY)
@@ -808,7 +808,7 @@ class AddSquareSymmetries(SymmetriesOfSquare):
 
         equation_square = Square(**self.square_config)
         equation = VGroup(
-            equation_square, TexMobject("+"), 
+            equation_square, TexMobject("+"),
             equation_square.copy(), TexMobject("="),
             equation_square.copy(),
         )
@@ -932,7 +932,7 @@ class AddCircleSymmetries(CircleSymmetries):
         for term, arc in zip(equation[::2], arcs):
             self.play(*[
                 ApplyMethod(mob.scale_in_place, 1.2, rate_func = there_and_back)
-                for mob in term, arc
+                for mob in (term, arc)
             ])
             self.wait()
 
@@ -954,7 +954,7 @@ class AddCubeSymmetries(GroupOfCubeSymmetries):
         cube = self.get_cube()
 
         equation = cube1, plus, cube2, equals, cube3 = VGroup(
-            cube, TexMobject("+"), 
+            cube, TexMobject("+"),
             cube.copy(), TexMobject("="),
             cube.copy()
         )
@@ -1001,7 +1001,7 @@ class AddCubeSymmetries(GroupOfCubeSymmetries):
                     start_angle = np.pi/12+a, angle = 5*np.pi/6,
                     color = YELLOW
                 ).add_tip()
-                for a in 0, np.pi
+                for a in (0, np.pi)
             ])
             arrows.scale_to_fit_height(1.5*cube.get_height())
             z_to_axis = z_to_vector(axis)
@@ -1072,7 +1072,7 @@ class DihedralGroupStructure(SymmetriesOfSquare):
         # self.add_labels_and_dots(prototype_square)
         prototype_square.scale(0.7)
         expression = s1, plus, s2, equals, s3 = VGroup(
-            prototype_square, TexMobject("+").scale(2), 
+            prototype_square, TexMobject("+").scale(2),
             prototype_square.copy(), TexMobject("=").scale(2),
             prototype_square.copy()
         )
@@ -1269,7 +1269,7 @@ class AdditiveGroupOfReals(Scene):
 
     def show_example_slides(self, *nums):
         for num in nums:
-            zero_point = self.number_line.number_to_point(0)            
+            zero_point = self.number_line.number_to_point(0)
             num_point = self.number_line.number_to_point(num)
             arrow = Arrow(zero_point, num_point, buff = 0)
             arrow.set_color(ADDER_COLOR)
@@ -1372,7 +1372,7 @@ class AdditiveGroupOfReals(Scene):
                     Write(num_mob, run_time = 1)
                 )
                 self.play(
-                    self.number_line.shift, 
+                    self.number_line.shift,
                     num_point - zero_point
                 )
                 self.wait()
@@ -1396,7 +1396,7 @@ class AdditiveGroupOfReals(Scene):
             )
             self.wait()
             self.play(
-                self.number_line.shift, 
+                self.number_line.shift,
                 num_point - zero_point,
                 run_time = 2
             )
@@ -1407,7 +1407,7 @@ class AdditiveGroupOfReals(Scene):
             )
 
     def get_adder_mobs(self, num):
-        zero_point = self.number_line.number_to_point(0)            
+        zero_point = self.number_line.number_to_point(0)
         num_point = self.number_line.number_to_point(num)
         arrow = Arrow(zero_point, num_point, buff = 0)
         arrow.set_color(ADDER_COLOR)
@@ -1560,7 +1560,7 @@ class AdditiveGroupOfComplexNumbers(ComplexTransformationScene):
         point2 = self.z_to_point(z2)
         dot2 = Dot(point2, color = TEAL)
         arrow2 = Vector(
-            point2, 
+            point2,
             buff = dot2.radius,
             color = dot2.get_color()
         )
@@ -1719,7 +1719,7 @@ class SchizophrenicNumbers(Scene):
         )
         for number in numbers:
             number.set_color(ADDER_COLOR)
-            number.scale(1.5)            
+            number.scale(1.5)
             if isinstance(number, PiCreature):
                 continue
             number.eyes = Eyes(number[0], height = 0.1)
@@ -1739,7 +1739,7 @@ class SchizophrenicNumbers(Scene):
             number.target.eyes.restore()
         self.play(*[
             MoveToTarget(
-                number, 
+                number,
                 rate_func = squish_rate_func(
                     smooth, alpha, alpha+0.5
                 ),
@@ -1800,7 +1800,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
         )[0]
         self.one.add_background_rectangle()
         self.one.background_rectangle.scale_in_place(1.3)
-        self.number_line.save_state()        
+        self.number_line.save_state()
 
     def introduce_stretch_and_squish(self):
         for num in [3, 0.25]:
@@ -1843,11 +1843,11 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
                 self.number_line.number_to_point(num),
                 self.shadow_line.number_to_point(num)
             )
-            for num in 3, 0.5
+            for num in (3, 0.5)
         ]
         three_mob = filter(
             lambda m : m.get_tex_string() == "3",
-            self.shadow_line.numbers    
+            self.shadow_line.numbers
         )[0]
         half_point = self.shadow_line.number_to_point(0.5)
         half_arrow = Arrow(
@@ -1858,7 +1858,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
         half_label.scale(0.7)
         half_label.set_color(MULTIPLIER_COLOR)
         half_label.next_to(half_arrow.get_start(), LEFT, buff = SMALL_BUFF)
-        
+
         self.play(
             ShowCreation(arrow),
             DrawBorderThenFill(dot),
@@ -1903,7 +1903,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
         self.play(
             self.number_line.restore,
             *map(FadeOut, [
-                half_label, half_arrow, 
+                half_label, half_arrow,
                 half_line, dot_copy
             ])
         )
@@ -1927,7 +1927,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
                 self.number_line.number_to_point(num),
                 self.shadow_line.number_to_point(num)
             )
-            for num in 0.33, 1
+            for num in (0.33, 1)
         ]
 
         self.play(
@@ -1965,7 +1965,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
     def compose_actions(self, num1, num2):
         words = VGroup(*[
             TextMobject("(%s by %s)"%(word, str(num)))
-            for num in num1, num2, num1*num2
+            for num in (num1, num2, num1*num2)
             for word in ["Stretch" if num > 1 else "Squish"]
         ])
         words.submobjects.insert(2, TexMobject("="))
@@ -1980,7 +1980,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
 
         for num, word in zip([num1, num2], top_words):
             self.stretch(
-                num, 
+                num,
                 added_anims = [FadeIn(word)],
                 run_time = 3
             )
@@ -2049,7 +2049,7 @@ class MultiplicativeGroupOfComplexNumbers(AdditiveGroupOfComplexNumbers):
     def add_plane(self):
         AdditiveGroupOfComplexNumbers.add_plane(self)
         one_dot = Dot(
-            self.z_to_point(1), 
+            self.z_to_point(1),
             color = MULTIPLIER_COLOR,
             radius = self.dot_radius,
         )
@@ -2060,7 +2060,7 @@ class MultiplicativeGroupOfComplexNumbers(AdditiveGroupOfComplexNumbers):
 
     def add_title(self):
         title = TextMobject(
-            "Multiplicative", "group of", 
+            "Multiplicative", "group of",
             "complex numbers"
         )
         title.to_edge(UP)
@@ -2074,7 +2074,7 @@ class MultiplicativeGroupOfComplexNumbers(AdditiveGroupOfComplexNumbers):
 
     def fix_zero_and_move_one(self):
         zero_arrow = Arrow(
-            UP+1.25*LEFT, ORIGIN, 
+            UP+1.25*LEFT, ORIGIN,
             buff = 2*self.dot_radius
         )
         zero_arrow.set_color(ADDER_COLOR)
@@ -2085,7 +2085,7 @@ class MultiplicativeGroupOfComplexNumbers(AdditiveGroupOfComplexNumbers):
 
         one_point = self.z_to_point(1)
         one_arrow = Arrow(
-            one_point+UP+1.25*RIGHT, one_point, 
+            one_point+UP+1.25*RIGHT, one_point,
             buff = 2*self.dot_radius,
             color = MULTIPLIER_COLOR,
         )
@@ -2174,7 +2174,7 @@ class MultiplicativeGroupOfComplexNumbers(AdditiveGroupOfComplexNumbers):
             self.turn_arrow, half_turn_arc,
             path_arc = np.pi/2
         ))
-        self.wait()        
+        self.wait()
         self.play(Indicate(neg_one_label, run_time = 2))
         self.wait()
         self.foreground_mobjects.remove(self.turn_arrow)
@@ -2226,7 +2226,7 @@ class MultiplicativeGroupOfComplexNumbers(AdditiveGroupOfComplexNumbers):
         angle_label = TexMobject("30^\\circ")
         angle_label.scale(0.7)
         angle_label.next_to(
-            arc, RIGHT, 
+            arc, RIGHT,
             buff = SMALL_BUFF, aligned_edge = DOWN
         )
         angle_label.set_color(MULTIPLIER_COLOR)
@@ -2258,7 +2258,7 @@ class MultiplicativeGroupOfComplexNumbers(AdditiveGroupOfComplexNumbers):
         self.wait(2)
         to_remove = [
             label, dot,
-            brace, brace_text, 
+            brace, brace_text,
             arc, angle_label,
         ]
         for mob in to_remove:
@@ -2372,7 +2372,7 @@ class ExponentsAsRepeatedMultiplication(TeacherStudentsScene):
             three_twos.brace_anim,
         )
         self.play(FadeIn(
-            five_twos, 
+            five_twos,
             run_time = 3,
             submobject_mode = "lagged_start"
         ))
@@ -2459,11 +2459,11 @@ class ExponentsAsRepeatedMultiplication(TeacherStudentsScene):
         self.wait()
 
         half_expression = TexMobject(
-            "\\big(", "2^{1/2}", "\\big)", 
+            "\\big(", "2^{1/2}", "\\big)",
             "\\big(2^{1/2}\\big) = 2^{1}"
         )
         neg_one_expression = TexMobject(
-            "\\big(", "2^{-1}", "\\big)", 
+            "\\big(", "2^{-1}", "\\big)",
             "\\big( 2^{1} \\big) = 2^{0}"
         )
         expressions = VGroup(half_expression, neg_one_expression)
@@ -2475,8 +2475,8 @@ class ExponentsAsRepeatedMultiplication(TeacherStudentsScene):
 
         self.play(
             Transform(half_power, half_expression[1]),
-            Write(half_expression),            
-            RemovePiCreatureBubble(self.get_teacher()),            
+            Write(half_expression),
+            RemovePiCreatureBubble(self.get_teacher()),
         )
         self.wait()
         self.play(
@@ -2515,7 +2515,7 @@ class ExponentsAsRepeatedMultiplication(TeacherStudentsScene):
         )
         group_theory_words.shift_onto_screen()
         self.play(
-            Write(group_theory_words), 
+            Write(group_theory_words),
             ShowCreation(arrow)
         )
         self.wait(2)
@@ -2601,7 +2601,7 @@ class ExponentsAsHomomorphism(Scene):
 
         self.play(
             multipliers.space_out_submobjects, 4,
-            multipliers.next_to, self.bottom_line_center, 
+            multipliers.next_to, self.bottom_line_center,
                 UP, MED_LARGE_BUFF,
             multipliers.set_color, YELLOW,
             FadeOut(self.rhs_brace_group),
@@ -2726,8 +2726,8 @@ class ExponentsAsHomomorphism(Scene):
             self.play(*anims)
             self.wait()
         self.play(*[
-            line.restore 
-            for line in self.top_line, self.bottom_line
+            line.restore
+            for line in (self.top_line, self.bottom_line)
         ])
 
     def get_stretch_anim(self, bottom_line, x):
@@ -2752,7 +2752,7 @@ class DihedralCubeHomomorphism(GroupOfCubeSymmetries, SymmetriesOfSquare):
         angle_axis_pairs *= 3
 
         title = TextMobject(
-            "``", "Homo", "morph", "ism", "''", 
+            "``", "Homo", "morph", "ism", "''",
             arg_separator = ""
         )
         homo_brace = Brace(title[1], UP, buff = SMALL_BUFF)
@@ -2760,7 +2760,7 @@ class DihedralCubeHomomorphism(GroupOfCubeSymmetries, SymmetriesOfSquare):
         morph_brace = Brace(title[2], UP, buff = SMALL_BUFF)
         morph_def = morph_brace.get_text("shape", buff = SMALL_BUFF)
         def_group = VGroup(
-            homo_brace, homo_def, 
+            homo_brace, homo_def,
             morph_brace, morph_def
         )
         VGroup(title, def_group).to_edge(UP)
@@ -2791,11 +2791,11 @@ class DihedralCubeHomomorphism(GroupOfCubeSymmetries, SymmetriesOfSquare):
             posed_axis = np.dot(raw_axis, pose_matrix.T)
             self.play(*[
                 Rotate(
-                    mob, angle = angle, axis = axis, 
+                    mob, angle = angle, axis = axis,
                     in_place = True,
                     run_time = abs(angle/(np.pi/2))
                 )
-                for mob, axis in (square, raw_axis), (cube, posed_axis)
+                for mob, axis in ((square, raw_axis), (cube, posed_axis))
             ])
             self.wait()
             if i == 2:
@@ -2863,7 +2863,7 @@ class ComplexExponentiationAbstract():
         arrow = Arrow(LEFT, RIGHT, color = WHITE)
         arrow.move_to(-FRAME_X_RADIUS*self.vect/2 + 2*UP)
         arrow.set_stroke(width = 6),
-        func_mob = TexMobject("2^x")    
+        func_mob = TexMobject("2^x")
         func_mob.next_to(arrow, UP, aligned_edge = LEFT)
         func_mob.add_background_rectangle()
 
@@ -2924,7 +2924,7 @@ class ComplexExponentiationAbstract():
         self.wait(2)
 
 class ComplexExponentiationAdderHalf(
-    ComplexExponentiationAbstract, 
+    ComplexExponentiationAbstract,
     AdditiveGroupOfComplexNumbers
     ):
     CONFIG = {
@@ -3001,7 +3001,7 @@ class ComplexExponentiationAdderHalf(
             GrowFromCenter(brace),
             Write(brace_text, run_time = 1)
         )
-        self.add_foreground_mobjects(brace, brace_text)        
+        self.add_foreground_mobjects(brace, brace_text)
         self.wait()
         self.apply_action(complex(0, 1))
         self.wait(7)##Line up with MultiplierHalf
@@ -3049,7 +3049,7 @@ class ComplexExponentiationAdderHalf(
             self.wait(4) ##Line up with multiplier half
 
 class ComplexExponentiationMultiplierHalf(
-    ComplexExponentiationAbstract, 
+    ComplexExponentiationAbstract,
     MultiplicativeGroupOfComplexNumbers
     ):
     CONFIG = {
@@ -3297,7 +3297,7 @@ class ECLPromo(PiCreatureScene):
         )
         self.wait(3)
         self.play(FadeIn(
-            logo_part1, run_time = 3, 
+            logo_part1, run_time = 3,
             submobject_mode = "lagged_start"
         ))
         logo_part2.save_state()
@@ -3306,7 +3306,7 @@ class ECLPromo(PiCreatureScene):
         logo_part2.shift(MED_SMALL_BUFF*RIGHT)
         self.play(
             self.pi_creature.change_mode, "raise_right_hand",
-        )        
+        )
         self.play(DrawBorderThenFill(logo_part2))
         self.play(
             logo_part2.scale_in_place, 0.5,
@@ -3334,7 +3334,7 @@ class ExpTransformation(ComplexTransformationScene):
         self.prepare_for_transformation(self.plane)
         final_plane = self.plane.copy().apply_complex_function(np.exp)
         cylinder = self.plane.copy().apply_function(
-            lambda (x, y, z) : np.array([x, np.sin(y), -np.cos(y)])
+            lambda x_y_z : np.array([x_y_z[0], np.sin(x_y_z[1]), -np.cos(x_y_z[1])])
         )
         title = TexMobject("x \\to e^x")
         title.add_background_rectangle()
@@ -3344,13 +3344,13 @@ class ExpTransformation(ComplexTransformationScene):
         self.add_foreground_mobjects(title)
 
         self.play(Transform(
-            self.plane, cylinder, 
+            self.plane, cylinder,
             run_time = 3,
             path_arc_axis = RIGHT,
             path_arc = np.pi,
         ))
         self.play(Rotate(
-            self.plane, -np.pi/3, UP, 
+            self.plane, -np.pi/3, UP,
             run_time = 5
         ))
         self.play(Transform(self.plane, final_plane, run_time = 3))
@@ -3372,37 +3372,3 @@ class Thumbnail(Scene):
         groups.to_edge(DOWN)
         via.move_to(VGroup(formula, groups))
         self.add(via, groups)
-
-
-
-      
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/chapter1.py
+++ b/old_projects/eoc/chapter1.py
@@ -52,7 +52,7 @@ class CircleScene(PiCreatureScene):
 
         self.play(
             Rotate(
-                self.radius_line, 2*np.pi-0.001, 
+                self.radius_line, 2*np.pi-0.001,
                 about_point = self.circle.get_center(),
             ),
             ShowCreation(self.circle),
@@ -95,7 +95,7 @@ class CircleScene(PiCreatureScene):
         outer_ring = self.get_outer_ring()
 
         self.play(
-            FadeIn(outer_ring),            
+            FadeIn(outer_ring),
             ShowCreation(nudge_line),
             ShowCreation(nudge_arrow),
             Write(nudge_label),
@@ -116,7 +116,7 @@ class CircleScene(PiCreatureScene):
         ring.set_stroke(width = 0)
         ring.set_fill(color)
         ring.move_to(self.circle)
-        ring.R = radius 
+        ring.R = radius
         ring.dR = dR
         return ring
 
@@ -196,8 +196,8 @@ class Chapter1OpeningQuote(OpeningQuote):
     CONFIG = {
         "quote" : [
             """The art of doing mathematics is finding
-            that """, "special case", 
-            """that contains all the 
+            that """, "special case",
+            """that contains all the
             germs of generality."""
         ],
         "quote_arg_separator" : " ",
@@ -281,11 +281,11 @@ class Introduction(TeacherStudentsScene):
         rules = list(it.starmap(TexMobject, [
             ("{d(", "x", "^2)", "\\over \\,", "dx}", "=", "2", "x"),
             (
-                "d(", "f", "g", ")", "=", 
+                "d(", "f", "g", ")", "=",
                 "f", "dg", "+", "g", "df",
             ),
             (
-                "F(x)", "=", "\\int_0^x", 
+                "F(x)", "=", "\\int_0^x",
                 "\\frac{dF}{dg}(t)\\,", "dt"
             ),
             (
@@ -385,7 +385,7 @@ class PreviewFrame(Scene):
 
         colors = iter(color_gradient([BLUE, YELLOW], 3))
         titles = [
-            TextMobject("Chapter %d:"%d, s).to_edge(UP).set_color(colors.next())
+            TextMobject("Chapter %d:"%d, s).to_edge(UP).set_color(next(colors))
             for d, s in [
                 (3, "Derivative formulas through geometry"),
                 (4, "Chain rule, product rule, etc."),
@@ -425,7 +425,7 @@ class ProductRuleDiagram(Scene):
             **rect_kwargs
         )
         corner_rect = Rectangle(
-            height = dg, 
+            height = dg,
             width = df,
             **rect_kwargs
         )
@@ -483,7 +483,7 @@ class ProductRuleDiagram(Scene):
         self.play(MoveToTarget(fg_group))
         self.play(*[
             mob.restore
-            for mob in df_brace, df_label, dg_brace, dg_label
+            for mob in (df_brace, df_label, dg_brace, dg_label)
         ] + [
             ReplacementTransform(d_rect.line, d_rect)
             for d_rect in d_rects
@@ -503,7 +503,7 @@ class ProductRuleDiagram(Scene):
         self.wait()
 
         deriv = TexMobject(
-            "d(", "fg", ")", "=", 
+            "d(", "fg", ")", "=",
             "f", "\\cdot", "dg", "+", "g", "\\cdot", "df"
         )
         deriv.to_edge(UP)
@@ -521,11 +521,11 @@ class ProductRuleDiagram(Scene):
                 (g_label, "g"),
                 (df_label, "df"),
             ]
-            for alpha in [alpha_iter.next()]
+            for alpha in [next(alpha_iter)]
         ]+[
             Write(VGroup(*it.chain(*[
                 deriv.get_parts_by_tex(tex, substring = False)
-                for tex in "d(", ")", "=", "\\cdot", "+"
+                for tex in ("d(", ")", "=", "\\cdot", "+")
             ])))
         ], run_time = 3)
         self.wait()
@@ -694,8 +694,8 @@ class ApproximateOneRing(CircleScene, ReconfigurableScene):
 
         self.play(
             ShowCreation(
-                lines, 
-                run_time = 2, 
+                lines,
+                run_time = 2,
                 submobject_mode = "lagged_start"
             ),
             Animation(self.radius_group),
@@ -766,7 +766,7 @@ class ApproximateOneRing(CircleScene, ReconfigurableScene):
         self.wait()
         self.play(*[
             ApplyMethod(
-                r.set_fill, YELLOW, 
+                r.set_fill, YELLOW,
                 rate_func = squish_rate_func(there_and_back, alpha, alpha+0.15),
                 run_time = 3
             )
@@ -789,7 +789,7 @@ class ApproximateOneRing(CircleScene, ReconfigurableScene):
         rectangle_ish = TextMobject("Rectangle-ish")
         for text in trapezoid, rectangle_ish:
             text.next_to(
-                self.pi_creature.get_corner(UP+RIGHT), 
+                self.pi_creature.get_corner(UP+RIGHT),
                 DOWN+RIGHT, buff = MED_LARGE_BUFF
             )
 
@@ -820,7 +820,7 @@ class ApproximateOneRing(CircleScene, ReconfigurableScene):
                 self.unwrapped_ring, vect, buff = SMALL_BUFF,
                 min_num_quads = 2,
             )
-            for vect in UP, LEFT
+            for vect in (UP, LEFT)
         ]
         top_brace.scale_in_place(self.ring.R/(self.ring.R+self.dR))
         side_brace.set_stroke(WHITE, 0.5)
@@ -847,7 +847,7 @@ class ApproximateOneRing(CircleScene, ReconfigurableScene):
 
         approx = TexMobject("\\approx")
         approx.next_to(
-            self.area_q.get_part_by_tex("Area"), 
+            self.area_q.get_part_by_tex("Area"),
             RIGHT,
             align_using_submobjects = True,
         )
@@ -899,7 +899,7 @@ class ApproximateOneRing(CircleScene, ReconfigurableScene):
             dr_label.restore
         )
         self.show_alternate_width(
-            40, 
+            40,
             transformation_kwargs = {"run_time" : 4},
             return_to_original_configuration = False,
         )
@@ -929,7 +929,7 @@ class MoveForwardWithApproximation(TeacherStudentsScene):
         self.change_student_modes("hesitant", "erm", "sassy")
         self.wait()
         words = TextMobject(
-            "It gets better", 
+            "It gets better",
             "\\\\ for smaller ",
             "$dr$"
         )
@@ -984,7 +984,7 @@ class GraphRectangles(CircleScene, GraphScene):
         rings.set_stroke(BLACK, 1)
         ring_sum, draw_ring_sum_anims = self.get_ring_sum(rings)
         area_label = TexMobject(
-            "\\text{Area}", "\\approx", 
+            "\\text{Area}", "\\approx",
             "2\\pi", "r", "\\,dr"
         )
         area_label.set_color_by_tex("r", YELLOW, substring = False)
@@ -1002,7 +1002,7 @@ class GraphRectangles(CircleScene, GraphScene):
             for ring in rings
             if ring.target.get_fill_opacity() > 0
         ])
-        
+
         self.add(rings, self.radius_group)
         self.remove(self.circle)
         self.wait()
@@ -1020,7 +1020,7 @@ class GraphRectangles(CircleScene, GraphScene):
         values_of_r = TextMobject("Values of ", "$r$")
         values_of_r.set_color_by_tex("r", YELLOW)
         values_of_r.next_to(
-            self.x_axis, UP, 
+            self.x_axis, UP,
             buff = 2*LARGE_BUFF,
             aligned_edge = LEFT
         )
@@ -1041,20 +1041,20 @@ class GraphRectangles(CircleScene, GraphScene):
                 color = YELLOW,
                 tip_length = 0.15
             )
-            for tick in r_ticks[0], r_ticks[-1]
+            for tick in (r_ticks[0], r_ticks[-1])
         ])
         first_tick = r_ticks[0].copy()
         moving_arrow = arrows[0].copy()
 
         index = 2
         dr_brace = Brace(
-            VGroup(*r_ticks[index:index+2]), 
+            VGroup(*r_ticks[index:index+2]),
             DOWN, buff = SMALL_BUFF
         )
         dr_label = TexMobject("dr")
         dr_label.next_to(
-            dr_brace, DOWN, 
-            buff = SMALL_BUFF, 
+            dr_brace, DOWN,
+            buff = SMALL_BUFF,
             aligned_edge = LEFT
         )
         dr_group = VGroup(dr_brace, dr_label)
@@ -1083,7 +1083,7 @@ class GraphRectangles(CircleScene, GraphScene):
         self.x_axis.add(r_ticks)
         self.r_ticks = r_ticks
         self.dr_group = dr_group
-        
+
     def unwrap_rings_onto_graph(self):
         rings = self.rings
         graph = self.get_graph(lambda r : 2*np.pi*r)
@@ -1094,12 +1094,12 @@ class GraphRectangles(CircleScene, GraphScene):
                 start_color = self.rings[0].get_fill_color(),
                 end_color = self.rings[-1].get_fill_color(),
             )
-            for g in graph, flat_graph
+            for g in (graph, flat_graph)
         ]
         self.graph, self.flat_rects = graph, flat_rects
 
         transformed_rings = VGroup()
-        self.ghost_rings = VGroup()        
+        self.ghost_rings = VGroup()
         for index, rect, r in zip(it.count(), rects, np.arange(0, 3, 0.1)):
             proportion = float(index)/len(rects)
             ring_index = int(len(rings)*proportion**0.6)
@@ -1115,7 +1115,7 @@ class GraphRectangles(CircleScene, GraphScene):
 
             ring.rect = rect
 
-            n_anchors = ring.get_num_anchor_points()            
+            n_anchors = ring.get_num_anchor_points()
             target = VMobject()
             target.set_points_as_corners([
                 interpolate(ORIGIN,  DOWN, a)
@@ -1152,7 +1152,7 @@ class GraphRectangles(CircleScene, GraphScene):
                 rate_func = squish_rate_func(smooth, alpha, alpha+0.25)
             )
             for ring, alpha in zip(
-                transformed_rings, 
+                transformed_rings,
                 np.linspace(0, 0.75, len(transformed_rings))
             )
         ] + foreground_animations)
@@ -1176,7 +1176,7 @@ class GraphRectangles(CircleScene, GraphScene):
         )
         self.play(
             self.dr_group.arrange_submobjects, DOWN,
-            self.dr_group.next_to, highlighted_ring, 
+            self.dr_group.next_to, highlighted_ring,
             DOWN, SMALL_BUFF
         )
         self.wait()
@@ -1201,7 +1201,7 @@ class GraphRectangles(CircleScene, GraphScene):
         ##Rescale
         self.play(*[
             ApplyMethod(
-                ring.replace, ring.rect, 
+                ring.replace, ring.rect,
                 method_kwargs = {"stretch" : True}
             )
             for ring in transformed_rings
@@ -1217,7 +1217,7 @@ class GraphRectangles(CircleScene, GraphScene):
 
     def draw_graph(self):
         graph_label = self.get_graph_label(
-            self.graph, "2\\pi r", 
+            self.graph, "2\\pi r",
             direction = UP+LEFT,
             x_val = 2.5,
             buff = SMALL_BUFF
@@ -1231,7 +1231,7 @@ class GraphRectangles(CircleScene, GraphScene):
                 rect, flat_rect,
                 run_time = 2,
                 rate_func = squish_rate_func(
-                    lambda t : 0.1*there_and_back(t), 
+                    lambda t : 0.1*there_and_back(t),
                     alpha, alpha+0.5
                 ),
                 submobject_mode = "lagged_start"
@@ -1269,7 +1269,7 @@ class GraphRectangles(CircleScene, GraphScene):
         thinner_rects_list = [
             self.get_riemann_rectangles(
                 self.graph,
-                x_min = 0, 
+                x_min = 0,
                 x_max = 3,
                 dx = 1./(10*2**n),
                 stroke_width = 1./(2**n),
@@ -1284,7 +1284,7 @@ class GraphRectangles(CircleScene, GraphScene):
         for new_rects in thinner_rects_list:
             self.play(
                 Transform(
-                    self.rects, new_rects, 
+                    self.rects, new_rects,
                     submobject_mode = "lagged_start",
                     run_time = 2
                 ),
@@ -1303,7 +1303,7 @@ class GraphRectangles(CircleScene, GraphScene):
     def compute_area_under_graph(self):
         formula, formula_with_R = formulas = [
             self.get_area_formula(R)
-            for R in "3", "R"
+            for R in ("3", "R")
         ]
         for mob in formulas:
             mob.to_corner(UP+RIGHT, buff = MED_SMALL_BUFF)
@@ -1369,7 +1369,7 @@ class GraphRectangles(CircleScene, GraphScene):
         unwrapped.stretch_to_fit_width(2)
         unwrapped.move_to(ORIGIN, DOWN)
         unwrapped.apply_function(
-            lambda p : np.dot(p, 
+            lambda p : np.dot(p,
                 np.array([[1, 0, 0], [-1, 1, 0], [0, 0, 1]])
             ),
             maintain_smoothness = False
@@ -1434,11 +1434,11 @@ class GraphRectangles(CircleScene, GraphScene):
             for ring, alpha in zip(rings, np.linspace(0, 0.2, len(rings)))
         ]
         draw_ring_sum_anims.append(FadeOut(self.radius_group))
-        
+
         ring_sum = VGroup(rings, tex_mobs)
         ring_sum.rings = VGroup(*[r.target for r in rings])
         ring_sum.tex_mobs = tex_mobs
-        
+
         return ring_sum, draw_ring_sum_anims
 
     def get_area_formula(self, R):
@@ -1446,7 +1446,7 @@ class GraphRectangles(CircleScene, GraphScene):
             "\\text{Area}", "&= \\frac{1}{2}", "b", "h",
             "\\\\ &=", "\\frac{1}{2}", "(%s)"%R, "(2\\pi \\cdot %s)"%R,
             "\\\\ &=", "\\pi ", "%s"%R, "^2"
-            
+
         )
         formula.set_color_by_tex("b", GREEN, substring = False)
         formula.set_color_by_tex("h", RED, substring = False)
@@ -1521,10 +1521,10 @@ class RecapCircleSolution(GraphRectangles, ReconfigurableScene):
         integral_condition.arrange_submobjects(DOWN)
         integral_condition.scale(0.8)
         integral_condition.to_corner(UP+RIGHT)
-        
+
         self.add(rings, self.radius_group)
         self.play(FadeIn(
-            integral_condition, 
+            integral_condition,
             submobject_mode = "lagged_start"
         ))
         self.wait()
@@ -1551,7 +1551,7 @@ class RecapCircleSolution(GraphRectangles, ReconfigurableScene):
         approximations = VGroup()
         for ring, radius in zip(visible_rings, radii):
             label = TexMobject(
-                "\\approx", "2\\pi", 
+                "\\approx", "2\\pi",
                 "(%s)"%str(radius), "(%s)"%str(self.dR)
             )
             label[2].set_color(YELLOW)
@@ -1649,7 +1649,7 @@ class RecapCircleSolution(GraphRectangles, ReconfigurableScene):
         )
         rects = self.get_riemann_rectangles(
             graph,
-            x_min = 0, 
+            x_min = 0,
             x_max = 3,
             dx = self.dR
         )
@@ -1684,7 +1684,7 @@ class RecapCircleSolution(GraphRectangles, ReconfigurableScene):
         thinner_rects_list = [
             self.get_riemann_rectangles(
                 self.graph,
-                x_min = 0, 
+                x_min = 0,
                 x_max = 3,
                 dx = 1./(10*2**n),
                 stroke_width = 1./(2**n),
@@ -1697,7 +1697,7 @@ class RecapCircleSolution(GraphRectangles, ReconfigurableScene):
         for new_rects in thinner_rects_list:
             self.play(
                 Transform(
-                    self.rects, new_rects, 
+                    self.rects, new_rects,
                     submobject_mode = "lagged_start",
                     run_time = 2
                 ),
@@ -1798,7 +1798,7 @@ class ExampleIntegralProblems(PiCreatureScene, GraphScene):
         self.play(
             MoveCar(car, end),
             FadeIn(
-                ticks, 
+                ticks,
                 submobject_mode = "one_at_a_time",
                 rate_func = None,
             ),
@@ -1828,7 +1828,7 @@ class ExampleIntegralProblems(PiCreatureScene, GraphScene):
         v_graph = self.get_derivative_graph(s_graph)
         rects = self.get_riemann_rectangles(
             v_graph,
-            x_min = 0, 
+            x_min = 0,
             x_max = self.t_max,
             dx = self.dt
         )
@@ -1850,7 +1850,7 @@ class ExampleIntegralProblems(PiCreatureScene, GraphScene):
 
         self.play(
             FadeIn(
-                pre_rects, 
+                pre_rects,
                 run_time = 2,
                 submobject_mode = "lagged_start"
             ),
@@ -1975,7 +1975,7 @@ class AreaUnderParabola(GraphScene):
     def show_graph(self):
         graph = self.get_graph(self.func)
         graph_label = self.get_graph_label(
-            graph, self.graph_label_tex, 
+            graph, self.graph_label_tex,
             direction = LEFT,
             x_val = self.graph_label_x_val,
         )
@@ -2017,7 +2017,7 @@ class AreaUnderParabola(GraphScene):
                 Transform(
                     rects, new_rects,
                     submobject_mode = "lagged_start",
-                ), 
+                ),
                 *map(Animation, foreground_mobjects)
             )
         self.wait()
@@ -2038,7 +2038,7 @@ class AreaUnderParabola(GraphScene):
                 FRAME_HEIGHT*UP, ORIGIN,
                 color = RED
             ).move_to(self.coords_to_point(x, 0), DOWN)
-            for x in 0, self.default_right_x
+            for x in (0, self.default_right_x)
         ])
 
         self.play(
@@ -2165,7 +2165,7 @@ class WhoCaresAboutArea(TeacherStudentsScene):
             self.teacher.look_at, point
         )
         self.change_student_modes(
-            *["pondering"]*3, 
+            *["pondering"]*3,
             look_at_arg = point,
             added_anims = [self.teacher.look_at, point]
 
@@ -2225,7 +2225,7 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
         self.foreground_mobjects.append(original_v_line)
         self.move_right_point_to(curr_x + self.deriv_dx)
         self.play(
-            FadeIn(shadow_rects), 
+            FadeIn(shadow_rects),
             *map(Animation, self.foreground_mobjects)
         )
 
@@ -2248,7 +2248,7 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
         dA_label.next_to(dA_rect, RIGHT, MED_LARGE_BUFF, UP)
         dA_label.set_color(GREEN)
         dA_arrow = Arrow(
-            dA_label.get_bottom()+MED_SMALL_BUFF*DOWN, 
+            dA_label.get_bottom()+MED_SMALL_BUFF*DOWN,
             dA_rect.get_center(),
             buff = 0,
             color = WHITE
@@ -2329,7 +2329,7 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
                 equation.get_part_by_tex(tex),
                 run_time = 2
             )
-            for mob, tex in (x_squared, f_tex), (dx, "dx"), (dA, "dA")
+            for mob, tex in ((x_squared, f_tex), (dx, "dx"), (dA, "dA"))
         ])
         self.play(Write(equation.get_part_by_tex("approx")))
         self.wait()
@@ -2345,7 +2345,7 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
                 deriv_equation.get_part_by_tex(tex),
                 run_time = 2,
             )
-            for tex in "dA", "approx", f_tex, "dx"
+            for tex in ("dA", "approx", f_tex, "dx")
         ] + [
             Write(deriv_equation.get_part_by_tex("over"))
         ])
@@ -2364,7 +2364,7 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
             Circle(color = color).replace(
                 mob, stretch = True
             ).scale_in_place(1.5)
-            for mob, color in (self.A_func, RED), (self.deriv_equation, GREEN)
+            for mob, color in ((self.A_func, RED), (self.deriv_equation, GREEN))
         ]
         q_marks = TexMobject("???")
         q_marks.next_to(A_circle, UP)
@@ -2420,14 +2420,14 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
             self.play(FadeOut(line_copy))
         self.wait()
 
-        self.three = three 
+        self.three = three
         self.three_plus_dx = three_plus_dx
 
     def show_dA_dx_in_detail(self):
         d = self.default_right_x
         expression = TexMobject(
-            "{A(", "%d.001"%d, ") ", "-A(", "%d"%d, ")", 
-            "\\over \\,", "0.001}", 
+            "{A(", "%d.001"%d, ") ", "-A(", "%d"%d, ")",
+            "\\over \\,", "0.001}",
             "\\approx", "%d"%d, "^2"
         )
         expression.scale(0.9)
@@ -2464,7 +2464,7 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
                 expression.get_part_by_tex("%d.001"%d).copy(),
                 expression.get_part_by_tex("0.001"),
             )
-            
+
         )
         self.wait()
         self.play(
@@ -2518,7 +2518,7 @@ class AlternateAreaUnderCurve(PlayingTowardsDADX):
         color = YELLOW
         approx = self.deriv_equation.get_part_by_tex("approx")
         dx_to_zero_words = TextMobject(
-            "Gets better \\\\ as", 
+            "Gets better \\\\ as",
             "$dx \\to 0$"
         )
         dx_to_zero_words.set_color_by_tex("dx", color)
@@ -2544,7 +2544,7 @@ class AlternateAreaUnderCurve(PlayingTowardsDADX):
         deriv_words.scale(0.9)
         deriv_words.to_edge(UP+RIGHT)
         moving_group = VGroup(
-            self.deriv_equation, 
+            self.deriv_equation,
             self.dx_to_zero_words,
             self.dx_to_zero_words_arrow,
         )
@@ -2732,8 +2732,8 @@ class EndScreen(PiCreatureScene):
 
         self.play(
             FadeIn(
-                words, 
-                run_time = 2, 
+                words,
+                run_time = 2,
                 submobject_mode = "lagged_start"
             ),
             self.pi_creature.change_mode, "hooray"
@@ -2785,23 +2785,3 @@ class Thumbnail(AlternateAreaUnderCurve):
         words.to_edge(UP)
 
         self.add(graph, rects, words)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/chapter10.py
+++ b/old_projects/eoc/chapter10.py
@@ -15,18 +15,18 @@ def taylor_approximation(func, highest_term, center_point = 0):
         for n in range(highest_term + 1)
     ]
     coefficients = [
-        d/math.factorial(n) 
+        d/math.factorial(n)
         for n, d in enumerate(derivatives)
     ]
     return lambda x : sum([
-        c*((x-center_point)**n) 
+        c*((x-center_point)**n)
         for n, c in enumerate(coefficients)
     ])
 
 class Chapter10OpeningQuote(OpeningQuote):
     CONFIG = {
         "quote" : [
-            "For me, mathematics is a collection of ", 
+            "For me, mathematics is a collection of ",
             "examples", "; a ",
             "theorem", " is a statement about a collection of ",
             "examples", " and the purpose of proving ",
@@ -46,7 +46,7 @@ class Chapter10OpeningQuote(OpeningQuote):
 class ExampleApproximation(GraphScene):
     CONFIG = {
         "function" : lambda x : np.exp(-x**2),
-        "function_tex" : "e^{-x^2}", 
+        "function_tex" : "e^{-x^2}",
         "function_color" : BLUE,
         "order_sequence" : [0, 2, 4],
         "center_point" : 0,
@@ -80,7 +80,7 @@ class ExampleApproximation(GraphScene):
         near_text.to_corner(UP + RIGHT)
         near_text.add_background_rectangle()
         equation = TexMobject(
-            self.function_tex, 
+            self.function_tex,
             "\\approx",
             *self.approximation_terms
         )
@@ -123,12 +123,12 @@ class ExampleApproximation(GraphScene):
 class ExampleApproximationWithSine(ExampleApproximation):
     CONFIG = {
         "function" : np.sin,
-        "function_tex" : "\\sin(x)", 
+        "function_tex" : "\\sin(x)",
         "order_sequence" : [1, 3, 5],
         "center_point" : 0,
         "approximation_terms" : [
-            "x", 
-            "-\\frac{1}{6}x^3", 
+            "x",
+            "-\\frac{1}{6}x^3",
             "+\\frac{1}{120}x^5",
         ],
         "approximation_color" : GREEN,
@@ -143,12 +143,12 @@ class ExampleApproximationWithSine(ExampleApproximation):
 class ExampleApproximationWithExp(ExampleApproximation):
     CONFIG = {
         "function" : np.exp,
-        "function_tex" : "e^x", 
+        "function_tex" : "e^x",
         "order_sequence" : [1, 2, 3, 4],
         "center_point" : 0,
         "approximation_terms" : [
-            "1 + x", 
-            "+\\frac{1}{2}x^2", 
+            "1 + x",
+            "+\\frac{1}{2}x^2",
             "+\\frac{1}{6}x^3",
             "+\\frac{1}{24}x^4",
         ],
@@ -254,11 +254,11 @@ class Pendulum(ReconfigurableScene):
         self.height_tex_R = height_tex_R
         self.cosine = VGroup(*[
             height_tex.get_part_by_tex(tex)
-            for tex in "cos", "theta", ")"
+            for tex in ("cos", "theta", ")")
         ])
         self.one_minus = VGroup(*[
             height_tex.get_part_by_tex(tex)
-            for tex in "\\big(1-", "\\big)"
+            for tex in ("\\big(1-", "\\big)")
         ])
 
     def get_angry_at_cosine(self):
@@ -357,7 +357,7 @@ class Pendulum(ReconfigurableScene):
         weight.move_to(line.get_end())
         result = VGroup(line, weight)
         result.rotate(
-            self.angle, 
+            self.angle,
             about_point = self.anchor_point
         )
         result.line = line
@@ -383,7 +383,7 @@ class Pendulum(ReconfigurableScene):
             Dot(angle_to_point(angle), radius = 0.005)
             for angle in angles
         ])
-            
+
         dots.set_color(color)
         dots.scale(self.radius)
         dots.rotate(-np.pi/2 + arc_angle)
@@ -392,7 +392,7 @@ class Pendulum(ReconfigurableScene):
 
     def get_v_line(self):
         return DashedLine(
-            self.anchor_point, 
+            self.anchor_point,
             self.anchor_point + self.radius*DOWN,
             color = WHITE
         )
@@ -437,7 +437,7 @@ class Pendulum(ReconfigurableScene):
         theta = TexMobject("\\theta")
         theta.set_color(YELLOW)
         theta.next_to(
-            arc.point_from_proportion(0.5), 
+            arc.point_from_proportion(0.5),
             DOWN, SMALL_BUFF
         )
         for mob in arc, theta:
@@ -476,11 +476,11 @@ class PendulumWithBetterApprox(Pendulum):
 class ExampleApproximationWithCos(ExampleApproximationWithSine):
     CONFIG = {
         "function" : np.cos,
-        "function_tex" : "\\cos(\\theta)", 
+        "function_tex" : "\\cos(\\theta)",
         "order_sequence" : [0, 2],
         "approximation_terms" : [
-            "1", 
-            "-\\frac{1}{2} \\theta ^2", 
+            "1",
+            "-\\frac{1}{2} \\theta ^2",
         ],
         "x_axis_label" : "$\\theta$",
         "y_axis_label" : "",
@@ -500,9 +500,9 @@ class ExampleApproximationWithCos(ExampleApproximationWithSine):
                     line_class = DashedLine,
                     color = YELLOW
                 )
-                for u in -1, 1
+                for u in (-1, 1)
             ])
-            for dx in 0.01, 0.7
+            for dx in (0.01, 0.7)
         ]
 
         self.play(*map(ShowCreation, v_lines), run_time = 2)
@@ -617,7 +617,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
         ]
 
         self.play(FadeIn(
-            quadratic_tex, 
+            quadratic_tex,
             run_time = 3,
             submobject_mode = "lagged_start"
         ))
@@ -657,7 +657,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
 
         v_line = self.get_vertical_line_to_graph(
             0, self.cosine_graph,
-            line_class = DashedLine, 
+            line_class = DashedLine,
             color = YELLOW
         )
 
@@ -736,7 +736,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
     def show_tangent_slope(self):
         graph_point_at_zero = self.input_to_graph_point(
             0, self.cosine_graph
-        ) 
+        )
         tangent_line = self.get_tangent_line(0, self.cosine_graph)
 
         self.play(ShowCreation(tangent_line))
@@ -804,7 +804,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
 
         self.play(FadeOut(self.free_to_change_group))
         self.play(FadeIn(
-            derivative, 
+            derivative,
             run_time = 3,
             submobject_mode = "lagged_start"
         ))
@@ -842,7 +842,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
     def point_out_negative_concavity(self):
         partial_cosine_graph = self.get_graph(
             np.cos,
-            x_min = -1, 
+            x_min = -1,
             x_max = 1,
             color = PINK
         )
@@ -892,7 +892,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
         ]
         tangent_change_anims = [
             self.get_tangent_line_change_anim(
-                line, np.pi/2, graph, 
+                line, np.pi/2, graph,
                 run_time = 6,
                 rate_func = there_and_back,
             )
@@ -921,13 +921,13 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
             )
             second_deriv[-1].set_color(self.colors[-1])
             second_deriv.next_to(
-                deriv, DOWN, 
+                deriv, DOWN,
                 buff = MED_LARGE_BUFF,
                 aligned_edge = LEFT
             )
 
         poly_group = VGroup(
-            second_derivs[0], 
+            second_derivs[0],
             derivs[0],
             self.quadratic_tex
         )
@@ -982,7 +982,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
 
     def get_quadratic_tex(self, c0, c1, c2, arg = "x"):
         tex_mob = TexMobject(
-            "P(", arg, ")", "=", 
+            "P(", arg, ")", "=",
             c0, "+", c1, arg, "+", c2, arg, "^2"
         )
         for tex, color in zip([c0, c1, c2], self.colors):
@@ -1063,7 +1063,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
         if not hasattr(self, "cosine_derivative"):
             self.get_cosine_derivative()
         second_deriv = TexMobject(
-            "{d^2(", "\\cos", ")", "\\over", "dx^2}", 
+            "{d^2(", "\\cos", ")", "\\over", "dx^2}",
             "(", "0", ")",
         )
         second_deriv.set_color_by_tex("cos", self.colors[0])
@@ -1079,7 +1079,7 @@ class ConstructQuadraticApproximation(ExampleApproximationWithCos):
         rhs.set_color_by_tex("cos", self.colors[2])
         rhs.scale(0.8)
         rhs.next_to(
-            second_deriv, RIGHT, 
+            second_deriv, RIGHT,
             align_using_submobjects = True
         )
         rhs.add_background_rectangle()
@@ -1101,12 +1101,12 @@ class ReflectOnQuadraticApproximation(TeacherStudentsScene):
                 "\\cos(", s, ")", "\\approx",
                 "1 - \\frac{1}{2}", "(", s, ")", "^2"
             ).next_to(self.get_students(), UP, 2)
-            for s in "x", "0.1",
+            for s in ("x", "0.1",)
         ]
         approx_rhs = TexMobject("=", "0.995")
         approx_rhs.next_to(approx_at_point, RIGHT)
         real_result = TexMobject(
-            "\\cos(", "0.1", ")", "=", 
+            "\\cos(", "0.1", ")", "=",
             "%.7f\\dots"%np.cos(0.1)
         )
         real_result.shift(
@@ -1259,7 +1259,7 @@ class SimilarityOfChangeBehavior(ConstructQuadraticApproximation):
         colors = [YELLOW, WHITE]
         max_x = np.pi/2
 
-        self.setup_axes()        
+        self.setup_axes()
         cosine_graph = self.get_graph(np.cos, color = self.colors[0])
         quadratic_graph = self.get_quadratic_graph()
         graphs = VGroup(cosine_graph, quadratic_graph)
@@ -1388,7 +1388,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
         third_derivative.shift(
             brace.get_bottom() + MED_SMALL_BUFF*DOWN -\
             third_derivative.get_part_by_tex("0").get_top()
-        )        
+        )
 
         self.play(Write(third_derivative[0]))
         self.play(GrowFromCenter(brace))
@@ -1442,7 +1442,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
         zeros[0].shift(0.25*SMALL_BUFF*(UP+LEFT))
 
         self.play(Transform(
-            c3s, zeros, 
+            c3s, zeros,
             run_time = 2,
             submobject_mode = "lagged_start"
         ))
@@ -1612,7 +1612,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
 
             possibly_added_anims = []
             try:
-                possibly_added_anims.append(added_anims_iter.next())
+                possibly_added_anims.append(next(added_anims_iter))
             except:
                 pass
 
@@ -1622,7 +1622,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
                     path_arc = np.pi,
                 ),
                 Write(
-                    front_num[1], 
+                    front_num[1],
                     rate_func = squish_rate_func(smooth, 0.5, 1)
                 ),
                 MoveToTarget(curr_term),
@@ -1641,7 +1641,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
         if not hasattr(self, "cosine_second_derivative"):
             self.get_cosine_second_derivative()
         third_deriv = TexMobject(
-            "{d^3(", "\\cos", ")", "\\over", "dx^3}", 
+            "{d^3(", "\\cos", ")", "\\over", "dx^3}",
             "(", "0", ")",
         )
         third_deriv.set_color_by_tex("cos", self.colors[0])
@@ -1657,7 +1657,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
         rhs.set_color_by_tex("sin", self.colors[3])
         rhs.scale(0.8)
         rhs.next_to(
-            third_deriv, RIGHT, 
+            third_deriv, RIGHT,
             align_using_submobjects = True
         )
         rhs.add_background_rectangle()
@@ -1670,7 +1670,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
         if not hasattr(self, "cosine_third_derivative"):
             self.get_cosine_third_derivative()
         fourth_deriv = TexMobject(
-            "{d^4(", "\\cos", ")", "\\over", "dx^4}", 
+            "{d^4(", "\\cos", ")", "\\over", "dx^4}",
             "(", "0", ")",
         )
         fourth_deriv.set_color_by_tex("cos", self.colors[0])
@@ -1685,7 +1685,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
         rhs.set_color_by_tex("cos", self.colors[4])
         rhs.scale(0.8)
         rhs.next_to(
-            fourth_deriv, RIGHT, 
+            fourth_deriv, RIGHT,
             align_using_submobjects = True
         )
         rhs.add_background_rectangle()
@@ -1737,7 +1737,7 @@ class FactorialTerms(CubicAndQuarticApproximations):
 
         coefficient = result[-1]
         words = TextMobject(
-            "Set", "$c_8$", 
+            "Set", "$c_8$",
             "$ = \\frac{\\text{Desired derivative value}}{8!}"
         )
         words.set_color_by_tex("c_8", YELLOW)
@@ -1771,25 +1771,25 @@ class HigherTermsDontMessUpLowerTerms(Scene):
         c4_tex = "c_4"
 
         polynomial = TexMobject(
-            "P(x) = ", 
-            c0_tex, "+", 
+            "P(x) = ",
+            c0_tex, "+",
             c2_tex, "x^2", "+",
             c4_tex, "x^4",
         )
         polynomial.shift(2*LEFT + UP)
         c0, c2, c4 = [
             polynomial.get_part_by_tex(tex)
-            for tex in c0_tex, c2_tex, c4_tex
+            for tex in (c0_tex, c2_tex, c4_tex)
         ]
         for term, color in zip([c0, c2, c4], self.colors):
             term.set_color(color)
         arrows = VGroup(*[
             Arrow(
-                c4.get_top(), c.get_top(), 
+                c4.get_top(), c.get_top(),
                 path_arc = arc,
                 color = c.get_color()
             )
-            for c, arc in (c2, 0.9*np.pi), (c0, np.pi)
+            for c, arc in ((c2, 0.9*np.pi), (c0, np.pi))
         ])
         no_affect_words = TextMobject(
             "Doesn't affect \\\\ previous terms"
@@ -1815,7 +1815,7 @@ class HigherTermsDontMessUpLowerTerms(Scene):
     def show_second_derivative(self):
         second_deriv = TexMobject(
             "{d^2 P \\over dx^2}(", "0", ")", "=",
-            "2", self.c2_tex, "+", 
+            "2", self.c2_tex, "+",
             "3 \\cdot 4", self.c4_tex, "(", "0", ")", "^2"
         )
         second_deriv.set_color_by_tex(self.c2_tex, self.colors[1])
@@ -1862,7 +1862,7 @@ class EachTermControlsOneDerivative(Scene):
             ]
         ])
         deriv_words.arrange_submobjects(
-            RIGHT, 
+            RIGHT,
             buff = LARGE_BUFF,
             aligned_edge = UP
         )
@@ -2046,7 +2046,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
         )
         outer_v_lines = VGroup(*[
             center_v_line.copy().shift(vect)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         outer_v_lines.set_color(GREEN)
         dot = Dot(color = YELLOW)
@@ -2066,7 +2066,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
         self.play(Write(output_info, run_time = 2))
 
         self.play(ReplacementTransform(
-            VGroup(center_v_line).copy(), 
+            VGroup(center_v_line).copy(),
             outer_v_lines
         ))
         self.play(ReplacementTransform(
@@ -2078,7 +2078,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
             self.play(UpdateFromAlphaFunc(
                 dot,
                 lambda d, a : d.move_to(self.input_to_graph_point(
-                    interpolate(start_x, x, a), 
+                    interpolate(start_x, x, a),
                     self.cosine_graph
                 )),
                 run_time = 2
@@ -2097,19 +2097,19 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
             VGroup(*[
                 TexMobject(tex, "(", arg, ")")
                 for tex in [
-                    "\\cos", "-\\sin", 
+                    "\\cos", "-\\sin",
                     "-\\cos", "\\sin", "\\cos"
                 ]
             ])
-            for arg in "x", "0"
+            for arg in ("x", "0")
         ]
         arrows = VGroup(*[
             Arrow(
-                UP, ORIGIN, 
+                UP, ORIGIN,
                 color = WHITE,
                 buff = 0,
                 tip_length = MED_SMALL_BUFF
-            ) 
+            )
             for d in derivs_at_x
         ])
         group = VGroup(*it.chain(*zip(
@@ -2189,7 +2189,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
                 path_arc = np.pi/2
             )
             for dv, pc, a in zip(
-                derivative_values, 
+                derivative_values,
                 polynomial.coefficients,
                 np.linspace(0, 0.6, len(derivative_values))
             )
@@ -2209,7 +2209,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
     def name_taylor_polynomial(self):
         brace = Brace(
             VGroup(
-                self.polynomial.coefficients, 
+                self.polynomial.coefficients,
                 self.polynomial.factorials
             ),
             DOWN
@@ -2219,7 +2219,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
         quartic_graph = self.get_graph(
             lambda x : 1 - (x**2)/2.0 + (x**4)/24.0,
             color = GREEN,
-            x_min = -3.2, 
+            x_min = -3.2,
             x_max = 3.2,
         )
         quartic_graph.set_color(self.colors[4])
@@ -2268,7 +2268,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
                     ("\\frac{d^4 f}{dx^4}", "(", arg, ")"),
                 ]
             ])
-            for arg in "x", "0", "a"
+            for arg in ("x", "0", "a")
         ]
         derivs_at_x.arrange_submobjects(DOWN, buff = MED_LARGE_BUFF)
         derivs_at_x.scale_to_fit_height(FRAME_HEIGHT - MED_LARGE_BUFF)
@@ -2424,7 +2424,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
         )
         self.wait()
         self.play(Transform(
-            self.derivs_at_zero, 
+            self.derivs_at_zero,
             self.derivs_at_a
         ))
         self.play(
@@ -2435,7 +2435,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
         for x in -1, np.pi/6:
             self.play(
                 UpdateFromAlphaFunc(
-                    group, get_update_function(x), 
+                    group, get_update_function(x),
                 ),
                 Animation(self.polynomial),
                 run_time = 4,
@@ -2492,11 +2492,11 @@ class ExpPolynomial(TranslationOfInformation, ExampleApproximationWithExp):
     def add_graph(self):
         graph = self.get_graph(np.exp)
         e_to_x = self.get_graph_label(graph, "e^x")
-    
+
         self.play(
             ShowCreation(graph),
             Write(
-                e_to_x, 
+                e_to_x,
                 rate_func = squish_rate_func(smooth, 0.5, 1)
             ),
             run_time = 2
@@ -2513,16 +2513,16 @@ class ExpPolynomial(TranslationOfInformation, ExampleApproximationWithExp):
                 TexMobject("e^%s"%s).set_color(c)
                 for c in self.colors
             ])
-            for s in "x", "0"
+            for s in ("x", "0")
         ]
         derivs_at_x.submobjects[0] = self.e_to_x.target
         arrows = VGroup(*[
             Arrow(
-                UP, ORIGIN, 
+                UP, ORIGIN,
                 color = WHITE,
                 buff = SMALL_BUFF,
                 tip_length = 0.2,
-            ) 
+            )
             for d in derivs_at_x
         ])
         group = VGroup(*it.chain(*zip(
@@ -2591,7 +2591,7 @@ class ExpPolynomial(TranslationOfInformation, ExampleApproximationWithExp):
                 path_arc = np.pi/2
             )
             for dv, pc in zip(
-                derivative_values, 
+                derivative_values,
                 polynomial.coefficients,
             )
         ])
@@ -2609,7 +2609,7 @@ class ShowSecondTerm(TeacherStudentsScene):
     def construct(self):
         colors = CubicAndQuarticApproximations.CONFIG["colors"]
         polynomial = TexMobject(
-            "f(a)", "+", 
+            "f(a)", "+",
             "\\frac{df}{dx}(a)", "(x - a)", "+",
             "\\frac{d^2 f}{dx^2}(a)", "(x - a)^2"
         )
@@ -2698,7 +2698,7 @@ class SecondTermIntuition(AreaIsDerivative):
                     new_t_max = target,
                     run_time = 3,
                 )
-        self.func_name = func_name
+        self.__name__ = func_name
 
     def write_derivative(self):
         deriv = TexMobject("\\frac{df_{\\text{area}}}{dx}(x)")
@@ -2826,7 +2826,7 @@ class SecondTermIntuition(AreaIsDerivative):
         tex_scale_factor = 0.7
         base_line = Line(*[
             triangle.get_corner(DOWN+vect)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         base_line.set_color(RED)
         base_label = TextMobject("Base = ", "$(x-a)$")
@@ -2835,7 +2835,7 @@ class SecondTermIntuition(AreaIsDerivative):
         base_label.shift(SMALL_BUFF*UP)
         base_term = base_label[1].copy()
         base_arrow = Arrow(
-            base_label.get_left(), 
+            base_label.get_left(),
             base_line.get_center(),
             buff = SMALL_BUFF,
             color = base_line.get_color(),
@@ -2846,7 +2846,7 @@ class SecondTermIntuition(AreaIsDerivative):
         height_labels = [
             TexMobject("\\text{Height} = ", s, "(x-a)")
             for s in [
-                "(\\text{Slope})", 
+                "(\\text{Slope})",
                 "\\frac{d^2 f_{\\text{area}}}{dx^2}(a)"
             ]
         ]
@@ -2905,7 +2905,7 @@ class SecondTermIntuition(AreaIsDerivative):
     def walk_through_taylor_terms(self):
         mini_area, mini_rect, mini_triangle = [
             mob.copy()
-            for mob in self.dark_area, self.rect, self.triangle
+            for mob in (self.dark_area, self.rect, self.triangle)
         ]
         mini_area.set_fill(BLUE_E, opacity = 1)
         mini_area.scale_to_fit_height(1)
@@ -2939,7 +2939,7 @@ class SecondTermIntuition(AreaIsDerivative):
             part.add_to_back(BackgroundRectangle(part))
 
         new_func_name = TexMobject("f_{\\text{area}}(a)")
-        new_func_name.replace(self.func_name)
+        new_func_name.replace(self.__name__)
 
         self.play(FadeIn(
             geometric_taylor,
@@ -2950,7 +2950,7 @@ class SecondTermIntuition(AreaIsDerivative):
         self.play(
             FadeIn(VGroup(*analytic_taylor[:3])),
             self.dark_area.set_fill, BLUE_E, 1,
-            Transform(self.func_name, new_func_name)
+            Transform(self.__name__, new_func_name)
         )
         self.wait()
         self.play(
@@ -2997,7 +2997,7 @@ class AskAboutInfiniteSum(TeacherStudentsScene):
         )
         randy = self.get_students()[1]
         series = TexMobject(
-            "\\cos(x)", "\\approx", 
+            "\\cos(x)", "\\approx",
             "1 - \\frac{x^2}{2!} + \\frac{x^4}{4!}",
             " - \\frac{x^6}{6!}",
             "+\\cdots"
@@ -3302,7 +3302,7 @@ class BoundedRadiusOfConvergence(CubicAndQuarticApproximations):
                 self.coords_to_point(x, 2),
                 color = WHITE
             )
-            for x in -1, 1
+            for x in (-1, 1)
         ])
 
         colors = list(self.colors) + [GREEN, MAROON_B, PINK]
@@ -3366,7 +3366,7 @@ class RadiusOfConvergenceForLnX(ExpGraphConvergence):
 
     def add_series(self):
         series = TexMobject(
-            "\\ln(x) \\rightarrow", 
+            "\\ln(x) \\rightarrow",
             "(x-1)", "-",
             "\\frac{(x-1)^2}{2}", "+",
             "\\frac{(x-1)^3}{3}", "-",
@@ -3386,7 +3386,7 @@ class RadiusOfConvergenceForLnX(ExpGraphConvergence):
             brace.remove(brace[-1])
 
         self.play(FadeIn(
-            series, 
+            series,
             run_time = 3,
             submobject_mode = "lagged_start"
         ))
@@ -3400,15 +3400,15 @@ class RadiusOfConvergenceForLnX(ExpGraphConvergence):
         v_lines = [
             DashedLine(*[
                 self.coords_to_point(x, y)
-                for y in -2, 2
+                for y in (-2, 2)
             ])
-            for x in 0, 1, 2
+            for x in (0, 1, 2)
         ]
         outer_v_lines = VGroup(*v_lines[::2])
         center_v_line = VGroup(v_lines[1])
         input_v_line = Line(*[
             self.coords_to_point(self.convergent_example, y)
-            for y in -4, 3
+            for y in (-4, 3)
         ])
         input_v_line.set_stroke(WHITE, width = 2)
 
@@ -3477,7 +3477,7 @@ class RadiusOfConvergenceForLnX(ExpGraphConvergence):
 
         self.approx_graphs = approx_graphs
         self.approx_dot = approx_dot
-        
+
     def show_diverging_point(self):
         for graph in self.approx_graphs:
             graph.dot.move_to(self.input_to_graph_point(
@@ -3535,7 +3535,7 @@ class RadiusOfConvergenceForLnX(ExpGraphConvergence):
     def write_radius_of_convergence(self):
         line = Line(*[
             self.coords_to_point(x, 0)
-            for x in 1, 2
+            for x in (1, 2)
         ])
         line.set_color(YELLOW)
         brace = Brace(line, DOWN)
@@ -3556,7 +3556,7 @@ class MoreToBeSaid(TeacherStudentsScene):
     }
     def construct(self):
         words = TextMobject(
-            "Lagrange error bounds, ", 
+            "Lagrange error bounds, ",
             "convergence tests, ",
             "$\\dots$"
         )
@@ -3564,7 +3564,7 @@ class MoreToBeSaid(TeacherStudentsScene):
         words[1].set_color(GREEN)
         words.to_edge(UP)
         fade_rect = FullScreenFadeRectangle()
-        rect = Rectangle(height = 9, width = 16)        
+        rect = Rectangle(height = 9, width = 16)
         rect.scale_to_fit_height(FRAME_Y_RADIUS)
         rect.to_corner(UP+RIGHT)
         randy = self.get_students()[1]
@@ -3658,18 +3658,3 @@ class Thumbnail(ExampleApproximationWithSine):
         title.add_background_rectangle()
         title.to_edge(UP)
         self.add(title)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/chapter2.py
+++ b/old_projects/eoc/chapter2.py
@@ -331,7 +331,7 @@ class GraphCarTrajectory(GraphScene):
     def introduce_graph(self, graph, origin):
         h_line, v_line = [
             Line(origin, origin, color = color, stroke_width = 2)
-            for color in TIME_COLOR, DISTANCE_COLOR
+            for color in (TIME_COLOR, DISTANCE_COLOR)
         ]
         def h_update(h_line, proportion = 1):
             end = graph.point_from_proportion(proportion)
@@ -931,7 +931,7 @@ class CompareTwoVerySimilarTimes(CompareTwoTimes):
                 for mob in formula
                 if mob.get_color() == Color(color)
             ])
-            for color in DISTANCE_COLOR, TIME_COLOR
+            for color in (DISTANCE_COLOR, TIME_COLOR)
         ]
         ds_brace = Brace(ds_symbols, UP)
         ds_text = ds_brace.get_text("$ds$", buff = SMALL_BUFF)
@@ -1086,7 +1086,7 @@ class DsOverDtGraphically(GraphCarTrajectory, ZoomedScene):
                 line_class = Line,
                 line_kwargs = {"color" : MAROON_B}
             )
-            for time in self.end_time, self.end_time + self.dt
+            for time in (self.end_time, self.end_time + self.dt)
         ]
 
 
@@ -1285,7 +1285,7 @@ class SecantLineToTangentLine(GraphCarTrajectory, DefineTrueDerivative):
     def get_ds_dt_group(self, dt, animate = False):
         points = [
             self.input_to_graph_point(time, self.graph)
-            for time in self.curr_time, self.curr_time+dt
+            for time in (self.curr_time, self.curr_time+dt)
         ]
         dots = map(Dot, points)
         for dot in dots:
@@ -1453,7 +1453,7 @@ class SecantLineToTangentLine(GraphCarTrajectory, DefineTrueDerivative):
             TextMobject(
                 "$dt$", "is", "not", s
             )
-            for s in "``infinitely small''", "0"
+            for s in ("``infinitely small''", "0")
         ]
         for phrase in phrases:
             phrase[0].set_color(TIME_COLOR)
@@ -1646,7 +1646,7 @@ class TCubedExample(SecantLineToTangentLine):
         self.play(Write(ds_dt_group, run_time = 2))
         self.play(
             FadeIn(lhs),
-            *[mob.restore for mob in ds, dt]
+            *[mob.restore for mob in (ds, dt)]
         )
         self.play(ShowCreation(v_lines[0]))
         self.wait()
@@ -1690,7 +1690,7 @@ class TCubedExample(SecantLineToTangentLine):
                     "dashed_segment_length" : 0.05,
                 }
             )
-            for time in self.start_time, self.start_time+self.start_dt
+            for time in (self.start_time, self.start_time+self.start_dt)
         ])
 
     def brace_for_details(self):
@@ -2315,7 +2315,7 @@ class TinyMovement(ZoomedScene):
 
         dots = VGroup(*[
             Dot(point, radius = self.distance/10)
-            for point in wheel_point, target_wheel_point
+            for point in (wheel_point, target_wheel_point)
         ])
         brace = Brace(Line(ORIGIN, RIGHT))
         distance_label = TexMobject(self.distance_label)

--- a/old_projects/eoc/chapter3.py
+++ b/old_projects/eoc/chapter3.py
@@ -10,7 +10,7 @@ class Chapter3OpeningQuote(OpeningQuote):
     CONFIG = {
         "quote" : [
             "You know, for a mathematician, he did not have \\\\ enough",
-            "imagination.", 
+            "imagination.",
             "But he has become a poet and \\\\ now he is fine.",
         ],
         "highlighted_quote_terms" : {
@@ -57,7 +57,7 @@ class ContrastAbstractAndConcrete(Scene):
             "\\v_dots"
         ]))
         functions.arrange_submobjects(
-            DOWN, 
+            DOWN,
             aligned_edge = LEFT,
             buff = LARGE_BUFF
         )
@@ -88,7 +88,7 @@ class ContrastAbstractAndConcrete(Scene):
         target_point = point + 5*RIGHT
         car.move_to(point)
         return MoveCar(
-            car, target_point, 
+            car, target_point,
             run_time = 5,
         )
 
@@ -99,7 +99,7 @@ class ContrastAbstractAndConcrete(Scene):
                 t_max = 12*np.pi,
                 num_anchor_points = 100,
             )
-            for denom in 12.0, 4.0
+            for denom in (12.0, 4.0)
         ]
         for spring in compact_spring, extended_spring:
             spring.scale(0.5)
@@ -112,7 +112,7 @@ class ContrastAbstractAndConcrete(Scene):
             )
             weight = Square(
                 side_length = 0.5,
-                stroke_width = 0, 
+                stroke_width = 0,
                 fill_color = LIGHT_GREY,
                 fill_opacity = 1,
             )
@@ -120,7 +120,7 @@ class ContrastAbstractAndConcrete(Scene):
             spring.add(weight)
 
         return Transform(
-            compact_spring, extended_spring, 
+            compact_spring, extended_spring,
             rate_func = lambda t : 1+np.sin(6*np.pi*t),
             run_time = 5
         )
@@ -253,7 +253,7 @@ class DerivativeOfXSquaredAsGraph(GraphScene, ZoomedScene, PiCreatureScene):
                 color = RED,
                 dashed_segment_length = 0.025
             )
-            for x in self.start_x, self.start_x+self.dx
+            for x in (self.start_x, self.start_x+self.dx)
         ]
 
         df_dx = TexMobject("\\frac{df}{dx} ?")
@@ -460,7 +460,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         little_braces = VGroup()
         for vect in RIGHT, DOWN:
             brace = Brace(
-                corner_square, vect, 
+                corner_square, vect,
                 buff = SMALL_BUFF,
             )
             text = brace.get_text("$dx$", buff = SMALL_BUFF)
@@ -514,7 +514,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         )
         df_equation.arrange_submobjects()
         df_equation.next_to(
-            self.function_label, DOWN, 
+            self.function_label, DOWN,
             aligned_edge = LEFT,
             buff = SMALL_BUFF
         )
@@ -522,8 +522,8 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
 
         pairs = [
             (df, self.function_label[0]),
-            (r1, right_rect), 
-            (r2, bottom_rect), 
+            (r1, right_rect),
+            (r2, bottom_rect),
             (s, corner_square),
         ]
         for mover, origin in pairs:
@@ -534,11 +534,11 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         self.play(
             *[
                 mob.restore
-                for mob in r1, r2, s
+                for mob in (r1, r2, s)
             ]+[
                 Write(symbol)
-                for symbol in equals, plus1, plus2
-            ], 
+                for symbol in (equals, plus1, plus2)
+            ],
             run_time = 2
         )
         self.change_mode("happy")
@@ -558,7 +558,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
                 *it.chain(*[
                     [m.scale_in_place, 1.2, m.set_color, RED]
                     for m in tup
-                ]), 
+                ]),
                 rate_func = there_and_back
             )
             self.wait()
@@ -586,7 +586,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         self.wait()
 
         xs = VGroup(*[
-            brace[-1] 
+            brace[-1]
             for brace in self.side_braces
         ])
         dxs = VGroup(*[
@@ -594,8 +594,8 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
             for brace in self.little_braces
         ])
         for group, tex, color in (xs, "3", self.three_color), (dxs, "0.01", self.dx_color):
-            group.save_state()            
-            group.generate_target()            
+            group.save_state()
+            group.generate_target()
             for submob in group.target:
                 number = TexMobject(tex)
                 number.set_color(color)
@@ -612,7 +612,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
             FadeOut(example_value),
             *[
                 mob.restore
-                for mob in xs, dxs, text
+                for mob in (xs, dxs, text)
             ]
         )
         self.remove(text)
@@ -622,7 +622,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         self.wait()
         self.dxs = dxs
         self.thin_rect_brace = thin_rect_brace
-        self.thin_rect_area = text        
+        self.thin_rect_area = text
 
     def examine_tiny_square(self):
         text = TexMobject("dx^2")
@@ -652,7 +652,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         self.wait(2)
         self.play(*[
             mob.restore
-            for mob in self.dxs, text
+            for mob in (self.dxs, text)
         ] + [
             self.pi_creature.change_mode, "erm"
         ])
@@ -716,7 +716,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         frac_line = TexMobject("-")
         frac_line.stretch_to_fit_width(df.get_width())
         frac_line.move_to(df)
-        dx = VGroup(*self.thin_rect_area[-2:]) 
+        dx = VGroup(*self.thin_rect_area[-2:])
         x = self.thin_rect_area[1]
 
         self.play(
@@ -734,7 +734,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         self.play(
             ApplyMethod(df.next_to, frac_line, UP, SMALL_BUFF),
             ApplyMethod(dx.next_to, frac_line, DOWN, SMALL_BUFF),
-            Write(frac_line),            
+            Write(frac_line),
             path_arc = -np.pi
         )
         self.wait()
@@ -872,7 +872,7 @@ class NudgeSideLengthOfCube(Scene):
             piece.on_cube_state = piece.copy()
         self.play(*[
             ApplyMethod(
-                piece.shift, 
+                piece.shift,
                 0.5*(piece.get_center()-cube.get_center())
             )
             for piece in dv_pieces
@@ -885,11 +885,11 @@ class NudgeSideLengthOfCube(Scene):
         self.dx_brace = dx_brace
         self.faces, self.bars, self.corner_cube = [
             VGroup(*[
-                piece 
+                piece
                 for piece in dv_pieces
                 if piece.type == target_type
             ])
-            for target_type in "face", "bar", "corner_cube"
+            for target_type in ("face", "bar", "corner_cube")
         ]
 
     def write_df_equation(self):
@@ -958,7 +958,7 @@ class NudgeSideLengthOfCube(Scene):
         self.play(*[
             ApplyMethod(mob.fade, 0.7)
             for mob in [
-                plus1, bars, plus2, corner_cube, 
+                plus1, bars, plus2, corner_cube,
                 extras_brace, ignore_text
             ]
         ])
@@ -970,8 +970,8 @@ class NudgeSideLengthOfCube(Scene):
     def write_derivative(self):
         df, equals, faces, plus1, bars, plus2, corner_cube = self.df_equation
         df = df.copy()
-        equals = equals.copy()        
-        df_equals = VGroup(df, equals)        
+        equals = equals.copy()
+        df_equals = VGroup(df, equals)
 
         derivative = self.derivative.copy()
         dx = derivative[1]
@@ -1023,7 +1023,7 @@ class NudgeSideLengthOfCube(Scene):
         self.shrink_dx("Derivative is written", restore = False)
         self.play(*[
             ApplyMethod(mob.fade, 0.7)
-            for mob in extra_stuff, inner_dx
+            for mob in (extra_stuff, inner_dx)
         ])
         self.wait(2)
 
@@ -1064,7 +1064,7 @@ class NudgeSideLengthOfCube(Scene):
         #in states dict
         self.states[state_name] = [
             mob.copy() for mob in mobjects_with_points
-        ] 
+        ]
         if not self.allow_recursion:
             return
         if restore:
@@ -1154,7 +1154,7 @@ class NudgeSideLengthOfCube(Scene):
         color_kwargs = {
             "fill_color" : YELLOW,
             "fill_opacity" : 0.4,
-            "stroke_color" : WHITE,            
+            "stroke_color" : WHITE,
             "stroke_width" : 0.1,
         }
         front = Rectangle(
@@ -1166,14 +1166,14 @@ class NudgeSideLengthOfCube(Scene):
         for vect in LEFT, RIGHT, UP, DOWN:
             if vect is LEFT or vect is RIGHT:
                 side = Rectangle(
-                    height = height, 
-                    width = depth, 
+                    height = height,
+                    width = depth,
                     **color_kwargs
                 )
             else:
                 side = Rectangle(
                     height = depth,
-                    width = width, 
+                    width = width,
                     **color_kwargs
                 )
             side.next_to(front, vect, buff = 0)
@@ -1236,13 +1236,13 @@ class GraphOfXCubed(GraphScene):
         deriv_label = self.get_graph_label(
             deriv_graph,
             "\\frac{df}{dx}(x) = 3x^2",
-            x_val = -3, 
+            x_val = -3,
             direction = LEFT
         )
         deriv_label.shift(0.5*DOWN)
 
         ss_group = self.get_secant_slope_group(
-            self.deriv_x_min, graph, 
+            self.deriv_x_min, graph,
             dx = self.dx,
             dx_line_color = WHITE,
             df_line_color = WHITE,
@@ -1309,7 +1309,7 @@ class PatternForPowerRule(PiCreatureScene):
         for d1, d2 in zip(derivatives, derivatives[1:]):
             self.play(Transform(
                 d1.copy(), d2,
-                replace_mobject_with_target_in_scene = True  
+                replace_mobject_with_target_in_scene = True
             ))
         self.change_mode("thinking")
         self.wait()
@@ -1337,7 +1337,7 @@ class PatternForPowerRule(PiCreatureScene):
             "\\frac{d (x^n)}{dx} = ",
             "nx^{n-1}"
         )
-        title = TextMobject("``Power rule''")        
+        title = TextMobject("``Power rule''")
         title.next_to(power_rule, UP, MED_LARGE_BUFF)
         lines = VGroup(*[
             Line(
@@ -1401,7 +1401,7 @@ class PatternForPowerRule(PiCreatureScene):
                 FadeIn(
                     form[5],
                     rate_func = squish_rate_func(smooth, 0.5, 1)
-                )   
+                )
             )
             self.wait()
             self.play(
@@ -1471,7 +1471,7 @@ class PowerRuleAlgebra(Scene):
                 for submob, tex in product_part_tex_pairs
                 if tex == target_tex
             ])
-            for target_tex in "x", "dx"
+            for target_tex in ("x", "dx")
         ]
 
         x_to_n = TexMobject("x^n")
@@ -1599,7 +1599,7 @@ class ReactToFullExpansion(Scene):
 
 class OneOverX(PiCreatureScene, GraphScene):
     CONFIG = {
-        "unit_length" : 3.0,    
+        "unit_length" : 3.0,
         "graph_origin" : (FRAME_X_RADIUS - LARGE_BUFF)*LEFT + 2*DOWN,
         "rectangle_color_kwargs" : {
             "fill_color" : BLUE,
@@ -1746,7 +1746,7 @@ class OneOverX(PiCreatureScene, GraphScene):
         recip_brace = rect_group.recip_brace
         recip_brace.generate_target()
         recip_brace.target.next_to(
-            new_rect, RIGHT, 
+            new_rect, RIGHT,
             buff = SMALL_BUFF,
             aligned_edge = DOWN,
         )
@@ -1756,11 +1756,11 @@ class OneOverX(PiCreatureScene, GraphScene):
 
         h_lines = VGroup(*[
             DashedLine(
-                ORIGIN, (rect_copy.get_width()+LARGE_BUFF)*RIGHT, 
+                ORIGIN, (rect_copy.get_width()+LARGE_BUFF)*RIGHT,
                 color = self.df_color,
                 stroke_width = 2
             ).move_to(rect.get_corner(UP+LEFT), LEFT)
-            for rect in rect_group.rectangle, new_rect
+            for rect in (rect_group.rectangle, new_rect)
         ])
 
         v_lines = VGroup(*[
@@ -1769,7 +1769,7 @@ class OneOverX(PiCreatureScene, GraphScene):
                 color = self.dx_color,
                 stroke_width = 2
             ).move_to(rect.get_corner(DOWN+RIGHT), DOWN)
-            for rect in rect_group.rectangle, new_rect
+            for rect in (rect_group.rectangle, new_rect)
         ])
 
         dx_brace = Brace(v_lines, UP, buff = 0)
@@ -1811,7 +1811,7 @@ class OneOverX(PiCreatureScene, GraphScene):
         area_gained_label = TextMobject("Area gained")
         area_gained_label.scale(0.75)
         area_gained_label.next_to(
-            rect_copy.get_corner(DOWN+RIGHT), 
+            rect_copy.get_corner(DOWN+RIGHT),
             UP+LEFT, buff = SMALL_BUFF
         )
         area_gained_arrow = Arrow(
@@ -1820,7 +1820,7 @@ class OneOverX(PiCreatureScene, GraphScene):
             buff = 0,
             color = WHITE
         )
-        
+
         area_lost_label = TextMobject("Area lost")
         area_lost_label.scale(0.75)
         area_lost_label.next_to(rect_copy.get_left(), RIGHT)
@@ -1835,7 +1835,7 @@ class OneOverX(PiCreatureScene, GraphScene):
             "\\frac{d(1/x)}{dx} = ???"
         )
         question.next_to(
-            self.pi_creature.get_corner(UP+LEFT), 
+            self.pi_creature.get_corner(UP+LEFT),
             UP, buff = MED_SMALL_BUFF,
         )
 
@@ -1888,7 +1888,7 @@ class OneOverX(PiCreatureScene, GraphScene):
     def create_pi_creature(self):
         morty = PiCreatureScene.create_pi_creature(self)
         morty.scale(
-            self.morty_scale_val, 
+            self.morty_scale_val,
             about_point = morty.get_corner(DOWN+RIGHT)
         )
         return morty
@@ -1912,8 +1912,8 @@ class OneOverX(PiCreatureScene, GraphScene):
         self.wait()
 
     def get_rectangle_group(
-        self, x, 
-        x_label = "x", 
+        self, x,
+        x_label = "x",
         one_over_x_label = "\\frac{1}{x}"
         ):
         result = VGroup()
@@ -1922,7 +1922,7 @@ class OneOverX(PiCreatureScene, GraphScene):
 
         result.x_brace, result.recip_brace = braces = [
             Brace(result.rectangle, vect)
-            for vect in UP, RIGHT
+            for vect in (UP, RIGHT)
         ]
         result.labels = VGroup()
         for brace, label in zip(braces, [x_label, one_over_x_label]):
@@ -1962,7 +1962,7 @@ class OneOverX(PiCreatureScene, GraphScene):
         return rectangle
 
     def change_rectangle_group(
-        self, 
+        self,
         rect_group, target_x,
         target_group_kwargs = None,
         added_anims = [],
@@ -1999,7 +1999,7 @@ class OneOverX(PiCreatureScene, GraphScene):
 class AskRecipriocalQuestion(Scene):
     def construct(self):
         tex = TexMobject(
-            "(\\text{What number?})",  
+            "(\\text{What number?})",
             "\\cdot x = 1"
         )
         arrow = Arrow(DOWN+LEFT, UP+RIGHT)
@@ -2048,7 +2048,7 @@ class SquareRootOfX(Scene):
 
         bottom_brace, right_brace = braces = VGroup(*[
             Brace(square, vect)
-            for vect in DOWN, RIGHT
+            for vect in (DOWN, RIGHT)
         ])
         for brace in braces:
             brace.add(brace.get_text("$\\sqrt{x}$"))
@@ -2086,11 +2086,11 @@ class SquareRootOfX(Scene):
                 stroke_width = 3
             ).shift(s.get_corner(corner))
             for corner, vect in [(DOWN+LEFT, RIGHT), (UP+RIGHT, DOWN)]
-            for s in square, bigger_square
+            for s in (square, bigger_square)
         ])
         little_braces = VGroup(*[
             Brace(VGroup(*line_pair), vect, buff = 0)
-            for line_pair, vect in (lines[:2], RIGHT), (lines[2:], DOWN)
+            for line_pair, vect in ((lines[:2], RIGHT), (lines[2:], DOWN))
         ])
         for brace in little_braces:
             tex = brace.get_text("$d\\sqrt{x}$", buff = SMALL_BUFF)
@@ -2104,11 +2104,11 @@ class SquareRootOfX(Scene):
         question = TexMobject("\\frac{d\\sqrt{x}}{dx} = ???")
         VGroup(*question[5:7]).set_color(bigger_square.get_color())
         question.next_to(
-            area_increase, DOWN, 
-            aligned_edge = LEFT, 
+            area_increase, DOWN,
+            aligned_edge = LEFT,
             buff = LARGE_BUFF
         )
-        
+
         self.play(
             Transform(square_copy, bigger_square),
             Animation(square),
@@ -2201,7 +2201,7 @@ class IntroduceUnitCircleWithSine(GraphScene):
 
         self.play(ShowCreation(radial_line))
         self.play(
-            ShowCreation(circle),            
+            ShowCreation(circle),
             Rotate(radial_line, 2*np.pi),
             run_time = 2,
         )
@@ -2375,7 +2375,7 @@ class DerivativeIntuitionFromSineGraph(GraphScene):
         )
         deriv_graph = self.get_graph(np.cos, color = DERIVATIVE_COLOR)
         v_line = DashedLine(
-            self.graph_origin, self.coords_to_point(0, 1), 
+            self.graph_origin, self.coords_to_point(0, 1),
             color = RED
         )
 
@@ -2393,14 +2393,14 @@ class DerivativeIntuitionFromSineGraph(GraphScene):
                     ShowCreation(
                         deriv_copy,
                         rate_func = lambda t : interpolate(
-                            last_theta/self.x_max, 
+                            last_theta/self.x_max,
                             next_theta/self.x_max,
                             smooth(t)
                         ),
                         run_time = 3,
                     ),
                     UpdateFromFunc(
-                        v_line, 
+                        v_line,
                         lambda v : self.v_line_update(v, deriv_copy),
                         run_time = 3
                     ),
@@ -2412,7 +2412,7 @@ class DerivativeIntuitionFromSineGraph(GraphScene):
                 words.next_to(self.graph_origin, RIGHT)
                 words.to_edge(UP)
                 arrow = Arrow(
-                    words.get_bottom(), 
+                    words.get_bottom(),
                     deriv_graph.point_from_proportion(0.45)
                 )
                 VGroup(words, arrow).set_color(deriv_graph.get_color())
@@ -2503,9 +2503,9 @@ class DerivativeFromZoomingInOnSine(IntroduceUnitCircleWithSine, ZoomedScene):
             self.little_rectangle, self.big_rectangle
         ]))
         self.play(
-            self.little_rectangle.move_to, 
+            self.little_rectangle.move_to,
             self.radial_line.get_end(), DOWN+RIGHT,
-            self.little_rectangle.shift, 
+            self.little_rectangle.shift,
             SMALL_BUFF*(DOWN+RIGHT)
         )
         self.wait()
@@ -2525,7 +2525,7 @@ class DerivativeFromZoomingInOnSine(IntroduceUnitCircleWithSine, ZoomedScene):
         )
         d_theta_label = TexMobject("d\\theta")
         d_theta_label.next_to(
-            d_theta_brace.get_center(), d_theta_brace.direction, 
+            d_theta_brace.get_center(), d_theta_brace.direction,
             MED_LARGE_BUFF
         )
         d_theta_label.set_color(d_theta_arc.get_color())
@@ -2537,7 +2537,7 @@ class DerivativeFromZoomingInOnSine(IntroduceUnitCircleWithSine, ZoomedScene):
         nudged_point = d_theta_arc.point_from_proportion(1)
         interim_point = nudged_point[0]*RIGHT+point[1]*UP
         h_line = DashedLine(
-            interim_point, point, 
+            interim_point, point,
             dashed_segment_length = 0.01
         )
         d_sine_line = Line(interim_point, nudged_point, color = DERIVATIVE_COLOR)
@@ -2623,7 +2623,7 @@ class DerivativeFromZoomingInOnSine(IntroduceUnitCircleWithSine, ZoomedScene):
             self.wait()
 
         self.play(ReplacementTransform(
-            little_triangle.copy().set_fill(opacity = 0), 
+            little_triangle.copy().set_fill(opacity = 0),
             big_triangle_copy,
             path_arc = np.pi/2,
             run_time = 2
@@ -2642,7 +2642,7 @@ class DerivativeFromZoomingInOnSine(IntroduceUnitCircleWithSine, ZoomedScene):
         self.wait()
         self.play(
             ReplacementTransform(
-                big_triangle.copy().set_fill(opacity = 0), 
+                big_triangle.copy().set_fill(opacity = 0),
                 little_triangle,
                 path_arc = -np.pi/2,
                 run_time = 3,
@@ -2674,8 +2674,8 @@ class DerivativeFromZoomingInOnSine(IntroduceUnitCircleWithSine, ZoomedScene):
         group = VGroup(d_ratio, trig_ratio, cos)
         group.arrange_submobjects()
         group.next_to(
-            self.title, DOWN, 
-            buff = MED_LARGE_BUFF, 
+            self.title, DOWN,
+            buff = MED_LARGE_BUFF,
             aligned_edge = LEFT
         )
 
@@ -2806,22 +2806,3 @@ class Thumbnail(NudgeSideLengthOfCube):
         title.scale_to_fit_width(FRAME_WIDTH-1)
         title.to_edge(UP)
         self.add(title)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/chapter4.py
+++ b/old_projects/eoc/chapter4.py
@@ -211,7 +211,7 @@ class DampenedSpring(Scene):
                 num_anchor_points = 100,
                 color = GREY,
             ).shift(3*LEFT)
-            for denom in 12.0, 2.0
+            for denom in (12.0, 2.0)
         ]
         for spring in compact_spring, extended_spring:
             spring.scale(0.5)
@@ -441,7 +441,7 @@ class SumRule(GraphScene):
             line.save_state()
         sine_lines, parabola_lines = [
             VGroup(example_v_lines[i], nudged_v_lines[i])
-            for i in 0, 1
+            for i in (0, 1)
         ]
         faders = VGroup(*filter(
             lambda line : line not in example_v_lines,
@@ -944,7 +944,7 @@ class IntroduceProductAsArea(ReconfigurableScene):
         line, triangle, x_mob = self.x_slider
         dx_line = Line(*[
             line.number_to_point(self.x_slider.x_val + num)
-            for num in 0, self.dx,
+            for num in (0, self.dx,)
         ])
         dx_line.set_stroke(
             self.df_box_kwargs["fill_color"], 
@@ -1943,7 +1943,7 @@ class GeneralizeChainRule(Scene):
         self.wait()
         self.play(*it.chain(*[
             [mob.scale_in_place, 1.2, mob.set_color, YELLOW]
-            for mob in example_inner, d_example_inner
+            for mob in (example_inner, d_example_inner)
         ]), rate_func = there_and_back)
         self.play(Transform(
             example_inner.copy(), d_example_inner,

--- a/old_projects/eoc/chapter5.py
+++ b/old_projects/eoc/chapter5.py
@@ -100,7 +100,7 @@ class DoublingPopulation(PiCreatureScene):
 
         pop_brace, mass_brace = [
             Brace(function[0], DOWN)
-            for function in P_t, M_t
+            for function in (P_t, M_t)
         ]
         for brace, word in (pop_brace, "size"), (mass_brace, "mass"):
             text = brace.get_text("Population %s"%word)
@@ -601,7 +601,7 @@ class FakeDiagram(TeacherStudentsScene):
                 x_min = -8,
                 x_max = 2 + dx
             )
-            for dx in 0.25, 0
+            for dx in (0.25, 0)
         ])
         for graph in graphs:
             end_point = graph.points[-1]
@@ -775,7 +775,7 @@ class AnalyzeExponentRatio(PiCreatureScene):
         ]
         words = VGroup(*[
             TextMobject(s, " ideas")
-            for s in "Additive", "Multiplicative"
+            for s in ("Additive", "Multiplicative")
         ])
         words[0].move_to(words[1], LEFT)
         words.set_color(BLUE)
@@ -812,14 +812,14 @@ class AnalyzeExponentRatio(PiCreatureScene):
                 run_time = 2,
                 rate_func = squish_rate_func(smooth, 0.5, 1)
             )
-            for mob in one, lp, rp
+            for mob in (one, lp, rp)
         ] + [
             ReplacementTransform(
                 mob, extracted_two_to_t,
                 path_arc = np.pi/2,
                 run_time = 2,
             )
-            for mob in two_to_t, VGroup(*two_to_t_two_to_dt[:2])
+            for mob in (two_to_t, VGroup(*two_to_t_two_to_dt[:2]))
         ] + [
             lhs.next_to, extracted_two_to_t, LEFT
         ])
@@ -1006,7 +1006,7 @@ class CompareTwoConstantToEightConstant(PiCreatureScene):
     def construct(self):
         two_deriv, eight_deriv = derivs = VGroup(*[
             self.get_derivative_expression(base)
-            for base in 2, 8
+            for base in (2, 8)
         ])
 
         derivs.arrange_submobjects(
@@ -1268,7 +1268,7 @@ class ApplyChainRule(TeacherStudentsScene):
                 path_arc = -np.pi,
                 run_time = 2
             )
-            for tex in "e^", "{3", "t}"
+            for tex in ("e^", "{3", "t}")
         ] + [
             Write(deriv_equation.get_part_by_tex("="))
         ])
@@ -1663,7 +1663,7 @@ class TemperatureOverTimeOfWarmWater(GraphScene):
         )
         h_line = DashedLine(*[
             self.coords_to_point(x, self.T_room)
-            for x in self.x_min, self.x_max
+            for x in (self.x_min, self.x_max)
         ])
         T_room_label = TexMobject("T_{\\text{room}}")
         T_room_label.next_to(h_line, LEFT)

--- a/old_projects/eoc/chapter6.py
+++ b/old_projects/eoc/chapter6.py
@@ -79,7 +79,7 @@ class SlopeOfCircleExample(ZoomedScene):
         equation = TexMobject("x^2 + y^2 = 5^2")
         equation.add_background_rectangle()
         equation.next_to(
-            circle.point_from_proportion(1./8), 
+            circle.point_from_proportion(1./8),
             UP+RIGHT
         )
         equation.to_edge(RIGHT)
@@ -108,7 +108,7 @@ class SlopeOfCircleExample(ZoomedScene):
             label.set_color(line.get_color())
             label.add_background_rectangle()
             label.next_to(
-                line.get_center(), 
+                line.get_center(),
                 rotate_vector(UP, line.get_angle()),
                 buff = SMALL_BUFF
             )
@@ -135,7 +135,7 @@ class SlopeOfCircleExample(ZoomedScene):
             radial_line.put_start_and_end_on(ORIGIN, new_point)
             for line, label in zip(lines, labels):
                 label.next_to(
-                    line.get_center(), 
+                    line.get_center(),
                     rotate_vector(UP, line.get_angle()),
                     buff = SMALL_BUFF
                 )
@@ -214,7 +214,7 @@ class SlopeOfCircleExample(ZoomedScene):
         self.wait()
         self.play(Indicate(perp_mark))
         self.wait()
-        
+
         morty =  Mortimer().flip().to_corner(DOWN+LEFT)
         self.play(FadeIn(morty))
         self.play(PiCreatureBubbleIntroduction(
@@ -266,7 +266,7 @@ class SlopeOfCircleExample(ZoomedScene):
         self.little_rectangle.move_to(step_line.get_center())
         self.little_rectangle.save_state()
         self.little_rectangle.scale_in_place(self.zoom_factor)
-        self.wait()        
+        self.wait()
         self.play(
             self.little_rectangle.restore,
             dot.scale_in_place, 1./self.zoom_factor,
@@ -354,7 +354,7 @@ class SlopeOfCircleExample(ZoomedScene):
         q_marks.next_to(morty, UP)
 
         rect = Rectangle(
-            width = FRAME_X_RADIUS - SMALL_BUFF, 
+            width = FRAME_X_RADIUS - SMALL_BUFF,
             height = FRAME_Y_RADIUS - SMALL_BUFF,
             stroke_width = 0,
             fill_color = BLACK,
@@ -372,7 +372,7 @@ class SlopeOfCircleExample(ZoomedScene):
 
         self.play(
             FadeIn(rect),
-            FadeIn(morty),            
+            FadeIn(morty),
             equation.next_to, ORIGIN, DOWN, MED_LARGE_BUFF,
             equation.shift, FRAME_X_RADIUS*RIGHT/2,
         )
@@ -396,7 +396,7 @@ class SlopeOfCircleExample(ZoomedScene):
                     equation[1][i].copy(),
                     derivative[j],
                 )
-                for i, j in (1, 0), (0, 1)
+                for i, j in ((1, 0), (0, 1))
             ]
         )
         self.play(Write(dx, run_time = 1))
@@ -406,16 +406,16 @@ class SlopeOfCircleExample(ZoomedScene):
                 equation[1][i].copy(),
                 derivative[j],
             )
-            for i, j in (2, 4), (3, 6), (4, 5)
+            for i, j in ((2, 4), (3, 6), (4, 5))
         ])
         self.play(Write(dy, run_time = 1))
-        self.play(Blink(morty)) 
+        self.play(Blink(morty))
         self.play(*[
             ReplacementTransform(
                 equation[1][i].copy(),
                 derivative[j],
             )
-            for i, j in (-3, -2), (-2, -1), (-1, -1)
+            for i, j in ((-3, -2), (-2, -1), (-1, -1))
         ])
         self.wait()
 
@@ -462,10 +462,10 @@ class SlopeOfCircleExample(ZoomedScene):
                 path_arc = np.pi/2,
             )
             for mover, target in [
-                (dy, new_dy), 
-                (dx, new_dx), 
-                (eq, new_eq), 
-                (x, new_x), 
+                (dy, new_dy),
+                (dx, new_dx),
+                (eq, new_eq),
+                (x, new_x),
                 (y, new_y)
             ]
         ] + [
@@ -480,7 +480,7 @@ class SlopeOfCircleExample(ZoomedScene):
         morty = self.morty
         dy_dx = self.dy_dx
         coords = self.example_point_coords_mob
-        x, y = coords[1][1].copy(), coords[1][3].copy()        
+        x, y = coords[1][1].copy(), coords[1][3].copy()
 
         frac = self.neg_x_over_y.copy()
         frac.generate_target()
@@ -563,7 +563,7 @@ class Ladder(VMobject):
     def generate_points(self):
         left_line, right_line = [
             Line(ORIGIN, self.height*UP).shift(self.width*vect/2.0)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ]
         rungs = [
             Line(
@@ -677,7 +677,7 @@ class RelatedRatesExample(ThreeDScene):
 
         down_arrow, left_arrow = [
             Arrow(ORIGIN, vect, color = YELLOW, buff = 0)
-            for vect in DOWN, LEFT
+            for vect in (DOWN, LEFT)
         ]
         down_arrow.shift(y_line.get_start()+MED_SMALL_BUFF*RIGHT)
         left_arrow.shift(x_line.get_start()+SMALL_BUFF*DOWN)
@@ -788,7 +788,7 @@ class RelatedRatesExample(ThreeDScene):
 
         randy = Randolph()
         randy.next_to(
-            alt_equation, DOWN, 
+            alt_equation, DOWN,
             buff = MED_LARGE_BUFF,
             aligned_edge = LEFT,
         )
@@ -800,11 +800,11 @@ class RelatedRatesExample(ThreeDScene):
 
         self.play(FadeIn(randy))
         self.play(
-            randy.change_mode, "raise_right_hand", 
+            randy.change_mode, "raise_right_hand",
             randy.look_at, alt_equation,
             *[
                 ReplacementTransform(
-                    self.equation[i].copy(), 
+                    self.equation[i].copy(),
                     alt_equation[j],
                     path_arc = np.pi/2,
                     run_time = 3,
@@ -907,8 +907,8 @@ class RelatedRatesExample(ThreeDScene):
             Write(dt_brace_text, run_time = 2)
         )
         self.play(*map(FadeOut, [
-            self.dy_arrow, self.dy_label, 
-            self.dx_arrow, self.dx_label, 
+            self.dy_arrow, self.dy_label,
+            self.dx_arrow, self.dx_label,
         ]))
         self.add(shadow_ladder)
         self.let_ladder_fall(
@@ -960,7 +960,7 @@ class RelatedRatesExample(ThreeDScene):
         self.play(Indicate(rhs))
         self.wait()
         self.reset_ladder(
-            self.ladder, 
+            self.ladder,
             *self.get_added_anims_for_ladder_fall()+[
                 Animation(self.dy_group),
                 Animation(self.dx_group),
@@ -1160,7 +1160,7 @@ class RelatedRatesExample(ThreeDScene):
 
     def get_ladder_brace(self, ladder):
         vect = rotate_vector(LEFT, -self.get_ladder_angle())
-        brace = Brace(ladder, vect)        
+        brace = Brace(ladder, vect)
         length_string = "%dm"%int(self.get_ladder_length())
         length_label = brace.get_text(
             length_string, use_next_to = False
@@ -1302,7 +1302,7 @@ class CompareLadderAndCircle(PiCreatureScene, ThreeDScene):
             for i, j in enumerate([1, 0, 3, 5, 4, 7])
         ]+[
             Write(derivative[j])
-            for j in 2, 6
+            for j in (2, 6)
         ])
         self.play(
             self.pi_creature.change_mode, "pondering",
@@ -1321,7 +1321,7 @@ class CompareLadderAndCircle(PiCreatureScene, ThreeDScene):
             "x(t)", "^2", "+", "y(t)", "^2", "= 5^2"
         )
         time_derivative = TexMobject(
-            "2", "x(t)", "\\frac{dx}{dt}", "+", 
+            "2", "x(t)", "\\frac{dx}{dt}", "+",
             "2", "y(t)", "\\frac{dy}{dt}", "=0"
         )
         self.color_equations(time_equation, time_derivative)
@@ -1430,7 +1430,7 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
         self.wait()
         self.play(
             FadeIn(s_rect),
-            s.restore, 
+            s.restore,
             GrowFromCenter(xy)
         )
         self.wait()
@@ -1508,7 +1508,7 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
             )
         ]+[
             Write(derivative[1][j])
-            for j in 3, 7
+            for j in (3, 7)
         ])
         self.play(*[
             ReplacementTransform(
@@ -1542,13 +1542,13 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
             label.next_to(line, vect, buff = SMALL_BUFF)
             label.add_background_rectangle()
             label.scale(
-                1./self.zoom_factor, 
+                1./self.zoom_factor,
                 about_point = line.get_center()
             )
             line.label = label
 
         self.activate_zooming()
-        lil_rect = self.little_rectangle        
+        lil_rect = self.little_rectangle
         lil_rect.move_to(dot)
         lil_rect.shift(0.05*lil_rect.get_width()*LEFT)
         lil_rect.shift(0.2*lil_rect.get_height()*DOWN)
@@ -1580,8 +1580,8 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
         new_s_label.scale_to_fit_height(s_label.get_height())
         new_s_label.scale(0.8)
         new_s_label.next_to(
-            new_dot, DOWN, 
-            buff = SMALL_BUFF/self.zoom_factor, 
+            new_dot, DOWN,
+            buff = SMALL_BUFF/self.zoom_factor,
             aligned_edge = LEFT
         )
         new_s_label.shift(MED_LARGE_BUFF*LEFT/self.zoom_factor)
@@ -1729,7 +1729,7 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
                 buff = SMALL_BUFF/self.zoom_factor,
                 tip_length = 0.15/self.zoom_factor
             )
-            for mob in dot, new_dot
+            for mob in (dot, new_dot)
         ]
 
         for line, tex, vect in (dy_line, "dy", RIGHT), (dx_line, "dx", UP):
@@ -1737,7 +1737,7 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
             label.set_color(line.get_color())
             label.next_to(line, vect)
             label.scale(
-                1./self.zoom_factor, 
+                1./self.zoom_factor,
                 about_point = line.get_center()
             )
             line.label = label
@@ -1836,7 +1836,7 @@ class AlternateExample(ZoomedScene):
         "zoomed_canvas_corner" : DOWN+RIGHT,
         "zoomed_canvas_frame_shape" : (3, 4),
     }
-    def construct(self): 
+    def construct(self):
         self.add_plane()
         self.draw_graph()
         self.emphasize_meaning_of_points()
@@ -1889,8 +1889,8 @@ class AlternateExample(ZoomedScene):
 
         self.play(
             ShowCreation(
-                graphs, 
-                run_time = 3, 
+                graphs,
+                run_time = 3,
                 submobject_mode = "all_at_once"
             ),
             Animation(self.formula)
@@ -2025,7 +2025,7 @@ class AlternateExample(ZoomedScene):
 
         arrows = VGroup(*[
             Arrow(word, part)
-            for part in lhs, rhs
+            for part in (lhs, rhs)
         ])
 
         self.play(FocusOn(formula))
@@ -2045,7 +2045,7 @@ class AlternateExample(ZoomedScene):
         y_squared = VGroup(*lhs[6:])
 
         mnemonic = TextMobject(
-            "``", 
+            "``",
             "Left", " d-Right", " + ",
             "Right",  " d-Left"
             "''",
@@ -2059,20 +2059,20 @@ class AlternateExample(ZoomedScene):
         mnemonic.to_edge(LEFT)
 
         derivative = TexMobject(
-            "\\sin(x)", "(2y\\,dy)", "+", 
+            "\\sin(x)", "(2y\\,dy)", "+",
             "y^2", "(\\cos(x)\\,dx)",
         )
         derivative.set_color_by_tex("dx", GREEN)
         derivative.set_color_by_tex("dy", RED)
         derivative.scale_to_fit_width(FRAME_X_RADIUS - 2*MED_LARGE_BUFF)
         derivative.next_to(
-            brace, DOWN, 
+            brace, DOWN,
             buff = MED_LARGE_BUFF,
             aligned_edge = LEFT
         )
         derivative_rects = [
             BackgroundRectangle(VGroup(*subset))
-            for subset in derivative[:2], derivative[2:]
+            for subset in (derivative[:2], derivative[2:])
         ]
         derivative_rects[1].stretch(1.05, dim = 0)
 
@@ -2150,7 +2150,7 @@ class AlternateExample(ZoomedScene):
         lil_rect = self.little_rectangle
         self.play(
             arrow.put_start_and_end_on, point, new_end_point,
-            dy_line.put_start_and_end_on, 
+            dy_line.put_start_and_end_on,
                 dy_line.get_start(), new_end_point,
             MaintainPositionRelativeTo(dy_line.label, dy_line),
             lil_rect.shift, lil_rect.get_height()*DOWN/3,
@@ -2258,8 +2258,8 @@ class DerivativeOfNaturalLog(ZoomedScene):
 
     def draw_graph(self):
         graph = FunctionGraph(
-            np.log, 
-            x_min = 0.01, 
+            np.log,
+            x_min = 0.01,
             x_max = FRAME_X_RADIUS,
             num_steps = 100
         )
@@ -2379,7 +2379,7 @@ class DerivativeOfNaturalLog(ZoomedScene):
         new_formula = TexMobject("e", "^y", "=", "x")
         e, new_y, new_eq, new_x = new_formula
         new_formula.next_to(
-            formula, DOWN, 
+            formula, DOWN,
             buff = MED_LARGE_BUFF,
         )
         rect = BackgroundRectangle(new_formula)
@@ -2441,7 +2441,7 @@ class DerivativeOfNaturalLog(ZoomedScene):
             label.next_to(line, vect, buff = SMALL_BUFF)
             label.set_color(line.get_color())
             label.scale(
-                1./self.zoom_factor, 
+                1./self.zoom_factor,
                 about_point = line.get_center()
             )
             line.label = label
@@ -2482,7 +2482,7 @@ class DerivativeOfNaturalLog(ZoomedScene):
 
         self.play(*[
             ReplacementTransform(
-                m1, m2, 
+                m1, m2,
                 run_time = 2,
                 path_arc = -np.pi/2,
             )
@@ -2520,7 +2520,7 @@ class DerivativeOfNaturalLog(ZoomedScene):
         equals_one_over_x.add_to_back(rect)
 
         self.play(
-            equals_one_over_x.next_to, 
+            equals_one_over_x.next_to,
             self.slope_equation, RIGHT, 0,
             run_time = 2
         )
@@ -2531,7 +2531,7 @@ class DerivativeOfNaturalLog(ZoomedScene):
         start_x = line.get_center()[0]
         target_x = 0.2
         graph = FunctionGraph(
-            lambda x : 1./x, 
+            lambda x : 1./x,
             x_min = 0.1,
             x_max = FRAME_X_RADIUS,
             num_steps = 100,
@@ -2619,7 +2619,7 @@ class Chapter6PatreonThanks(PatreonThanks):
             "Meshal  Alshammari",
             "CrypticSwarm    ",
             "Nathan Pellegrin",
-            "Karan Bhargava", 
+            "Karan Bhargava",
             "Justin Helps",
             "Ankit   Agarwal",
             "Yu  Jun",
@@ -2671,57 +2671,3 @@ class Thumbnail(AlternateExample):
 
 
         self.add(title)
-
-
-
-
-
-
-
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/chapter7.py
+++ b/old_projects/eoc/chapter7.py
@@ -191,7 +191,7 @@ class RefreshOnDerivativeDefinition(GraphScene):
                 line_class = DashedLine,
                 color = RED
             )
-            for nudge in 0, self.start_dx
+            for nudge in (0, self.start_dx)
         ]
         nudged_x_v_line.save_state()
         ss_group = self.get_secant_slope_group(
@@ -343,7 +343,7 @@ class RantOpenAndClose(Scene):
                 start, "Rant on infinitesimals", "$>$",
                 arg_separator = ""
             )
-            for start in "$<$", "$<$/"
+            for start in ("$<$", "$<$/")
         ]
         self.play(FadeIn(opening))
         self.wait(2)
@@ -439,7 +439,7 @@ class DiscussLowercaseDs(RefreshOnDerivativeDefinition, PiCreatureScene, ZoomedS
                 lhs.get_part_by_tex(tex)[0],
                 stretch = True,
             ).scale_in_place(1.5).rotate_in_place(-np.pi/12)
-            for tex in "df", "dx"
+            for tex in ("df", "dx")
         ])
         d_words = TextMobject("""
             Limit idea is
@@ -452,7 +452,7 @@ class DiscussLowercaseDs(RefreshOnDerivativeDefinition, PiCreatureScene, ZoomedS
             Rectangle(color = GREEN_B).replace(
                 mob, stretch = True
             )
-            for mob in lhs, rhs.target
+            for mob in (lhs, rhs.target)
         ]
         for rect in rects:
             rect.stretch_to_fit_width(rect.get_width()+2*MED_SMALL_BUFF)
@@ -654,7 +654,7 @@ class OtherViewsOfDx(TeacherStudentsScene):
                 VGroup(*statement.get_parts_by_tex(
                     tex, substring = False
                 )).set_color(GREEN)
-                for tex in "$h$", "$dx$"
+                for tex in ("$h$", "$dx$")
             ]
 
         #Question
@@ -1165,14 +1165,14 @@ class GraphLimitExpression(GraphScene):
                     (limit_x+basically_zero, limit_x+delta),
                 ]
             ]).set_stroke(width = input_range_stroke_width)
-            for func in (lambda h : 0), self.func
+            for func in ((lambda h : 0), self.func)
         ]
         result.epsilon_lines = VGroup(*[
             dashed_line.copy().move_to(
                 self.coords_to_point(limit_x, 0)[0]*RIGHT+\
                 result.output_range.get_edge_center(vect)[1]*UP
             )
-            for vect in DOWN, UP
+            for vect in (DOWN, UP)
         ])
 
         result.digest_mobject_attrs()
@@ -1588,7 +1588,7 @@ class EpsilonDeltaExample(GraphLimitExpression, ZoomedScene):
             Line(
                 ORIGIN, line_length*RIGHT,
             ).move_to(self.coords_to_point(0, limit_value+nudge))
-            for nudge in 0, -epsilon, epsilon
+            for nudge in (0, -epsilon, epsilon)
         ]
         result.limit_line = lines[0]
         result.limit_line.set_stroke(RED, width = 3)
@@ -1599,7 +1599,7 @@ class EpsilonDeltaExample(GraphLimitExpression, ZoomedScene):
             brace.copy().scale_to_fit_height(
                 group.get_height()
             ).next_to(group, RIGHT, SMALL_BUFF)
-            for i in 1, 2
+            for i in (1, 2)
             for group in [VGroup(lines[0], lines[i])]
         ])
         result.labels = VGroup(*[
@@ -1623,7 +1623,7 @@ class EpsilonDeltaExample(GraphLimitExpression, ZoomedScene):
         )
         result.braces = VGroup(*[
             brace.copy().move_to(self.coords_to_point(x, 0))
-            for x in -delta/2, delta/2
+            for x in (-delta/2, delta/2)
         ])
         result.braces.shift(self.holes[0].get_height()*DOWN)
         result.labels = VGroup(*[
@@ -1897,11 +1897,11 @@ class LHopitalExample(LimitCounterExample, PiCreatureScene, ZoomedScene, Reconfi
                 line_class = DashedLine,
                 color = self.x_color
             )
-            for x in 1, -1
+            for x in (1, -1)
         ]
         hole, alt_hole = [
             self.get_hole(x, self.func(x))
-            for x in 1, -1
+            for x in (1, -1)
         ]
         ed_group = self.get_epsilon_delta_group(
             self.big_delta, limit_x = 1,
@@ -2090,7 +2090,7 @@ class LHopitalExample(LimitCounterExample, PiCreatureScene, ZoomedScene, Reconfi
                 fill_opacity = 0.75,
                 fill_color = BLACK,
             ).next_to(self.coords_to_point(1, 0), vect, MED_LARGE_BUFF)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
 
         self.play(
@@ -2149,7 +2149,7 @@ class LHopitalExample(LimitCounterExample, PiCreatureScene, ZoomedScene, Reconfi
                 tip_length = arrow_tip_length,
                 color = graph.get_color()
             )
-            for graph in self.sine_graph, self.parabola
+            for graph in (self.sine_graph, self.parabola)
         ]
         tex_arrow_pairs = [
             [("d\\big(", "\\sin(", "\\pi", "x", ")", "\\big)"), d_sine_arrow],
@@ -2606,7 +2606,7 @@ class GeneralLHoptial(LHopitalExample):
                 tip_length = arrow_tip_length,
                 color = graph.get_color()
             )
-            for graph in self.f_graph, self.g_graph
+            for graph in (self.f_graph, self.g_graph)
         ]
         v_labels = []
         for char, arrow in ("f", df_arrow), ("g", dg_arrow):
@@ -2881,7 +2881,7 @@ class NextVideo(TeacherStudentsScene):
             ])
         ]+[
             Write(VGroup(*ftc.get_parts_by_tex(part)))
-            for part in "-", "=", "over", "(x)"
+            for part in ("-", "=", "over", "(x)")
         ])
         self.change_student_modes(*["pondering"]*3)
         self.wait(3)

--- a/old_projects/eoc/chapter8.py
+++ b/old_projects/eoc/chapter8.py
@@ -53,7 +53,7 @@ class Chapter8OpeningQuote(OpeningQuote, PiCreatureScene):
             self.pi_creature.change_mode, "plain"
         )
         self.play(
-            words_copy.next_to, self.pi_creature, 
+            words_copy.next_to, self.pi_creature,
                 LEFT, MED_SMALL_BUFF, UP,
             self.pi_creature.change_mode, "thinking"
         )
@@ -67,9 +67,9 @@ class Chapter8OpeningQuote(OpeningQuote, PiCreatureScene):
     def get_formula(self):
         result = TexMobject(
             "{d(\\sin(\\theta)) \\over \\,", "d\\theta}", "=",
-            "\\lim_{", "h", " \\to 0}", 
+            "\\lim_{", "h", " \\to 0}",
             "{\\sin(\\theta+", "h", ") - \\sin(\\theta) \\over", " h}", "=",
-            "\\lim_{", "h", " \\to 0}", 
+            "\\lim_{", "h", " \\to 0}",
             "{\\big[ \\sin(\\theta)\\cos(", "h", ") + ",
             "\\sin(", "h", ")\\cos(\\theta)\\big] - \\sin(\\theta) \\over", "h}",
             "= \\dots"
@@ -89,8 +89,8 @@ class ThisVideo(TeacherStudentsScene):
         next_video = series[8]
 
         deriv, integral, v_t, dt, equals, v_T = formula = TexMobject(
-            "\\frac{d}{dT}", 
-            "\\int_0^T", "v(t)", "\\,dt", 
+            "\\frac{d}{dT}",
+            "\\int_0^T", "v(t)", "\\,dt",
             "=", "v(T)"
         )
         formula.set_color_by_tex("v", VELOCITY_COLOR)
@@ -216,7 +216,7 @@ class GraphDistanceVsTime(GraphCarTrajectory):
     def construct(self):
         self.setup_axes()
         graph = self.get_graph(
-            s_func, 
+            s_func,
             color = DISTANCE_COLOR,
             x_min = 0,
             x_max = 8,
@@ -255,7 +255,7 @@ class PlotVelocity(GraphScene):
         speedometer.to_edge(UP)
 
         self.play(DrawBorderThenFill(
-            speedometer, 
+            speedometer,
             submobject_mode = "lagged_start",
             rate_func = None,
         ))
@@ -320,7 +320,7 @@ class PlotVelocity(GraphScene):
 
     def get_v_graph_and_label(self):
         graph = self.get_graph(
-            v_func, 
+            v_func,
             x_min = 0,
             x_max = 8,
             color = VELOCITY_COLOR
@@ -419,7 +419,7 @@ class AskAboutAntiderivative(PlotVelocity):
 
         self.play(FadeIn(randy))
         self.play(PiCreatureSays(
-            randy, words, 
+            randy, words,
             target_mode = "confused",
             bubble_kwargs = {"height" : 3, "width" : 4},
         ))
@@ -450,7 +450,7 @@ class Antiderivative(PiCreatureScene):
         self.wait(2)
 
         self.pi_creature_says(
-            "But first!", 
+            "But first!",
             target_mode = "surprised",
             look_at_arg = 50*OUT,
             added_anims = [group.to_edge, LEFT],
@@ -504,7 +504,7 @@ class AreaUnderVGraph(PlotVelocity):
 
     def show_rects(self):
         rect_list = self.get_riemann_rectangles_list(
-            self.v_graph, 7, 
+            self.v_graph, 7,
             max_dx = 1.0,
             x_min = 0,
             x_max = 8,
@@ -556,7 +556,7 @@ class ConstantVelocityPlot(PlotVelocity):
     def draw_graph(self):
         graph = self.get_graph(
             lambda t : 10,
-            x_min = 0, 
+            x_min = 0,
             x_max = 8,
             color = VELOCITY_COLOR
         )
@@ -636,7 +636,7 @@ class ConstantVelocityPlot(PlotVelocity):
         self.play(
             randy.change_mode, "confused",
             randy.look_at, randy.bubble,
-            ShowCreation(bubble), 
+            ShowCreation(bubble),
             Write(bubble.content),
         )
         self.wait()
@@ -653,7 +653,7 @@ class ConstantVelocityPlot(PlotVelocity):
     def note_units(self):
         x_line, y_line  = lines = VGroup(*[
             axis.main_line.copy()
-            for axis in self.x_axis, self.y_axis
+            for axis in (self.x_axis, self.y_axis)
         ])
         lines.set_color(TIME_COLOR)
         square = Square(
@@ -665,7 +665,7 @@ class ConstantVelocityPlot(PlotVelocity):
         square.replace(
             VGroup(*[
                 VectorizedPoint(self.coords_to_point(i, i))
-                for i in 0, 1
+                for i in (0, 1)
             ]),
             stretch = True
         )
@@ -691,7 +691,7 @@ class ConstantVelocityPlot(PlotVelocity):
         for FadeClass in FadeIn, FadeOut:
             self.play(
                 FadeClass(
-                    units_of_area, 
+                    units_of_area,
                     submobject_mode = "lagged_start",
                     run_time = 3
                 ),
@@ -828,7 +828,7 @@ class PiecewiseConstantPlot(PlotVelocity):
 
     def compute_distance_on_each_interval(self):
         rect_list = self.get_riemann_rectangles_list(
-            self.v_graph, self.num_riemann_approximations, 
+            self.v_graph, self.num_riemann_approximations,
             max_dx = 1,
             x_min = 0,
             x_max = 8,
@@ -875,8 +875,8 @@ class PiecewiseConstantPlot(PlotVelocity):
         self.play(
             FadeOut(self.pw_constant_graph),
             *[
-                m.restore 
-                for m in self.v_graph, self.v_graph_label
+                m.restore
+                for m in (self.v_graph, self.v_graph_label)
             ]+[Animation(self.rects)]
         )
         for new_rects in self.rect_list[1:]:
@@ -919,7 +919,7 @@ class PiecewiseConstantPlot(PlotVelocity):
         self.wait()
         self.play(
             FadeIn(
-                example_text, 
+                example_text,
                 run_time = 2,
                 submobject_mode = "lagged_start",
             ),
@@ -1022,7 +1022,7 @@ class PiecewiseConstantPlot(PlotVelocity):
 
         self.play(*map(FadeOut, [
             group[1]
-            for group in v_lines, h_lines, height_labels
+            for group in (v_lines, h_lines, height_labels)
         ]))
         self.play(
             v_lines[0].set_color, RED,
@@ -1039,7 +1039,7 @@ class PiecewiseConstantPlot(PlotVelocity):
         )
         area.next_to(rect, RIGHT, LARGE_BUFF)
         arrow = Arrow(
-            area.get_left(), rect.get_center(), 
+            area.get_left(), rect.get_center(),
             buff = 0,
             color = WHITE
         )
@@ -1051,7 +1051,7 @@ class PiecewiseConstantPlot(PlotVelocity):
         )
         self.wait(2)
         self.play(*map(FadeOut, [
-            area, arrow, 
+            area, arrow,
             v_lines[0], h_lines[0], height_labels[0],
             rect, t_labels
         ]))
@@ -1129,7 +1129,7 @@ class PiecewiseConstantPlot(PlotVelocity):
 
         for mob, tex in (self.v_t, "v(t)"), (self.dt_label, "dt"):
             self.play(ReplacementTransform(
-                mob.copy().set_color(YELLOW), 
+                mob.copy().set_color(YELLOW),
                 integral.get_part_by_tex(tex),
                 run_time = 2
             ))
@@ -1177,7 +1177,7 @@ class PiecewiseConstantPlot(PlotVelocity):
                 )
             )
             for tick, alpha in zip(
-                self.ticks, 
+                self.ticks,
                 np.linspace(0, 0.8, len(self.ticks))
             )
         ])
@@ -1222,7 +1222,7 @@ class PiecewiseConstantPlot(PlotVelocity):
                 )
             )
             for rect, alpha in zip(
-                rects, 
+                rects,
                 np.linspace(0, 0.8, len(rects))
             )
         ]+[
@@ -1274,7 +1274,7 @@ class PiecewiseConstantPlot(PlotVelocity):
                 every_other_rect.set_fill(opacity = 0)
             self.play(
                 Transform(
-                    rects, new_rects, 
+                    rects, new_rects,
                     run_time = 2,
                     submobject_mode = "lagged_start"
                 ),
@@ -1317,7 +1317,7 @@ class PiecewiseConstantPlot(PlotVelocity):
                 )
             )
             for rect, alpha in zip(
-                self.rects, 
+                self.rects,
                 np.linspace(0, 0.8, len(self.rects))
             )
         ]+[
@@ -1345,7 +1345,7 @@ class PiecewiseConstantPlot(PlotVelocity):
     def get_ticks(self, rects):
         ticks = VGroup(*[
             Line(
-                point+self.tick_size*UP/2, 
+                point+self.tick_size*UP/2,
                 point+self.tick_size*DOWN/2
             )
             for t in np.linspace(0, 8, len(rects)+1)
@@ -1368,7 +1368,7 @@ class CarJourneyApproximation(Scene):
         "bottom_words" : "Approximated motion (5 jumps)",
     }
     def construct(self):
-        points = [5*LEFT + v for v in UP, 2*DOWN]
+        points = [5*LEFT + v for v in (UP, 2*DOWN)]
         cars = [Car().move_to(point) for point in points]
         h_line = Line(LEFT, RIGHT).scale(FRAME_X_RADIUS)
         words = [
@@ -1501,7 +1501,7 @@ class AreaIsDerivative(PlotVelocity, ReconfigurableScene):
         self.add(*self.get_v_graph_and_label())
         self.x_axis_label_mob.shift(MED_LARGE_BUFF*DOWN)
         self.v_graph_label.shift(MED_LARGE_BUFF*DOWN)
-        self.foreground_mobjects = []        
+        self.foreground_mobjects = []
 
     def construct(self):
         self.introduce_variable_area()
@@ -1539,7 +1539,7 @@ class AreaIsDerivative(PlotVelocity, ReconfigurableScene):
                 mob.get_left(), self.area.get_center(),
                 color = WHITE
             )
-            for mob in integral, s_T
+            for mob in (integral, s_T)
         ]
 
         distance_word = TextMobject("Distance")
@@ -1573,7 +1573,7 @@ class AreaIsDerivative(PlotVelocity, ReconfigurableScene):
         self.play(FadeOut(distance_word))
         self.change_area_bounds(new_t_max = 0, run_time = 2)
         self.change_area_bounds(
-            new_t_max = 8, 
+            new_t_max = 8,
             rate_func = None,
             run_time = 7.9,
         )
@@ -1678,7 +1678,7 @@ class AreaIsDerivative(PlotVelocity, ReconfigurableScene):
                 formula1.get_part_by_tex(tex),
                 formula2.get_part_by_tex(tex),
             )
-            for tex in "ds", "=", "v(T)", "dT"
+            for tex in ("ds", "=", "v(T)", "dT")
         ] + [
             Write(formula2.get_part_by_tex("over"))
         ])
@@ -1742,7 +1742,7 @@ class AreaIsDerivative(PlotVelocity, ReconfigurableScene):
             T_label.move_to(new_v_line.get_bottom(), UP)
 
             #Fade close to 0
-            T_label[0].set_fill(opacity = min(1, t_max)) 
+            T_label[0].set_fill(opacity = min(1, t_max))
 
             Transform(area, new_area).update(1)
             Transform(v_line, new_v_line).update(1)
@@ -1780,7 +1780,7 @@ class DirectInterpretationOfDsDt(TeacherStudentsScene):
         for words, part in (s_words, ds), (t_words, dt):
             self.play(
                 FadeIn(
-                    words, 
+                    words,
                     run_time = 2,
                     submobject_mode = "lagged_start",
                 ),
@@ -1849,8 +1849,8 @@ class FindAntiderivative(Antiderivative):
             self.pi_creature.change, "plain", self.v_part1
         )
         self.play(ApplyWave(
-            self.q_marks, 
-            direction = UP, 
+            self.q_marks,
+            direction = UP,
             amplitude = SMALL_BUFF
         ))
         self.wait(2)
@@ -1865,7 +1865,7 @@ class FindAntiderivative(Antiderivative):
                 run_time = 2,
                 path_arc = -np.pi/6.
             )
-            for i in 0, 1
+            for i in (0, 1)
         ])
         self.change_mode("thinking")
         self.wait()
@@ -1882,7 +1882,7 @@ class FindAntiderivative(Antiderivative):
         self.arcs_copy = self.arcs.copy()
         self.words_copy = self.words.copy()
         part1_group = VGroup(
-            self.s_part1, self.v_part1, 
+            self.s_part1, self.v_part1,
             self.arcs_copy, self.words_copy
         )
 
@@ -1919,7 +1919,7 @@ class FindAntiderivative(Antiderivative):
                 path_arc = -np.pi/6,
                 run_time = 2,
             )
-            for i, j in (0, 1), (1, 0), (1, 2)
+            for i, j in ((0, 1), (1, 0), (1, 2))
         ])
         self.wait()
         self.play(FadeIn(third))
@@ -1976,7 +1976,7 @@ class GraphSPlusC(GraphDistanceVsTime):
     def construct(self):
         self.setup_axes()
         graph = self.get_graph(
-            s_func, 
+            s_func,
             color = DISTANCE_COLOR,
             x_min = 0,
             x_max = 8,
@@ -2008,7 +2008,7 @@ class GraphSPlusC(GraphDistanceVsTime):
         graph.add(tangent)
         self.play(ShowCreation(v_line))
         self.play(
-            graph.shift, 2*DOWN, 
+            graph.shift, 2*DOWN,
             run_time = 4,
             rate_func = there_and_back,
         )
@@ -2169,10 +2169,10 @@ class LowerBound(AreaIsDerivative):
         new_antideriv_diff = self.get_antiderivative_difference("1", "7")
         numbers = [
             TexMobject("%d"%d).next_to(
-                self.coords_to_point(d, 0), 
+                self.coords_to_point(d, 0),
                 DOWN, MED_LARGE_BUFF
             )
-            for d in 1, 7
+            for d in (1, 7)
         ]
         tex_mobs = [new_integral]+new_antideriv_diff[1::2]+numbers
         for tex_mob in tex_mobs:
@@ -2220,7 +2220,7 @@ class LowerBound(AreaIsDerivative):
 
     def get_integral(self, lower_bound, upper_bound):
         result = TexMobject(
-            "\\int", "^"+upper_bound, "_"+lower_bound, 
+            "\\int", "^"+upper_bound, "_"+lower_bound,
             "t(8-t)", "\\,dt"
         )
         result.next_to(self.graph_origin, RIGHT, MED_LARGE_BUFF)
@@ -2245,7 +2245,7 @@ class LowerBound(AreaIsDerivative):
             part.set_color_by_tex(s, YELLOW, substring = False)
             parts.append(part)
         result = VGroup(
-            TexMobject("="), parts[0], 
+            TexMobject("="), parts[0],
             TexMobject("-"), parts[1],
         )
         result.left_part, result.right_part = parts
@@ -2329,12 +2329,12 @@ class FundamentalTheorem(GraphScene):
         )
 
         self.transform_between_riemann_rects(
-            flat_rects, rects, 
+            flat_rects, rects,
             replace_mobject_with_target_in_scene = True,
         )
         self.play(*[
             ApplyMethod(
-                rect.set_fill, None, 
+                rect.set_fill, None,
                 1 if rect is start_rect else low_opacity
             )
             for rect in rects
@@ -2353,13 +2353,13 @@ class FundamentalTheorem(GraphScene):
                 dx_brace.next_to, rects[i], DOWN, 0,
                 *[
                     MaintainPositionRelativeTo(brace.label, brace)
-                    for brace in f_brace, dx_brace
+                    for brace in (f_brace, dx_brace)
                 ]
             )
         self.wait()
         self.play(*it.chain(
             map(FadeOut, [
-                f_brace, dx_brace, 
+                f_brace, dx_brace,
                 f_brace.label, dx_brace.label
             ]),
             [rects.set_fill, None, kwargs["fill_opacity"]]
@@ -2407,8 +2407,8 @@ class FundamentalTheorem(GraphScene):
 
     def write_fundamental_theorem_of_calculus(self):
         words = TextMobject("""
-            Fundamental 
-            theorem of 
+            Fundamental
+            theorem of
             calculus
         """)
         words.to_edge(RIGHT)
@@ -2419,7 +2419,7 @@ class FundamentalTheorem(GraphScene):
     def show_integral_considering_continuum(self):
         self.play(*[
             ApplyMethod(mob.set_fill, None, 0.2)
-            for mob in self.deriv, self.rhs
+            for mob in (self.deriv, self.rhs)
         ])
         self.play(
             self.rects.restore,
@@ -2439,7 +2439,7 @@ class FundamentalTheorem(GraphScene):
                     )
                 )
                 for rect, alpha in zip(
-                    self.rects, 
+                    self.rects,
                     np.linspace(0, 0.8, len(self.rects))
                 )
             ])
@@ -2500,7 +2500,7 @@ class NegativeArea(GraphScene):
             color = VELOCITY_COLOR
         )
         area = self.get_riemann_rectangles(
-            graph, 
+            graph,
             x_min = 0,
             x_max = 8,
             dx = self.small_dx,
@@ -2513,7 +2513,7 @@ class NegativeArea(GraphScene):
         self .play(
             ShowCreation(graph),
             FadeIn(
-                area, 
+                area,
                 run_time = 2,
                 submobject_mode = "lagged_start",
             )
@@ -2564,7 +2564,7 @@ class NegativeArea(GraphScene):
         self.play(FadeIn(car))
         self.play(ShowCreation(arrow))
         self.play(MoveCar(
-            car, end_point, 
+            car, end_point,
             moving_forward = False,
             run_time = 3
         ))
@@ -2600,7 +2600,7 @@ class NegativeArea(GraphScene):
                 equation.get_part_by_tex(tex).get_top(),
                 color = RED,
             )
-            for tex in "ds", "v(t)"
+            for tex in ("ds", "v(t)")
         ])
 
         self.play(
@@ -2641,8 +2641,8 @@ class NegativeArea(GraphScene):
 
         self.play(FadeOut(self.v_line), FadeIn(rect))
         self.play(
-            GrowFromCenter(dt_brace), 
-            GrowFromCenter(v_brace), 
+            GrowFromCenter(dt_brace),
+            GrowFromCenter(v_brace),
             Write(dt_label),
             Write(v_label),
         )
@@ -2760,15 +2760,3 @@ class Thumbnail(Chapter1Thumbnail):
         words.to_edge(UP)
 
         self.add(graph, rects, words)
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/chapter9.py
+++ b/old_projects/eoc/chapter9.py
@@ -1149,9 +1149,9 @@ class Antiderivative(AverageOfSineStart):
         (start_pi, end_pi), (start_zero, end_zero) = start_end_pairs = [
             [
                 m.get_part_by_tex(tex) 
-                for m in integral, rhs
+                for m in (integral, rhs)
             ]
-            for tex in "\\pi", "0"
+            for tex in ("\\pi", "0")
         ]
 
         for tex_mob in integral, rhs:
@@ -1271,7 +1271,7 @@ class Antiderivative(AverageOfSineStart):
             TexMobject("\\over\\,").stretch_to_fit_width(
                 mob.get_width()
             ).move_to(mob)
-            for mob in integral, rhs_without_eq
+            for mob in (integral, rhs_without_eq)
         ])
         frac_lines.shift(
             (integral.get_height()/2 + SMALL_BUFF)*DOWN
@@ -1301,7 +1301,7 @@ class Antiderivative(AverageOfSineStart):
                 integral.get_part_by_tex(tex).copy(),
                 pi_minus_zeros[0].get_part_by_tex(tex)
             )
-            for tex in "\\pi","0"
+            for tex in ("\\pi","0")
         ] + [
             Write(pi_minus_zeros[0].get_part_by_tex("-"))
         ])
@@ -1312,7 +1312,7 @@ class Antiderivative(AverageOfSineStart):
                 ).copy(),
                 pi_minus_zeros[1].get_part_by_tex(tex)
             )
-            for tex in "\\pi", "-", "0"
+            for tex in ("\\pi", "-", "0")
         ])
         self.wait(2)
 
@@ -1514,7 +1514,7 @@ class GeneralAverage(AverageOfContinuousVariable):
             Write(
                 VGroup(*[
                     fraction.get_part_by_tex(tex)
-                    for tex in "int", "f(x)", "dx", "over"
+                    for tex in ("int", "f(x)", "dx", "over")
                 ]),
                 rate_func = squish_rate_func(smooth, 0.25, 0.75),
                 run_time = 4

--- a/old_projects/eoc/footnote.py
+++ b/old_projects/eoc/footnote.py
@@ -135,7 +135,7 @@ class SecondDerivativeGraphically(GraphScene):
         second_deriv.set_color(self.second_deriv_color)
         points = [
             self.input_to_graph_point(x, self.graph)
-            for x in self.x2, self.x3
+            for x in (self.x2, self.x3)
         ]
         words = TextMobject("Change to \\\\ slope")
         words.next_to(
@@ -151,7 +151,7 @@ class SecondDerivativeGraphically(GraphScene):
         self.play(
             Write(words),
             ShowCreation(
-                arrows[0], 
+                arrows[0],
                 rate_func = squish_rate_func(smooth, 0.5, 1)
             ),
             run_time = 2
@@ -161,7 +161,7 @@ class SecondDerivativeGraphically(GraphScene):
             run_time = 3,
             added_anims = [
                 Transform(
-                    *arrows, 
+                    *arrows,
                     run_time = 3,
                     path_arc = 0.75*np.pi
                 ),
@@ -226,7 +226,7 @@ class SecondDerivativeGraphically(GraphScene):
         )
         self.wait(2)
         self.play(*map(FadeOut, [
-            self.graph, self.ss_group, 
+            self.graph, self.ss_group,
             negative_curve, self.second_deriv_words
         ]))
 
@@ -243,11 +243,11 @@ class SecondDerivativeGraphically(GraphScene):
         ]
         arg_rhs_list = [
             TexMobject("(", str(x0), ")", "=", str(rhs))
-            for rhs in 10, 0.4, 0
+            for rhs in (10, 0.4, 0)
         ]
         for graph, arg_rhs in zip(graphs, arg_rhs_list):
             graph.ss_group = self.get_secant_slope_group(
-                x0-1, graph, 
+                x0-1, graph,
                 dx = 0.001,
                 secant_line_color = YELLOW
             )
@@ -426,7 +426,7 @@ class HowToReadNotation(GraphScene, ReconfigurableScene):
         self.setup_axes()
         graph = self.get_graph(lambda x : x**2)
         graph_label = self.get_graph_label(
-            graph, "f(x)", 
+            graph, "f(x)",
             direction = LEFT,
             x_val = 3.3
         )
@@ -529,12 +529,12 @@ class HowToReadNotation(GraphScene, ReconfigurableScene):
         df_dx_groups = self.df_dx_groups.copy()
         df_dx_groups.generate_target()
         df_dx_groups.target.arrange_submobjects(
-            RIGHT, 
+            RIGHT,
             buff = MED_LARGE_BUFF,
             aligned_edge = DOWN
         )
         df_dx_groups.target.next_to(
-            self.df_dx_groups, RIGHT, 
+            self.df_dx_groups, RIGHT,
             buff = 3,
             aligned_edge = DOWN
         )
@@ -560,7 +560,7 @@ class HowToReadNotation(GraphScene, ReconfigurableScene):
         ddf_brace = Brace(h_lines, LEFT, buff = SMALL_BUFF)
         ddf = ddf_brace.get_tex("d(df)", buff = SMALL_BUFF)
         ddf.scale(
-            df_labels[0].get_height()/ddf.get_height(), 
+            df_labels[0].get_height()/ddf.get_height(),
             about_point = ddf.get_right()
         )
         ddf.set_color(MAROON_B)
@@ -630,11 +630,11 @@ class HowToReadNotation(GraphScene, ReconfigurableScene):
             Write(ddf_over_dx_squared.get_part_by_tex("over")),
             *[
                 ReplacementTransform(
-                    mob, 
+                    mob,
                     ddf_over_dx_squared.get_part_by_tex(tex),
-                    path_arc = -np.pi/2,                    
+                    path_arc = -np.pi/2,
                 )
-                for mob, tex in (self.ddf, "df"), (self.dx_squared, "dx")
+                for mob, tex in ((self.ddf, "df"), (self.dx_squared, "dx"))
             ]
         )
         self.wait(2)
@@ -650,10 +650,10 @@ class HowToReadNotation(GraphScene, ReconfigurableScene):
 class Footnote(Scene):
     def construct(self):
         self.add(TextMobject("""
-            Interestingly, there is a notion in math 
-            called the ``exterior derivative'' which 
-            treats this ``d'' as having a more independent 
-            meaning, though it's less related to the 
+            Interestingly, there is a notion in math
+            called the ``exterior derivative'' which
+            treats this ``d'' as having a more independent
+            meaning, though it's less related to the
             intuitions I've introduced in this series.
         """, alignment = ""))
 
@@ -724,19 +724,19 @@ class SecondDerivativeAsAcceleration(Scene):
             func = get_deriv(2),
             color = MAROON_B,
             y_axis_label = "a",
-            y_min = -2, 
+            y_min = -2,
             y_max = 2,
         )
         j_scene = TrajectoryGraphScene(
             func = get_deriv(3),
             color = PINK,
             y_axis_label = "j",
-            y_min = -2, 
+            y_min = -2,
             y_max = 2,
         )
         s_graph, v_graph, a_graph, j_graph = graphs = [
             VGroup(*scene.get_top_level_mobjects())
-            for scene in s_scene, v_scene, a_scene, j_scene
+            for scene in (s_scene, v_scene, a_scene, j_scene)
         ]
         for i, graph in enumerate(graphs):
             graph.scale_to_fit_height(FRAME_Y_RADIUS)
@@ -748,19 +748,19 @@ class SecondDerivativeAsAcceleration(Scene):
         )
         s_words.set_color_by_tex("s(t)", s_scene.graph.get_color())
         v_words = TexMobject(
-            "\\frac{ds}{dt}(t)", "\\Leftrightarrow", 
+            "\\frac{ds}{dt}(t)", "\\Leftrightarrow",
             "\\text{Velocity}"
         )
         v_words.set_color_by_tex("ds", v_scene.graph.get_color())
         j_words = TexMobject(
-            "\\frac{d^3 s}{dt^3}(t)", "\\Leftrightarrow", 
+            "\\frac{d^3 s}{dt^3}(t)", "\\Leftrightarrow",
             "\\text{Jerk}"
         )
         j_words.set_color_by_tex("d^3", j_scene.graph.get_color())
         self.a_words.generate_target()
         words_group = VGroup(s_words, v_words, self.a_words.target, j_words)
         words_group.arrange_submobjects(
-            DOWN, 
+            DOWN,
             buff = MED_LARGE_BUFF,
             aligned_edge = LEFT
         )
@@ -889,29 +889,3 @@ class Thumbnail(SecondDerivativeGraphically):
         tex.to_edge(UP)
 
         self.add(tex)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/old_chapter1.py
+++ b/old_projects/eoc/old_chapter1.py
@@ -723,12 +723,12 @@ class IntroduceTinyChangeInArea(CircleScene):
         self.wait(2)
         self.play(*[
             ApplyMethod(mob.set_color, RED)
-            for mob in pi_R_squared, pi_R_squared2
+            for mob in (pi_R_squared, pi_R_squared2)
         ])
         self.wait()
         self.play(*[
             ApplyMethod(mob.fade, 0.7)
-            for mob in plus, pi_R_squared, pi_R_squared2, minus2
+            for mob in (plus, pi_R_squared, pi_R_squared2, minus2)
         ]) 
         self.wait()
 
@@ -2056,7 +2056,7 @@ class GraphIntegral(GraphScene):
     def show_horizontal_axis(self):
         arrows = [
             Arrow(self.little_r, self.coords_to_point(*coords))
-            for coords in (0, 0), (self.x_max, 0)
+            for coords in ((0, 0), (self.x_max, 0))
         ]
         moving_arrow = arrows[0].copy()
         self.play(

--- a/old_projects/eola/chapter0.py
+++ b/old_projects/eola/chapter0.py
@@ -381,7 +381,7 @@ class LinAlgPyramid(Scene):
         self.wait()
         self.play(*[
             ApplyMethod(m.set_color, DARK_GREY)
-            for m in words[0], rects[0]
+            for m in (words[0], rects[0])
         ])
         self.wait()
         self.list_applications(rects[-1])
@@ -390,7 +390,7 @@ class LinAlgPyramid(Scene):
         height = 1
         rects = [
             Rectangle(height = height, width = width)
-            for width in 8, 5, 2
+            for width in (8, 5, 2)
         ]
         rects[0].shift(2*DOWN)
         for i in 1, 2:
@@ -907,7 +907,7 @@ class ResourceForTeachers(Scene):
         bubble.clear()
         randys = VMobject(*[
             Randolph(color = c)
-            for c in BLUE_D, BLUE_C, BLUE_E
+            for c in (BLUE_D, BLUE_C, BLUE_E)
         ])
         randys.arrange_submobjects(RIGHT)
         randys.scale(0.8)
@@ -937,7 +937,7 @@ class DifferingBackgrounds(Scene):
         ])
         students = VMobject(*[
             Randolph(color = c)
-            for c in BLUE_D, BLUE_C, BLUE_E
+            for c in (BLUE_D, BLUE_C, BLUE_E)
         ])
         modes = ["pondering", "speaking_looking_left", "sassy"]
         students.arrange_submobjects(RIGHT)

--- a/old_projects/eola/chapter1.py
+++ b/old_projects/eola/chapter1.py
@@ -403,7 +403,7 @@ class HelpsToHaveOneThought(Scene):
 
         randys = VMobject(*[
             Randolph(color = color).scale(0.8)
-            for color in BLUE_D, BLUE_C, BLUE_E
+            for color in (BLUE_D, BLUE_C, BLUE_E)
         ])
         randys.arrange_submobjects(RIGHT)
         randys.to_corner(DOWN+LEFT)
@@ -795,7 +795,7 @@ class VectorAdditionNumerically(VectorScene):
             Write(plus, run_time = 1), 
             *[
                 ApplyMethod(mob.shift, v1.get_end())
-                for mob in v2, x_line2, y_line2
+                for mob in (v2, x_line2, y_line2)
             ]
         )
         equals.next_to(coords2, RIGHT)

--- a/old_projects/eola/chapter10.py
+++ b/old_projects/eola/chapter10.py
@@ -9,13 +9,13 @@ class OpeningQuote(Scene):
     def construct(self):
         words = TextMobject(
             "``Last time, I asked: `What does",
-            "mathematics", 
-            """ mean to you?', and some people answered: `The 
-            manipulation of numbers, the manipulation of structures.' 
+            "mathematics",
+            """ mean to you?', and some people answered: `The
+            manipulation of numbers, the manipulation of structures.'
             And if I had asked what""",
             "music",
-            """means to you, would you have answered: `The 
-            manipulation of notes?' '' """, 
+            """means to you, would you have answered: `The
+            manipulation of notes?' '' """,
             enforce_new_line_structure = False,
             alignment = "",
         )
@@ -39,7 +39,7 @@ class StudentsFindThisConfusing(TeacherStudentsScene):
         students = self.get_students()
 
         self.play(
-            Write(title), 
+            Write(title),
             *[
                 ApplyMethod(pi.look_at, title)
                 for pi in self.get_pi_creatures()
@@ -70,8 +70,8 @@ class StudentsFindThisConfusing(TeacherStudentsScene):
         question2 = students[2].bubble.content.copy()
         question2.target = question2.copy()
         question2.target.next_to(
-            question1, DOWN, 
-            aligned_edge = LEFT, 
+            question1, DOWN,
+            aligned_edge = LEFT,
             buff = MED_SMALL_BUFF
         )
         equation = TexMobject(
@@ -176,10 +176,10 @@ class IntroduceExampleTransformation(ExampleTranformationScene):
         self.play(*[
             Transform(*pair)
             for pair in [
-                (i_coords_copy.rect, self.matrix.rect),            
+                (i_coords_copy.rect, self.matrix.rect),
                 (i_coords_copy.get_brackets(), self.matrix.get_brackets()),
                 (
-                    i_coords_copy.get_entries(), 
+                    i_coords_copy.get_entries(),
                     VGroup(*self.matrix.get_mob_matrix()[:,0])
                 )
             ]
@@ -241,7 +241,7 @@ class VectorRemainsOnSpan(ExampleTranformationScene):
         self.wait()
         target_vectors = [
             vector.copy().scale(scalar)
-            for scalar in 2, -2, 1
+            for scalar in (2, -2, 1)
         ]
         for target, time in zip(target_vectors, [1, 2, 2]):
             self.play(Transform(vector, target, run_time = time))
@@ -250,7 +250,7 @@ class VectorRemainsOnSpan(ExampleTranformationScene):
 class IHatAsEigenVector(ExampleTranformationScene):
     def construct(self):
         self.set_color_first_column()
-        self.set_color_x_axis()        
+        self.set_color_x_axis()
         self.apply_transposed_matrix(self.t_matrix, path_arc = 0)
         self.label_i_hat_landing_spot()
 
@@ -269,7 +269,7 @@ class IHatAsEigenVector(ExampleTranformationScene):
         x_axis = self.plane.axes[0]
         targets = [
             self.i_hat.copy().scale(val)
-            for val in -FRAME_X_RADIUS, FRAME_X_RADIUS, 1
+            for val in (-FRAME_X_RADIUS, FRAME_X_RADIUS, 1)
         ]
         lines = [
             Line(v1.get_end(), v2.get_end(), color = YELLOW)
@@ -277,7 +277,7 @@ class IHatAsEigenVector(ExampleTranformationScene):
         ]
         for target, line in zip(targets, lines):
             self.play(
-                ShowCreation(line),                
+                ShowCreation(line),
                 Transform(self.i_hat, target),
             )
         self.wait()
@@ -289,7 +289,7 @@ class IHatAsEigenVector(ExampleTranformationScene):
         array.set_color(X_COLOR)
         array.rect = BackgroundRectangle(array)
         array.add_to_back(array.rect)
-        brace = Brace(self.i_hat, buff = 0)
+        brace = Brace(self.i_hat, buff=0)
         brace.put_at_tip(array)
 
         self.play(GrowFromCenter(brace))
@@ -298,7 +298,7 @@ class IHatAsEigenVector(ExampleTranformationScene):
             Transform(matrix.rect, array.rect),
             Transform(matrix.get_brackets(), array.get_brackets()),
             Transform(
-                VGroup(*matrix.get_mob_matrix()[:,0]), 
+                VGroup(*matrix.get_mob_matrix()[:,0]),
                 array.get_entries()
             ),
         )
@@ -309,7 +309,7 @@ class AllXAxisVectorsAreEigenvectors(ExampleTranformationScene):
         vectors = VGroup(*[
             self.add_vector(u*x*RIGHT, animate = False)
             for x in reversed(range(1, int(FRAME_X_RADIUS)+1))
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         vectors.set_color_by_gradient(YELLOW, X_COLOR)
         self.play(ShowCreation(vectors))
@@ -324,7 +324,7 @@ class SneakierEigenVector(ExampleTranformationScene):
         array = Matrix(coords)
         array.scale(0.7)
         array.set_color(vector.get_color())
-        array.add_to_back(BackgroundRectangle(array))        
+        array.add_to_back(BackgroundRectangle(array))
         array.target = array.copy()
         array.next_to(vector.get_end(), LEFT)
         array.target.next_to(2*vector.get_end(), LEFT)
@@ -339,7 +339,7 @@ class SneakierEigenVector(ExampleTranformationScene):
         self.add_vector(vector)
         self.play(Write(array))
         self.play(
-            ShowCreation(span_line), 
+            ShowCreation(span_line),
             Animation(vector),
             Animation(array),
         )
@@ -360,7 +360,7 @@ class FullSneakyEigenspace(ExampleTranformationScene):
         vectors = VGroup(*[
             self.add_vector(u*x*(LEFT+UP), animate = False)
             for x in reversed(np.arange(0.5, 5, 0.5))
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         vectors.set_color_by_gradient(MAROON_B, YELLOW)
         words = TextMobject("Stretch by 2")
@@ -391,14 +391,14 @@ class NameEigenvectorsAndEigenvalues(ExampleTranformationScene):
         x_vectors = VGroup(*[
             self.add_vector(u*x*RIGHT, animate = False)
             for x in range(int(FRAME_X_RADIUS)+1, 0, -1)
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         x_vectors.set_color_by_gradient(YELLOW, X_COLOR)
         self.remove(x_vectors)
         sneak_vectors = VGroup(*[
             self.add_vector(u*x*(LEFT+UP), animate = False)
             for x in np.arange(int(FRAME_Y_RADIUS), 0, -0.5)
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         sneak_vectors.set_color_by_gradient(MAROON_B, YELLOW)
         self.remove(sneak_vectors)
@@ -431,8 +431,8 @@ class NameEigenvectorsAndEigenvalues(ExampleTranformationScene):
 
         non_eigen = Vector([1, 1], color = PINK)
         non_eigen_span = Line(
-            -FRAME_Y_RADIUS*non_eigen.get_end(), 
-            FRAME_Y_RADIUS*non_eigen.get_end(), 
+            -FRAME_Y_RADIUS*non_eigen.get_end(),
+            FRAME_Y_RADIUS*non_eigen.get_end(),
             color = RED
         )
         non_eigen_words = TextMobject("""
@@ -502,14 +502,14 @@ class EigenvalueNegativeOneHalf(LinearTransformationScene):
         words.add_background_rectangle()
         words.next_to(vector.get_end(), RIGHT)
         span = Line(
-            -FRAME_Y_RADIUS*vector.get_end(), 
+            -FRAME_Y_RADIUS*vector.get_end(),
             FRAME_Y_RADIUS*vector.get_end(),
             color = MAROON_B
         )
 
         self.play(Write(words))
         self.play(
-            ShowCreation(span), 
+            ShowCreation(span),
             Animation(vector),
             Animation(words),
         )
@@ -524,7 +524,7 @@ class EigenvalueNegativeOneHalf(LinearTransformationScene):
             Animation(vector),
         )
         self.wait()
-        
+
 class ThreeDRotationTitle(Scene):
     def construct(self):
         title = TextMobject("3D Rotation")
@@ -561,7 +561,7 @@ class EigenvalueOne(Scene):
 class ContrastMatrixUnderstandingWithEigenvalue(TeacherStudentsScene):
     def construct(self):
         axis_and_rotation = TextMobject(
-            "Rotate", "$30^\\circ$", "around", 
+            "Rotate", "$30^\\circ$", "around",
             "$%s$"%matrix_to_tex_string([2, 3, 1])
         )
         axis_and_rotation[1].set_color(BLUE)
@@ -569,7 +569,7 @@ class ContrastMatrixUnderstandingWithEigenvalue(TeacherStudentsScene):
 
         matrix = Matrix([
             [
-                "\\cos(\\theta)\\cos(\\phi)", 
+                "\\cos(\\theta)\\cos(\\phi)",
                 "-\\sin(\\phi)",
                 "\\cos(\\theta)\\sin(\\phi)",
             ],
@@ -615,7 +615,7 @@ class ContrastMatrixUnderstandingWithEigenvalue(TeacherStudentsScene):
 class CommonPattern(TeacherStudentsScene):
     def construct(self):
         self.teacher_says("""
-            This is a common pattern 
+            This is a common pattern
             in linear algebra.
         """)
         self.random_blink(2)
@@ -625,7 +625,7 @@ class DeduceTransformationFromMatrix(ColumnsToBasisVectors):
         self.setup()
         self.move_matrix_columns([[3, 0], [1, 2]])
         words = TextMobject("""
-            This gives too much weight 
+            This gives too much weight
             to our coordinate system
         """)
         words.add_background_rectangle()
@@ -660,7 +660,7 @@ class SymbolicEigenvectors(Scene):
 
     def introduce_terms(self):
         self.expression = TexMobject(
-            "A", "\\vec{\\textbf{v}}", "=", 
+            "A", "\\vec{\\textbf{v}}", "=",
             "\\lambda", "\\vec{\\textbf{v}}"
         )
         self.expression.scale(1.5)
@@ -705,7 +705,7 @@ class SymbolicEigenvectors(Scene):
         )
         self.wait(2)
         self.play(*map(FadeOut, [
-            A_brace, A_text, 
+            A_brace, A_text,
             lamb_brace, lamb_text,
             v_text, v_arrows
         ]))
@@ -818,7 +818,7 @@ class SymbolicEigenvectors(Scene):
         ))
         self.wait()
         self.play(Transform(
-            q_marks, matrix.get_entries(), 
+            q_marks, matrix.get_entries(),
             submobject_mode = "lagged_start",
             run_time = 2
         ))
@@ -843,7 +843,7 @@ class SymbolicEigenvectors(Scene):
         for mob in lamb, id_text, v2:
             mob.target = mob.copy()
         VGroup(
-            l_paren, lamb.target, id_text.target, 
+            l_paren, lamb.target, id_text.target,
             r_paren, v2.target
         ).arrange_submobjects().next_to(equals).shift(SMALL_BUFF*UP)
         self.play(
@@ -855,7 +855,7 @@ class SymbolicEigenvectors(Scene):
             corner_group, id_brace, id_text_copy, new_lamb
         ]))
         self.expression = VGroup(
-            A, v1, equals, 
+            A, v1, equals,
             VGroup(l_paren, lamb, id_text, r_paren),
             v2
         )
@@ -876,7 +876,7 @@ class SymbolicEigenvectors(Scene):
             lamb_group.target, v2.target
         ).arrange_submobjects().next_to(equals, LEFT)
         self.play(
-            Write(zero), 
+            Write(zero),
             Write(minus),
             *map(MoveToTarget, movers),
             path_arc = np.pi/3
@@ -926,7 +926,7 @@ class SymbolicEigenvectors(Scene):
         vect_words.to_corner(UP+LEFT)
         arrow = Arrow(vect_words.get_bottom(), v2.get_top())
         self.play(
-            Write(vect_words), 
+            Write(vect_words),
             ShowCreation(arrow)
         )
         self.wait()
@@ -1089,11 +1089,11 @@ class TweakLambda(LinearTransformationScene):
             transformations.append(MoveToTarget(mob))
         transformations += [
             Transform(
-                self.i_hat, 
+                self.i_hat,
                 Vector(matrix_transform(RIGHT), color = X_COLOR)
             ),
             Transform(
-                self.j_hat, 
+                self.j_hat,
                 Vector(matrix_transform(UP), color = Y_COLOR)
             ),
         ]
@@ -1149,7 +1149,7 @@ class ShowEigenVectorAfterComputing(LinearTransformationScene):
         v_label = TexMobject(
             "\\vec{\\textbf{v}}",
             "=",
-            "1", 
+            "1",
             "\\vec{\\textbf{v}}",
         )
         v_label.next_to(matrix, RIGHT)
@@ -1246,7 +1246,7 @@ class RevisitExampleTransformation(ExampleTranformationScene):
             coords.rect = BackgroundRectangle(coords)
             coords.add_to_back(coords.rect)
             coords.next_to(
-                vect.get_end(), 
+                vect.get_end(),
                 RIGHT+DOWN if coords is i_coords else RIGHT
             )
         self.play(
@@ -1257,10 +1257,10 @@ class RevisitExampleTransformation(ExampleTranformationScene):
         self.play(*[
             Transform(*pair)
             for pair in [
-                (i_coords.rect, self.matrix.rect),            
+                (i_coords.rect, self.matrix.rect),
                 (i_coords.get_brackets(), self.matrix.get_brackets()),
                 (
-                    i_coords.get_entries(), 
+                    i_coords.get_entries(),
                     VGroup(*self.matrix.get_mob_matrix()[:,0])
                 )
             ]
@@ -1299,7 +1299,7 @@ class RevisitExampleTransformation(ExampleTranformationScene):
         rect.target = BackgroundRectangle(
             VGroup(l_bracket.target, r_bracket.target)
         )
-        result = map(MoveToTarget, movers) 
+        result = map(MoveToTarget, movers)
         result += map(Write, [minus1, minus2])
         result += map(Animation, [
             self.matrix.get_mob_matrix()[i, 1-i]
@@ -1365,7 +1365,7 @@ class RevisitExampleTransformation(ExampleTranformationScene):
         )
         self.wait()
         self.play(
-            Write(parens),            
+            Write(parens),
             MoveToTarget(three_minus_lamb),
             MoveToTarget(two_minus_lamb),
             run_time = 2
@@ -1397,9 +1397,9 @@ class RevisitExampleTransformation(ExampleTranformationScene):
         )
         self.wait()
         faders = [
-            det_text, equals, parens, 
+            det_text, equals, parens,
             three_minus_lamb, two_minus_lamb,
-            brace, brace_text, equals_0, 
+            brace, brace_text, equals_0,
         ]
         if to_fade is not None:
             faders.append(to_fade)
@@ -1407,7 +1407,7 @@ class RevisitExampleTransformation(ExampleTranformationScene):
             map(FadeOut, faders),
             [
                 lambda_equals_two.scale_in_place, 1.3,
-                lambda_equals_two.next_to, self.matrix, DOWN                
+                lambda_equals_two.next_to, self.matrix, DOWN
             ]
         ))
         self.add_foreground_mobject(lambda_equals_two)
@@ -1422,8 +1422,8 @@ class RevisitExampleTransformation(ExampleTranformationScene):
             two.move_to(lamb)
             self.play(Transform(lamb, two))
         self.play(*it.chain(
-            [mob.restore for mob in self.plane, self.i_hat, self.j_hat],
-            map(Animation, self.foreground_mobjects),            
+            [mob.restore for mob in (self.plane, self.i_hat, self.j_hat)],
+            map(Animation, self.foreground_mobjects),
         ))
 
         xy_array = Matrix(["x", "y"])
@@ -1442,13 +1442,13 @@ class RevisitExampleTransformation(ExampleTranformationScene):
         vectors = VGroup(*[
             self.add_vector(u*x*(LEFT+UP), animate = False)
             for x in range(4, 0, -1)
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         vectors.set_color_by_gradient(MAROON_B, YELLOW)
         vectors.save_state()
         self.play(
             ShowCreation(
-                vectors, 
+                vectors,
                 submobject_mode = "lagged_start",
                 run_time = 2
             ),
@@ -1460,7 +1460,7 @@ class RevisitExampleTransformation(ExampleTranformationScene):
         )
         self.wait()
         self.play(*it.chain(
-            [mob.restore for mob in self.plane, self.i_hat, self.j_hat, vectors],
+            [mob.restore for mob in (self.plane, self.i_hat, self.j_hat, vectors)],
             map(FadeOut, [xy_array, equals, zero_array]),
             map(Animation, self.foreground_mobjects)
         ))
@@ -1534,7 +1534,7 @@ class SolveRotationEigenvalues(Rotate90Degrees):
         self.apply_transposed_matrix(self.t_matrix, run_time = 0)
         self.wait()
         diag_entries = [
-            self.matrix.get_mob_matrix()[i, i] 
+            self.matrix.get_mob_matrix()[i, i]
             for i in range(2)
         ]
         off_diag_entries = [
@@ -1593,13 +1593,13 @@ class SolveRotationEigenvalues(Rotate90Degrees):
         self.wait()
 
         interesting_tidbit = TextMobject("""
-            Interestingly, though, the fact that multiplication by i 
-            in the complex plane looks like a 90 degree rotation is 
-            related to the fact that i is an eigenvalue of this 
-            transformation of 2d real vectors. The specifics of this 
-            are a little beyond what I want to talk about today, but 
-            note that that eigenvalues which are complex numbers 
-            generally correspond to some kind of rotation in the 
+            Interestingly, though, the fact that multiplication by i
+            in the complex plane looks like a 90 degree rotation is
+            related to the fact that i is an eigenvalue of this
+            transformation of 2d real vectors. The specifics of this
+            are a little beyond what I want to talk about today, but
+            note that that eigenvalues which are complex numbers
+            generally correspond to some kind of rotation in the
             transformation.
         """, alignment = "")
         interesting_tidbit.add_background_rectangle()
@@ -1635,7 +1635,7 @@ class ShearExample(RevisitExampleTransformation):
         vectors = VGroup(*[
             self.add_vector(u*x*RIGHT, animate = False)
             for x in range(int(FRAME_X_RADIUS)+1, 0, -1)
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         vectors.set_color_by_gradient(YELLOW, X_COLOR)
         words = VGroup(
@@ -1702,7 +1702,7 @@ class ShearExample(RevisitExampleTransformation):
         )
         self.wait()
         self.play(
-            Write(parens),            
+            Write(parens),
             MoveToTarget(three_minus_lamb),
             MoveToTarget(two_minus_lamb),
             run_time = 2
@@ -1733,9 +1733,9 @@ class ShearExample(RevisitExampleTransformation):
         )
         self.wait()
         # faders = [
-        #     det_text, equals, parens, 
+        #     det_text, equals, parens,
         #     three_minus_lamb, two_minus_lamb,
-        #     brace, brace_text, equals_0, 
+        #     brace, brace_text, equals_0,
         # ]
         # if to_fade is not None:
         #     faders.append(to_fade)
@@ -1743,7 +1743,7 @@ class ShearExample(RevisitExampleTransformation):
         #     map(FadeOut, faders),
         #     [
         #         lambda_equals_two.scale_in_place, 1.3,
-        #         lambda_equals_two.next_to, self.matrix, DOWN                
+        #         lambda_equals_two.next_to, self.matrix, DOWN
         #     ]
         # ))
         # self.add_foreground_mobject(lambda_equals_two)
@@ -1753,7 +1753,7 @@ class ShearExample(RevisitExampleTransformation):
 class EigenvalueCanHaveMultipleEigenVectors(TeacherStudentsScene):
     def construct(self):
         self.teacher_says("""
-            A single eigenvalue can 
+            A single eigenvalue can
             have more that a line
             full of eigenvectors
         """)
@@ -1952,7 +1952,7 @@ class RepeatedMultiplicationInAction(Scene):
             *map(MoveToTarget, scalars + [l_bracket])
         )
         self.wait()
-        #nth multiplications                    
+        #nth multiplications
         for scalar in scalars:
             scalar.exp = VectorizedPoint(scalar.get_corner(UP+RIGHT))
             scalar.exp.shift(SMALL_BUFF*RIGHT/2.)
@@ -2110,9 +2110,9 @@ class ChangeToEigenBasis(ExampleTranformationScene):
             VGroup(*[
                 self.add_vector(u*x*vect, animate = False)
                 for x in range(num, 0, -1)
-                for u in -1, 1
+                for u in (-1, 1)
             ])
-            for vect, num in (RIGHT, 7), (UP+LEFT, 4)
+            for vect, num in ((RIGHT, 7), (UP+LEFT, 4))
         ]
         x_vectors.set_color_by_gradient(YELLOW, X_COLOR)
         v_vectors.set_color_by_gradient(MAROON_B, YELLOW)
@@ -2122,7 +2122,7 @@ class ChangeToEigenBasis(ExampleTranformationScene):
         self.wait()
         self.plane.save_state()
         self.apply_transposed_matrix(
-            self.t_matrix, 
+            self.t_matrix,
             rate_func = there_and_back,
             path_arc = 0
         )
@@ -2167,7 +2167,7 @@ class ChangeToEigenBasis(ExampleTranformationScene):
 
         cob_matrix = Matrix(np.array([
             list(vect.entries.target)
-            for vect in b1, b2
+            for vect in (b1, b2)
         ]).T)
         cob_matrix.rect = BackgroundRectangle(cob_matrix)
         cob_matrix.add_to_back(cob_matrix.rect)
@@ -2178,7 +2178,7 @@ class ChangeToEigenBasis(ExampleTranformationScene):
         brace_text.next_to(brace, DOWN, aligned_edge = LEFT)
         brace_text.add_background_rectangle()
 
-        copies = [vect.coords.copy() for vect in b1, b2]
+        copies = [vect.coords.copy() for vect in (b1, b2)]
         self.to_fade += copies
         self.add(*copies)
         self.play(
@@ -2207,8 +2207,8 @@ class ChangeToEigenBasis(ExampleTranformationScene):
             self.matrix, LEFT, buff = neg_1.get_width()+2*SMALL_BUFF
         )
         neg_1.next_to(
-            inv_cob.target.get_corner(UP+RIGHT), 
-            RIGHT, 
+            inv_cob.target.get_corner(UP+RIGHT),
+            RIGHT,
         )
         self.play(
             MoveToTarget(inv_cob, path_arc = -np.pi/2),
@@ -2219,7 +2219,7 @@ class ChangeToEigenBasis(ExampleTranformationScene):
         self.play(*map(FadeOut, self.to_fade))
         self.wait()
         self.play(FadeOut(self.plane))
-        cob_transform = self.get_matrix_transformation([[1, 0], [-1, 1]])        
+        cob_transform = self.get_matrix_transformation([[1, 0], [-1, 1]])
         ApplyMethod(self.plane.apply_function, cob_transform).update(1)
         self.plane.main_lines.set_color(BLUE_D)
         self.plane.axes.set_color(WHITE)
@@ -2281,19 +2281,3 @@ class CannotDoWithWithAllTransformations(TeacherStudentsScene):
         """)
         self.change_student_modes(*["tired"]*3)
         self.random_blink(2)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eola/chapter11.py
+++ b/old_projects/eola/chapter11.py
@@ -26,14 +26,14 @@ class CSStudent(Student):
         "color" : PURPLE_E,
         "flip_at_start" : True,
         "name" : "CS Student"
-    } 
+    }
 
 class OpeningQuote(Scene):
     def construct(self):
         words = TextMobject(
             "``Such",
-            "axioms,", 
-            "together with other unmotivated definitions,", 
+            "axioms,",
+            "together with other unmotivated definitions,",
             "serve mathematicians mainly by making it",
             "difficult for the uninitiated",
             "to master their subject, thereby elevating its authority.''",
@@ -93,7 +93,7 @@ class WhatIsA2DVector(LinearTransformationScene):
         coords.next_to(v.get_end(), RIGHT)
 
         two_d_vector = TextMobject(
-            "``Two-dimensional ", "vector", "''", 
+            "``Two-dimensional ", "vector", "''",
             arg_separator = ""
         )
         two_d_vector.set_color_by_tex("vector", YELLOW)
@@ -181,7 +181,7 @@ class WhatIsA2DVector(LinearTransformationScene):
             ]),
             [ApplyMethod(s.change_mode, "plain") for s in students],
             map(Animation, [cs_student.bubble, cs_student.arrow]),
-            [mob.restore for mob in cs_student.v, cs_student.coords],
+            [mob.restore for mob in (cs_student.v, cs_student.coords)],
         ))
         bubble = cs_student.get_bubble(SpeechBubble, width = 4, height = 3)
         bubble.set_fill(BLACK, opacity = 1)
@@ -198,9 +198,9 @@ class WhatIsA2DVector(LinearTransformationScene):
 class HigherDimensionalVectorsNumerically(Scene):
     def construct(self):
         words = VGroup(*map(TextMobject, [
-            "4D vector", 
-            "5D vector", 
-            "100D vector", 
+            "4D vector",
+            "5D vector",
+            "100D vector",
         ]))
         words.arrange_submobjects(RIGHT, buff = LARGE_BUFF*2)
         words.to_edge(UP)
@@ -225,7 +225,7 @@ class HigherDimensionalVectorsNumerically(Scene):
             brace = Brace(v, direction)
             brace.move_to(v)
             v.target.next_to(brace, -direction)
-            text = brace.get_text("%d numbers"%dim)            
+            text = brace.get_text("%d numbers"%dim)
             self.play(
                 MoveToTarget(v),
                 GrowFromCenter(brace),
@@ -238,11 +238,11 @@ class HigherDimensionalVectorsNumerically(Scene):
                     entries[i],
                     entries[i].copy().scale_in_place(1.2).set_color(WHITE),
                     rate_func = squish_rate_func(
-                        there_and_back, 
-                        i/(2.*num_entries), 
+                        there_and_back,
+                        i/(2.*num_entries),
                         i/(2.*num_entries)+0.5
                     ),
-                    run_time = 2                    
+                    run_time = 2
                 )
                 for i in range(num_entries)
             ])
@@ -251,7 +251,7 @@ class HigherDimensionalVectorsNumerically(Scene):
 class HyperCube(VMobject):
     CONFIG = {
         "color" : BLUE_C,
-        "color2" : BLUE_D, 
+        "color2" : BLUE_D,
         "dims" : 4,
     }
     def generate_points(self):
@@ -283,7 +283,7 @@ class AskAbout4DPhysicsStudent(Scene):
         hyper_cube = HyperCube()
         thought_mobs = []
         for i, mob in enumerate([line, square, cube, hyper_cube]):
-            mob.scale_to_fit_height(2)            
+            mob.scale_to_fit_height(2)
             tex = TexMobject("%dD"%(i+1))
             tex.next_to(mob, UP)
             group = VGroup(mob, tex)
@@ -380,7 +380,7 @@ class ManyCoordinateSystems(LinearTransformationScene):
         coord1, coord2 = array.get_entries().copy()
         for coord, vect in (coord1, self.i_hat), (coord2, self.j_hat):
             coord.target = coord.copy().next_to(
-                vect.target.get_end()/2, 
+                vect.target.get_end()/2,
                 rotate_vector(vect.get_end(), -np.pi/2)
             )
 
@@ -409,9 +409,9 @@ class DeterminantAndEigenvectorDontCare(LinearTransformationScene):
     }
     def construct(self):
         words = TextMobject(
-            "Determinant", 
-            "and", 
-            "eigenvectors", 
+            "Determinant",
+            "and",
+            "eigenvectors",
             "don't \\\\ care about the coordinate system"
         )
         words.set_color_by_tex("Determinant", YELLOW)
@@ -455,7 +455,7 @@ class DeterminantAndEigenvectorDontCare(LinearTransformationScene):
             Animation(words)
         )
         self.wait()
-        
+
         self.add_transformable_mobject(blob)
         self.add_moving_mobject(det_label, det_label_target)
         for vector in eigenvectors:
@@ -463,12 +463,12 @@ class DeterminantAndEigenvectorDontCare(LinearTransformationScene):
         self.remove(self.plane)
         non_plane_mobs = self.get_mobjects()
         self.add(self.plane, *non_plane_mobs)
-        
+
         cob_matrices = [
             None,
             [[1, -1], [-3, -1]],
             [[-1, 2], [-0.5, -1]],
-        ] 
+        ]
         def special_rate_func(t):
             if t < 0.3:
                 return smooth(t/0.3)
@@ -495,7 +495,7 @@ class DeterminantAndEigenvectorDontCare(LinearTransformationScene):
             )
 
 
-        
+
 
     def get_eigenvectors(self):
         vals, (eig_matrix) = np.linalg.eig(self.t_matrix.T)
@@ -505,7 +505,7 @@ class DeterminantAndEigenvectorDontCare(LinearTransformationScene):
             vectors = VGroup(*[
                 Vector(u*x*v)
                 for x in range(7, 0, -1)
-                for u in -1, 1
+                for u in (-1, 1)
             ])
             vectors.set_color_by_gradient(MAROON_A, MAROON_C)
             result += list(vectors)
@@ -583,7 +583,7 @@ class FunctionGraphScene(Scene):
         self.add(self.axes)
         self.graphs = []
 
-    def get_function_graph(self, func = None, animate = True, 
+    def get_function_graph(self, func = None, animate = True,
                            add = True, **kwargs):
         index = len(self.graphs)
         if func is None:
@@ -661,7 +661,7 @@ class AddTwoFunctions(FunctionGraphScene):
         sum_def = self.get_sum_definition(DecimalNumber(curr_x_point[0]))
         # sum_def.scale_to_fit_width(FRAME_X_RADIUS-1)
         sum_def.to_corner(UP+LEFT)
-        arrow = Arrow(sum_def[2].get_bottom(), curr_x_point, color = WHITE)        
+        arrow = Arrow(sum_def[2].get_bottom(), curr_x_point, color = WHITE)
         prefix = sum_def[0]
         suffix = VGroup(*sum_def[1:])
         rect = BackgroundRectangle(sum_def)
@@ -672,7 +672,7 @@ class AddTwoFunctions(FunctionGraphScene):
             Write(prefix, run_time = 2),
             FadeIn(brace)
         )
-        self.wait()        
+        self.wait()
         for lines in f_lines, g_lines:
             self.add_lines(lines)
         self.play(*map(FadeOut, [f_graph, g_graph]))
@@ -716,7 +716,7 @@ class AddTwoFunctions(FunctionGraphScene):
 
     def get_sum_definition(self, input_mob):
         result = VGroup(*it.chain(
-            TexMobject("(f+g)", "("), 
+            TexMobject("(f+g)", "("),
             [input_mob.copy()],
             TexMobject(")", "=", "f("),
             [input_mob.copy()],
@@ -739,7 +739,7 @@ class AddTwoFunctions(FunctionGraphScene):
             align_perfectly = f_line.get_end()[1]*g_line.get_end()[1] > 0
             dot = Dot(g_line.get_end(), radius = 0.07)
             g_line.shift(f_line.get_end()-g_line.get_start())
-            dot.target = Dot(g_line.get_end())            
+            dot.target = Dot(g_line.get_end())
             if not align_perfectly:
                 g_line.shift(self.line_to_line_buff*RIGHT)
             dots.add(dot)
@@ -756,7 +756,7 @@ class AddTwoFunctions(FunctionGraphScene):
             }
         self.play(*[
             MoveToTarget(mob, **kwargs)
-            for mob in g_lines, dots
+            for mob in (g_lines, dots)
         ])
         # self.play(
         #     *[mob.fade for mob in g_lines, f_lines]+[
@@ -859,7 +859,7 @@ class ShowSlopes(Animation):
         Animation.__init__(self, line, **kwargs)
 
     def update_mobject(self, alpha):
-        f = self.graph.point_from_proportion        
+        f = self.graph.point_from_proportion
         low, high = map(f, np.clip([alpha-self.dx, alpha+self.dx], 0, 1))
         slope = (high[1]-low[1])/(high[0]-low[0])
         self.mobject.restore()
@@ -933,7 +933,7 @@ class FromVectorsToFunctions(VectorScene):
         self.wait()
         self.play(*[
             ApplyMethod(mob.shift, FRAME_WIDTH*RIGHT)
-            for mob in axes, everything
+            for mob in (axes, everything)
         ] + [Animation(words)]
         )
         self.play(ShowCreation(graph), Animation(words))
@@ -1064,7 +1064,7 @@ class FormalDefinitionOfLinear(LinearTransformationScene):
         "include_background_plane" : False,
         "t_matrix" : [[1, 1], [-0.5, 1]],
         "w_coords" : [1, 1],
-        "v_coords" : [1, -2],        
+        "v_coords" : [1, -2],
         "foreground_plane_kwargs" : {
             "x_radius" : FRAME_WIDTH,
             "y_radius" : FRAME_HEIGHT,
@@ -1171,7 +1171,7 @@ class FormalDefinitionOfLinear(LinearTransformationScene):
         point = transform(vw_sum.get_end())
         vw_label.target.next_to(point, UP)
         self.apply_transposed_matrix(
-            self.t_matrix, 
+            self.t_matrix,
             added_anims = [MoveToTarget(vw_label)]
         )
         self.wait()
@@ -1202,7 +1202,7 @@ class FormalDefinitionOfLinear(LinearTransformationScene):
         self.plane.restore()
         self.play(FadeIn(self.plane), *map(Animation, self.foreground_mobjects))
         self.transformable_mobjects = []
-        self.moving_vectors = []        
+        self.moving_vectors = []
         self.transformable_labels = []
         self.moving_mobjects = []
         self.add_transformable_mobject(self.plane)
@@ -1237,7 +1237,7 @@ class FormalDefinitionOfLinear(LinearTransformationScene):
         scaled_v_label.target.add_background_rectangle()
 
         self.apply_transposed_matrix(
-            self.t_matrix, 
+            self.t_matrix,
             added_anims = [MoveToTarget(scaled_v_label)]
         )
         self.wait()
@@ -1254,7 +1254,7 @@ class FormalDefinitionOfLinear(LinearTransformationScene):
         self.play(Write(rhs))
         self.wait()
         faders = [
-            scaled_v_label, scaled_v, v_copy, 
+            scaled_v_label, scaled_v, v_copy,
             v, rhs
         ] + self.transformable_labels + self.moving_vectors
         self.play(*map(FadeOut, faders))
@@ -1276,7 +1276,7 @@ class FormalDefinitionOfLinear(LinearTransformationScene):
 
         self.play(FadeIn(randy))
         self.play(
-            ShowCreation(bubble),            
+            ShowCreation(bubble),
             Write(words),
             randy.change_mode, "speaking",
         )
@@ -1327,7 +1327,7 @@ class DerivativeIsLinear(Scene):
         deriv_tex = "\\dfrac{d}{dx}"
         deriv_additivity = TexMobject(
             deriv_tex, "(", "x^3", "+", "x^2", ")", "=",
-            deriv_tex, "(", "x^3", ")", "+", 
+            deriv_tex, "(", "x^3", ")", "+",
             deriv_tex, "(", "x^2", ")"
         )
         deriv_scaling = TexMobject(
@@ -1362,7 +1362,7 @@ class DerivativeIsLinear(Scene):
         self.point_out(inner_sum)
         self.point_out(outer_sum_deriv)
         self.wait()
-        self.point_out(outer_deriv1, outer_deriv2)        
+        self.point_out(outer_deriv1, outer_deriv2)
         self.point_out(inner_func1, inner_func2)
         self.point_out(plus)
         self.wait()
@@ -1405,7 +1405,7 @@ class ProposeDerivativeAsMatrix(TeacherStudentsScene):
         self.teacher_says(
             """
             Let's describe the
-            derivative with 
+            derivative with
             a matrix
             """,
             target_mode = "hooray"
@@ -1453,8 +1453,8 @@ class GeneneralPolynomialCoordinates(Scene):
             "a_n", "x^n", "+",
             "a_{n-1}", "x^{n-1}", "+",
             "\\cdots",
-            "a_1", "x", "+",             
-            "a_0", 
+            "a_1", "x", "+",
+            "a_0",
         )
         poly.set_color_by_tex("a_n", YELLOW)
         poly.set_color_by_tex("a_{n-1}", MAROON_B)
@@ -1477,8 +1477,8 @@ class GeneneralPolynomialCoordinates(Scene):
         group.to_edge(RIGHT)
 
         pre_entries = VGroup(
-            poly[-1], poly[-4], poly[-5], 
-            poly[3], poly[0], 
+            poly[-1], poly[-4], poly[-5],
+            poly[3], poly[0],
             VectorizedPoint(poly.get_left()),
             VectorizedPoint(poly.get_left()),
         )
@@ -1518,7 +1518,7 @@ class IntroducePolynomialSpace(Scene):
         cloud = ThoughtBubble()[-1]
         cloud.stretch_to_fit_height(6)
         cloud.center()
-        
+
 
         polys = VGroup(
             TexMobject("x^2", "+", "3", "x", "+", "5"),
@@ -1660,7 +1660,7 @@ class IntroducePolynomialSpace(Scene):
             TexMobject("+0", "x^3").set_color_by_tex("x^3", MAROON_B),
             TexMobject("+0", "x^4").set_color_by_tex("x^4", YELLOW),
             TexMobject("\\vdots")
-        ]        
+        ]
         for entry, term in zip(entries, terms+more_terms):
             term.next_to(entry, LEFT, buff = LARGE_BUFF)
         more_terms[-1].shift(MED_SMALL_BUFF*LEFT)
@@ -1668,7 +1668,7 @@ class IntroducePolynomialSpace(Scene):
         self.play(Transform(self.poly1, target))
         self.wait()
         self.play(FadeIn(
-            VGroup(*more_terms), 
+            VGroup(*more_terms),
             submobject_mode = "lagged_start",
             run_time = 2
         ))
@@ -1704,7 +1704,7 @@ class IntroducePolynomialSpace(Scene):
     def derivative_as_matrix(self):
         matrix = Matrix([
             [
-                str(j) if j == i+1 else "0" 
+                str(j) if j == i+1 else "0"
                 for j in range(4)
             ] + ["\\cdots"]
             for i in range(4)
@@ -1747,7 +1747,7 @@ class IntroducePolynomialSpace(Scene):
         matrix.target.to_corner(DOWN+LEFT).shift(0.25*UP)
         deriv.generate_target()
         deriv.target.next_to(
-            matrix.target, UP, 
+            matrix.target, UP,
             buff = MED_SMALL_BUFF,
             aligned_edge = LEFT
         )
@@ -1779,14 +1779,14 @@ class IntroducePolynomialSpace(Scene):
             self.play(Transform(coef.copy(), entry))
             to_remove += self.get_mobjects_from_last_animation()
         self.play(Write(array.get_entries()[-1]))
-        to_remove += self.get_mobjects_from_last_animation()        
+        to_remove += self.get_mobjects_from_last_animation()
         self.remove(*to_remove)
         self.add(array)
 
         eq1, eq2 = TexMobject("="), TexMobject("=")
         eq1.next_to(poly)
         eq2.next_to(array)
-        
+
         poly_result = TexMobject(
             "3", "x^2", "+",
             "10", "x", "+",
@@ -1891,7 +1891,7 @@ class MatrixVectorMultiplicationAndDerivative(TeacherStudentsScene):
             Write(group)
         )
         self.random_blink()
-        group.generate_target()        
+        group.generate_target()
         group.target.scale(0.8)
         words = TextMobject("Linear transformations")
         h_line = Line(ORIGIN, RIGHT).scale(words.get_width())
@@ -1953,7 +1953,7 @@ class BackToTheQuestion(TeacherStudentsScene):
         self.student_says(
             """
             Wait...so how does
-            this relate to what vectors 
+            this relate to what vectors
             really are?
             """,
             target_mode = "confused"
@@ -2036,7 +2036,7 @@ class ShowVectorSpaces(Scene):
             Line(
                 h_line.get_center(), FRAME_Y_RADIUS*DOWN
             ).shift(vect*FRAME_X_RADIUS/3.)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ]
         vectors = self.get_vectors()
         vectors.shift(LEFT*FRAME_X_RADIUS*(2./3))
@@ -2121,7 +2121,7 @@ class MathematicianSpeakingToAll(Scene):
         mathy = Mathematician().to_corner(DOWN+LEFT)
         others = VGroup(*[
             Randolph().flip().set_color(color)
-            for color in BLUE_D, GREEN_E, GOLD_E, BLUE_C
+            for color in (BLUE_D, GREEN_E, GOLD_E, BLUE_C)
         ])
         others.arrange_submobjects()
         others.scale(0.8)
@@ -2172,39 +2172,39 @@ class ListAxioms(Scene):
         u_tex, v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in "uvw"]
         axioms = VGroup(*it.starmap(TexMobject, [
             (
-                "1. \\,", 
-                u_tex, "+", "(", v_tex, "+", w_tex, ")=(", 
+                "1. \\,",
+                u_tex, "+", "(", v_tex, "+", w_tex, ")=(",
                 u_tex, "+", v_tex, ")+", w_tex
             ),
-            (   "2. \\,", 
+            (   "2. \\,",
                 v_tex, "+", w_tex, "=", w_tex, "+", v_tex
             ),
             (
-                "3. \\,", 
+                "3. \\,",
                 "\\text{There is a vector }", "\\textbf{0}",
                 "\\text{ such that }", "\\textbf{0}+", v_tex,
                 "=", v_tex, "\\text{ for all }", v_tex
             ),
             (
-                "4. \\,", 
-                "\\text{For every vector }", v_tex, 
+                "4. \\,",
+                "\\text{For every vector }", v_tex,
                 "\\text{ there is a vector }", "-", v_tex,
                 "\\text{ so that }", v_tex, "+", "(-", v_tex, ")=\\textbf{0}"
             ),
-            (   "5. \\,", 
+            (   "5. \\,",
                 "a", "(", "b", v_tex, ")=(", "a", "b", ")", v_tex
             ),
-            (  
-                "6. \\,", 
+            (
+                "6. \\,",
                 "1", v_tex, "=", v_tex
             ),
             (
-                "7. \\,", 
-                "a", "(", v_tex, "+", w_tex, ")", "=", 
+                "7. \\,",
+                "a", "(", v_tex, "+", w_tex, ")", "=",
                 "a", v_tex, "+", "a", w_tex
             ),
             (
-                "8. \\,", 
+                "8. \\,",
                 "(", "a", "+", "b", ")", v_tex, "=",
                 "a", v_tex, "+", "b", v_tex
             ),
@@ -2246,7 +2246,7 @@ class AxiomsAreInterface(Scene):
         mathy.change_mode("pondering")
         others = [
             Randolph().flip().set_color(color)
-            for color in BLUE_D, GREEN_E, GOLD_E, BLUE_C
+            for color in (BLUE_D, GREEN_E, GOLD_E, BLUE_C)
         ]
         others = VGroup(
             VGroup(*others[:2]),
@@ -2309,9 +2309,9 @@ class VectorSpaceOfPiCreatures(Scene):
             pi.change_mode(random.choice([
                 "pondering", "pondering",
                 "happy", "happy", "happy",
-                "confused", 
-                "angry", "erm", "sassy", "hooray", 
-                "speaking", "tired", 
+                "confused",
+                "angry", "erm", "sassy", "hooray",
+                "speaking", "tired",
                 "plain", "plain"
             ]))
             if random.random() < 0.5:
@@ -2336,7 +2336,7 @@ class VectorSpaceOfPiCreatures(Scene):
 
     def show_sum(self, creatures):
         def is_valid(pi1, pi2, pi3):
-            if len(set([pi.get_color() for pi in pi1, pi2, pi3])) < 3:
+            if len(set([pi.get_color() for pi in (pi1, pi2, pi3)])) < 3:
                 return False
             if pi1.is_flipped()^pi2.is_flipped():
                 return False
@@ -2421,7 +2421,7 @@ class TextbooksAreAbstract(TeacherStudentsScene):
         self.random_blink(3)
         self.teacher_says(
             """
-            For each new concept, 
+            For each new concept,
             contemplate it for 2d space
             with grid lines...
             """
@@ -2475,14 +2475,14 @@ class WhatIsThree(Scene):
         triplets = [
             VGroup(*[
                 PiCreature(color = color).scale(0.4)
-                for color in BLUE_E, BLUE_C, BLUE_D
+                for color in (BLUE_E, BLUE_C, BLUE_D)
             ]),
             VGroup(*[HyperCube().scale(0.3) for x in range(3)]),
             VGroup(*[Vector(RIGHT) for x in range(3)]),
             TexMobject("""
                 \\Big\\{
-                    \\emptyset, 
-                    \\{\\emptyset\\}, 
+                    \\emptyset,
+                    \\{\\emptyset\\},
                     \\{\\{\\emptyset\\}, \\emptyset\\}
                 \\Big\\}
             """)
@@ -2503,7 +2503,7 @@ class WhatIsThree(Scene):
         self.wait()
         self.play(*[
             Transform(
-                trip, three, 
+                trip, three,
                 submobject_mode = "lagged_start",
                 run_time = 2
             )
@@ -2513,7 +2513,7 @@ class WhatIsThree(Scene):
 class IStillRecommendConcrete(TeacherStudentsScene):
     def construct(self):
         self.teacher_says("""
-            I still recommend 
+            I still recommend
             thinking concretely
         """)
         self.random_blink(2)
@@ -2544,31 +2544,3 @@ class GoodLuck(TeacherStudentsScene):
         )
         self.change_student_modes(*["happy"]*3)
         self.random_blink(3)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eola/chapter2.py
+++ b/old_projects/eola/chapter2.py
@@ -4,11 +4,11 @@ from eola.chapter1 import plane_wave_homotopy
 class OpeningQuote(Scene):
     def construct(self):
         words = TextMobject("""
-            Mathematics requires a small dose, not of genius, 
-            but of an imaginative freedom which, in a larger 
+            Mathematics requires a small dose, not of genius,
+            but of an imaginative freedom which, in a larger
             dose, would be insanity.
         """)
-        words.to_edge(UP)    
+        words.to_edge(UP)
         for mob in words.submobjects[49:49+18]:
             mob.set_color(GREEN)
         author = TextMobject("-Angus K. Rodgers")
@@ -61,11 +61,11 @@ class CoordinatesAsScalars(VectorScene):
 
         i_hat, j_hat = self.get_basis_vectors()
         new_i_hat = Vector(
-            self.vector_coords[0]*i_hat.get_end(), 
+            self.vector_coords[0]*i_hat.get_end(),
             color = X_COLOR
         )
         new_j_hat = Vector(
-            self.vector_coords[1]*j_hat.get_end(), 
+            self.vector_coords[1]*j_hat.get_end(),
             color = Y_COLOR
         )
         VMobject(i_hat, new_i_hat).shift(3*LEFT)
@@ -112,21 +112,21 @@ class CoordinatesAsScalars(VectorScene):
         i_hat, j_hat = self.get_basis_vectors()
         self.add_vector(i_hat)
         i_hat_label = self.label_vector(
-            i_hat, "\\hat{\\imath}", 
-            color = X_COLOR, 
+            i_hat, "\\hat{\\imath}",
+            color = X_COLOR,
             label_scale_factor = 1
         )
         self.add_vector(j_hat)
         j_hat_label = self.label_vector(
-            j_hat, "\\hat{\\jmath}", 
-            color = Y_COLOR, 
+            j_hat, "\\hat{\\jmath}",
+            color = Y_COLOR,
             label_scale_factor = 1
         )
         self.wait()
 
         x, y = new_array.get_mob_matrix().flatten()
         for coord, v, label, factor, shift_right in [
-            (x, i_hat, i_hat_label, self.vector_coords[0], False), 
+            (x, i_hat, i_hat_label, self.vector_coords[0], False),
             (y, j_hat, j_hat_label, self.vector_coords[1], True)
             ]:
             faded_v = v.copy().fade(0.7)
@@ -153,8 +153,8 @@ class CoordinatesAsScalars(VectorScene):
 
     def show_symbolic_sum(self, new_array, vector):
         new_mob = TexMobject([
-            "(%d)\\hat{\\imath}"%self.vector_coords[0], 
-            "+", 
+            "(%d)\\hat{\\imath}"%self.vector_coords[0],
+            "+",
             "(%d)\\hat{\\jmath}"%self.vector_coords[1]
         ])
         new_mob.move_to(new_array)
@@ -165,7 +165,7 @@ class CoordinatesAsScalars(VectorScene):
 
         self.play(Transform(new_array, new_mob))
         self.wait()
-        
+
 
 
 class CoordinatesAsScalarsExample2(CoordinatesAsScalars):
@@ -181,7 +181,7 @@ class CoordinatesAsScalarsExample2(CoordinatesAsScalars):
         self.add(*basis_vectors)
         self.add(*labels)
         text = TextMobject("""
-            $\\hat{\\imath}$ and $\\hat{\\jmath}$ 
+            $\\hat{\\imath}$ and $\\hat{\\jmath}$
             are the ``basis vectors'' \\\\
             of the $xy$ coordinate system
         """)
@@ -219,7 +219,7 @@ class ShowVaryingLinearCombinations(VectorScene):
             (1, -1.13),
             (1.25, 0.5),
             (-0.8, 1.3),
-        ], 
+        ],
         "leave_sum_vector_copies" : False,
         "start_with_non_sum_scaling" : True,
         "finish_with_standard_basis_comparison" : True,
@@ -230,16 +230,16 @@ class ShowVaryingLinearCombinations(VectorScene):
         v1 = self.add_vector(self.vector1, color = self.vector1_color)
         v2 = self.add_vector(self.vector2, color = self.vector2_color)
         v1_label = self.label_vector(
-            v1, self.vector1_label, color = self.vector1_color, 
+            v1, self.vector1_label, color = self.vector1_color,
             buff_factor = 3
         )
         v2_label = self.label_vector(
-            v2, self.vector2_label, color = self.vector2_color, 
+            v2, self.vector2_label, color = self.vector2_color,
             buff_factor = 3
         )
         label_anims = [
             MaintainPositionRelativeTo(label, v)
-            for v, label in (v1, v1_label), (v2, v2_label)
+            for v, label in ((v1, v1_label), (v2, v2_label))
         ]
         scalar_anims = self.get_scalar_anims(v1, v2, v1_label, v2_label)
         self.last_scalar_pair = (1, 1)
@@ -270,14 +270,14 @@ class ShowVaryingLinearCombinations(VectorScene):
                 scale_factor = 0.75,
                 value_function = get_val_func(v)
             )
-            for v, label in (v1, v1_label), (v2, v2_label)
+            for v, label in ((v1, v1_label), (v2, v2_label))
         ]
 
     def get_rate_func_pair(self):
         return [
-            squish_rate_func(smooth, a, b) 
-            for a, b in (0, 0.7), (0.3, 1)
-        ] 
+            squish_rate_func(smooth, a, b)
+            for a, b in ((0, 0.7), (0.3, 1))
+        ]
 
     def initial_scaling(self, v1, v2, label_anims, scalar_anims):
         scalar_pair = self.scalar_pairs.pop(0)
@@ -291,7 +291,7 @@ class ShowVaryingLinearCombinations(VectorScene):
         ]
         anims += [
             ApplyMethod(v.copy().fade, 0.7)
-            for v in v1, v2
+            for v in (v1, v2)
         ]
         anims += label_anims + scalar_anims
         self.play(*anims, **{"run_time" : 2})
@@ -315,8 +315,8 @@ class ShowVaryingLinearCombinations(VectorScene):
             anims = [
                 ApplyMethod(v.scale, s/s_old, rate_func = rf)
                 for v, s, s_old, rf in zip(
-                    [v1, v2], 
-                    scalar_pair, 
+                    [v1, v2],
+                    scalar_pair,
                     self.last_scalar_pair,
                     self.get_rate_func_pair()
                 )
@@ -333,7 +333,7 @@ class ShowVaryingLinearCombinations(VectorScene):
             v2, lambda m : m.shift(v1.get_end()-m.get_start())
         )
         sum_anim = UpdateFromFunc(
-            self.sum_vector, 
+            self.sum_vector,
             lambda v : v.put_start_and_end_on(v1.get_start(), v2.get_end())
         )
         return v2_anim, sum_anim
@@ -346,7 +346,7 @@ class ShowVaryingLinearCombinations(VectorScene):
         array = Matrix([
             mob.copy().set_color(color)
             for mob, color in zip(
-                alt_coords, 
+                alt_coords,
                 [self.vector1_color, self.vector2_color]
             )
         ])
@@ -368,7 +368,7 @@ class ShowVaryingLinearCombinations(VectorScene):
         self.remove(brackets, *alt_coords)
         self.add(array)
         self.play(
-            FadeOut(everything), 
+            FadeOut(everything),
             Animation(array),
         )
 
@@ -402,7 +402,7 @@ class ShowVaryingLinearCombinations(VectorScene):
                 curr_tip = self.sum_vector.get_end()
                 line = Line(ORIGIN, curr_tip)
                 self.play(
-                    ApplyMethod(w2.scale, num), 
+                    ApplyMethod(w2.scale, num),
                     UpdateFromFunc(
                         line, lambda l : l.put_start_and_end_on(curr_tip, self.sum_vector.get_end())
                     ),
@@ -422,7 +422,7 @@ class AltShowVaryingLinearCombinations(ShowVaryingLinearCombinations):
             (1, 1.13),
             (1.25, 0.5),
             (-0.8, 1.14),
-        ], 
+        ],
         "finish_with_standard_basis_comparison" : False
     }
 
@@ -457,7 +457,7 @@ class NameLinearCombinations(Scene):
         scalars_word.next_to(equation, DOWN, buff = 2)
         arrows = [
             Arrow(scalars_word, letter)
-            for letter in a, b
+            for letter in (a, b)
         ]
 
         self.add(equation)
@@ -475,7 +475,7 @@ class LinearCombinationsDrawLines(ShowVaryingLinearCombinations):
             (1.5, 0.6),
             (0.7, 1.3),
             (1, 1),
-        ], 
+        ],
         "start_with_non_sum_scaling" : False,
         "finish_with_standard_basis_comparison" : False,
         "finish_by_drawing_lines" : True,
@@ -493,7 +493,7 @@ class LinearCombinationsWithSumCopies(ShowVaryingLinearCombinations):
             (-0.8, 1.3),
             (-0.9, 1.4),
             (0.9, 2),
-        ], 
+        ],
         "leave_sum_vector_copies" : True,
         "start_with_non_sum_scaling" : False,
         "finish_with_standard_basis_comparison" : False,
@@ -519,7 +519,7 @@ class LinearDependentVectors(ShowVaryingLinearCombinations):
             (-0.8, 1.3),
             (-0.9, 1.4),
             (0.9, 2),
-        ], 
+        ],
         "leave_sum_vector_copies" : False,
         "start_with_non_sum_scaling" : False,
         "finish_with_standard_basis_comparison" : False,
@@ -527,7 +527,7 @@ class LinearDependentVectors(ShowVaryingLinearCombinations):
     }
 
     def get_sum_animations(self, v1, v2):
-        v2_anim, sum_anim = ShowVaryingLinearCombinations.get_sum_animations(self, v1, v2) 
+        v2_anim, sum_anim = ShowVaryingLinearCombinations.get_sum_animations(self, v1, v2)
         self.remove(self.sum_vector)
         return v2_anim, Animation(VMobject())
 
@@ -538,8 +538,8 @@ class WhenVectorsLineUp(LinearDependentVectors):
         "scalar_pairs" : [
             (1.5, 0.6),
             (0.7, 1.3),
-        ], 
-    }    
+        ],
+    }
 
 class AnimationUnderSpanDefinition(ShowVaryingLinearCombinations):
     CONFIG = {
@@ -551,7 +551,7 @@ class AnimationUnderSpanDefinition(ShowVaryingLinearCombinations):
             (0.8, 1.3),
             (0.93, -1.4),
             (-2, -0.5),
-        ], 
+        ],
         "leave_sum_vector_copies" : True,
         "start_with_non_sum_scaling" : False,
         "finish_with_standard_basis_comparison" : False,
@@ -576,7 +576,7 @@ class DefineSpan(Scene):
         w_color = BLUE
 
         definition = TextMobject("""
-            The ``span'' of $\\vec{\\textbf{v}}$ and 
+            The ``span'' of $\\vec{\\textbf{v}}$ and
             $\\vec{\\textbf{w}}$ is the \\\\ set of all their
             linear combinations.
         """)
@@ -605,7 +605,7 @@ class DefineSpan(Scene):
         vary_words.next_to(equation, DOWN, buff = 2)
         arrows = [
             Arrow(vary_words, letter)
-            for letter in a, b
+            for letter in (a, b)
         ]
 
         self.play(Write(definition))
@@ -644,7 +644,7 @@ class VectorsToDotsScene(VectorScene):
         vector_group = VMobject(*vectors)
         self.play(
             ShowCreation(
-                vector_group, 
+                vector_group,
                 submobject_mode = "one_at_a_time",
                 run_time = 3
             )
@@ -667,7 +667,7 @@ class VectorsToDotsScene(VectorScene):
             for x in range(len(vectors))
         ]
         self.play(*[
-            Transform(v, v_to_dot(v), rate_func = rf, run_time = 2) 
+            Transform(v, v_to_dot(v), rate_func = rf, run_time = 2)
             for v, rf in zip(vectors, rate_functions)
         ])
         self.wait()
@@ -735,7 +735,7 @@ class VectorsInThePlane(VectorsToDotsScene):
         self.play(
             ShowCreation(plane),
             *[
-                Transform(v, p, rate_func = rf) 
+                Transform(v, p, rate_func = rf)
                 for v, p, rf in zip(vectors, line_pairs, rate_functions)
             ]
         )
@@ -804,21 +804,21 @@ class VaryingLinearCombinationOfThreeVectors(Scene):
 class LinearCombinationOfThreeVectorsText(Scene):
     def construct(self):
         text = TextMobject("""
-            Linear combination of 
-            $\\vec{\\textbf{v}}$, 
+            Linear combination of
+            $\\vec{\\textbf{v}}$,
             $\\vec{\\textbf{w}}$, and
             $\\vec{\\textbf{u}}$:
         """)
         VMobject(*text.split()[-12:-10]).set_color(MAROON_C)
         VMobject(*text.split()[-9:-7]).set_color(BLUE)
         VMobject(*text.split()[-3:-1]).set_color(RED_C)
-        VMobject(*text.split()[:17]).set_color(GREEN)        
+        VMobject(*text.split()[:17]).set_color(GREEN)
         text.scale_to_fit_width(FRAME_WIDTH - 1)
         text.to_edge(UP)
 
         equation = TextMobject("""$
-            a\\vec{\\textbf{v}} + 
-            b\\vec{\\textbf{w}} + 
+            a\\vec{\\textbf{v}} +
+            b\\vec{\\textbf{w}} +
             c\\vec{\\textbf{u}}
         $""")
         VMobject(*equation.split()[-10:-8]).set_color(MAROON_C)
@@ -836,7 +836,7 @@ class LinearCombinationOfThreeVectorsText(Scene):
         VMobject(*span_comment.split()[3:7]).set_color(YELLOW)
         arrows = VMobject(*[
             Arrow(span_comment, var)
-            for var in a, b, c
+            for var in (a, b, c)
         ])
 
         self.play(Write(text))
@@ -886,7 +886,7 @@ class SpanCasesWords(Scene):
 class LinearDependentWords(Scene):
     def construct(self):
         words1 = TextMobject([
-            "$\\vec{\\textbf{v}}$", 
+            "$\\vec{\\textbf{v}}$",
             "and",
             "$\\vec{\\textbf{w}}$",
             "are",
@@ -898,7 +898,7 @@ class LinearDependentWords(Scene):
         rest.set_color(YELLOW)
 
         words2 = TextMobject([
-            "$\\vec{\\textbf{v}}$,", 
+            "$\\vec{\\textbf{v}}$,",
             "$\\vec{\\textbf{w}}$",
             "and",
             "$\\vec{\\textbf{u}}$",
@@ -967,7 +967,7 @@ class LinearDependentEquations(Scene):
         low_words2.to_edge(DOWN)
         arrows = VMobject(*[
             Arrow(low_words2, var)
-            for var in a, b
+            for var in (a, b)
         ])
 
         self.play(Write(equation1))
@@ -1064,7 +1064,7 @@ class AlternateDefOfLinearlyDependent(Scene):
         scalar_specification.shift(1.5*DOWN)
         scalar_specification.add(*[
             Arrow(scalar_specification, equations[0].split()[i])
-            for i in 2, 5
+            for i in (2, 5)
         ])
 
         brace = Brace(VMobject(*equations[2].split()[2:]))
@@ -1073,7 +1073,7 @@ class AlternateDefOfLinearlyDependent(Scene):
 
         equation = equations[0]
         for added_words in added_words1, added_words2:
-            added_words.next_to(title, DOWN, buff = 3.5, aligned_edge = LEFT) 
+            added_words.next_to(title, DOWN, buff = 3.5, aligned_edge = LEFT)
         self.play(Write(equation))
         for i, new_eq in enumerate(equations):
             if i == 0:
@@ -1088,7 +1088,7 @@ class AlternateDefOfLinearlyDependent(Scene):
                 self.wait(3)
                 self.play(FadeOut(brace), FadeOut(brace_words))
             self.play(Transform(
-                equation, new_eq, 
+                equation, new_eq,
                 path_arc = (np.pi/2 if i == 1 else 0)
             ))
             self.wait(3)
@@ -1196,7 +1196,7 @@ class MathematiciansLikeToConfuse(TeacherStudentsScene):
     def construct(self):
         self.setup()
         self.teacher_says("""
-            We wouldn't want things to \\\\ 
+            We wouldn't want things to \\\\
             be \\emph{understandable} would we?
         """)
         modes = "pondering", "sassy", "confused"
@@ -1248,19 +1248,4 @@ class NextVideo(Scene):
 
         self.add(title)
         self.play(ShowCreation(rect))
-        self.wait() 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        self.wait()

--- a/old_projects/eola/chapter3.py
+++ b/old_projects/eola/chapter3.py
@@ -152,7 +152,7 @@ class WhyConfuseWithTerminology(TeacherStudentsScene):
     def construct(self):
         self.setup()
         self.student_says("Why confuse us with \\\\ redundant terminology?")
-        other_students = [self.get_students()[i] for i in 0, 2]
+        other_students = [self.get_students()[i] for i in (0, 2)]
         self.play(*[
             ApplyMethod(student.change_mode, "confused")
             for student in other_students
@@ -668,7 +668,7 @@ class TrackBasisVectorsExample(LinearTransformationScene):
         self.remove(coords)
 
     def show_linear_combination(self, clean_up = True):
-        i_hat_copy, j_hat_copy = [m.copy() for m in self.i_hat, self.j_hat]
+        i_hat_copy, j_hat_copy = [m.copy() for m in (self.i_hat, self.j_hat)]
         self.play(ApplyFunction(
             lambda m : m.scale(self.v_coords[0]).fade(0.3),
             i_hat_copy

--- a/old_projects/eola/chapter4.py
+++ b/old_projects/eola/chapter4.py
@@ -164,7 +164,7 @@ class FollowLinearCombination(LinearTransformationScene):
         scaled_j = self.get_mobjects_from_last_animation()[0]
         self.play(*[
             ApplyMethod(mob.shift, scaled_i.get_end())
-            for mob in scaled_j, scaled_j_label
+            for mob in (scaled_j, scaled_j_label)
         ])
         self.wait()
         self.play(*map(FadeOut, [
@@ -313,7 +313,7 @@ class IntroduceIdeaOfComposition(RotationThenShear):
         matrix.next_to(words, RIGHT, aligned_edge = UP)
         col1, col2 = [
             VMobject(*matrix.get_mob_matrix()[:,i])
-            for i in 0, 1
+            for i in (0, 1)
         ]
         matrix_background = BackgroundRectangle(matrix)
 
@@ -536,7 +536,7 @@ class MoreComplicatedExampleNumerically(MoreComplicatedExampleVisually):
 
         col1, col2 = [
             VMobject(*m1_mob.split()[1].get_mob_matrix()[:,i])
-            for i in 0, 1
+            for i in (0, 1)
         ]
         col1.target_color = X_COLOR
         col2.target_color = Y_COLOR
@@ -862,9 +862,9 @@ class AskAssociativityQuestion(Scene):
 
         lhs = TexMobject(list("(AB)C"))
         lp, a, b, rp, c = lhs.split()
-        rhs = VMobject(*[m.copy() for m in a, lp, b, c, rp])
+        rhs = VMobject(*[m.copy() for m in (a, lp, b, c, rp)])
         point = VectorizedPoint()
-        start = VMobject(*[m.copy() for m in point, a, b, point, c])
+        start = VMobject(*[m.copy() for m in (point, a, b, point, c)])
         for mob in lhs, rhs, start:
             mob.arrange_submobjects(buff = 0.1)
         a, lp, b, c, rp = rhs.split()
@@ -904,7 +904,7 @@ class AskAssociativityQuestion(Scene):
 
         matrices = map(matrix_to_mobject, [
             np.array(list(m)).reshape((2, 2))
-            for m in "abcd", "efgh", "ijkl"
+            for m in ("abcd", "efgh", "ijkl")
         ])
         VMobject(*matrices).arrange_submobjects()
 
@@ -931,10 +931,10 @@ class AskAssociativityQuestion(Scene):
             m3
         )
         state2 = VMobject(*[
-            m.copy() for m in lp, m1, m2, rp, m3
+            m.copy() for m in (lp, m1, m2, rp, m3)
         ])
         state3 = VMobject(*[
-            m.copy() for m in m1, lp, m2, m3, rp
+            m.copy() for m in (m1, lp, m2, m3, rp)
         ])
         for state in state2, state3:
             state.arrange_submobjects(RIGHT, buff = 0.1)

--- a/old_projects/eola/chapter5.py
+++ b/old_projects/eola/chapter5.py
@@ -893,7 +893,7 @@ class TwoDDeterminantFormula(Scene):
         self.wait()
         self.play(*[
             Transform(m, m.zero)
-            for m in mb, mc, b, c
+            for m in (mb, mc, b, c)
         ])
         self.wait()
         for pair in (mb, b), (mc, c):
@@ -932,7 +932,7 @@ class TwoDDeterminantFormulaIntuition(LinearTransformationScene):
             [[1, 0], [float(b)/d, 1]],
             added_anims = [
                 ApplyMethod(m.shift, b*RIGHT)
-                for m in side_brace, height
+                for m in (side_brace, height)
             ]
         )
         self.wait()

--- a/old_projects/eola/chapter6.py
+++ b/old_projects/eola/chapter6.py
@@ -6,7 +6,7 @@ class OpeningQuote(Scene):
         words = TextMobject(
             "To ask the",
             "right question\\\\",
-            "is harder than to answer it." 
+            "is harder than to answer it."
         )
         words.to_edge(UP)
         words[1].set_color(BLUE)
@@ -26,8 +26,8 @@ class ListTerms(Scene):
         title.to_edge(UP)
         randy = Randolph().to_corner()
         words = VMobject(*map(TextMobject, [
-            "Inverse matrices", 
-            "Column space", 
+            "Inverse matrices",
+            "Column space",
             "Rank",
             "Null space",
         ]))
@@ -105,7 +105,7 @@ class UsefulnessOfMatrices(Scene):
         equations.to_edge(RIGHT, buff = 2)
         syms = VMobject(*np.array(equations.split())[[1, 4, 7]])
         new_syms = VMobject(*[
-            m.copy().set_color(c) 
+            m.copy().set_color(c)
             for m, c in zip(syms.split(), [X_COLOR, Y_COLOR, Z_COLOR])
         ])
         new_syms.arrange_submobjects(RIGHT, buff = 0.5)
@@ -250,12 +250,12 @@ class SystemOfEquations(Scene):
         equations = VMobject()
         for row in mob_matrix:
             equation = VMobject(*it.chain(*zip(
-                row, 
+                row,
                 [v.copy() for v in variables],
                 map(TexMobject, list("++="))
             )))
             equation.arrange_submobjects(
-                RIGHT, buff = 0.1, 
+                RIGHT, buff = 0.1,
                 aligned_edge = DOWN
             )
             equation.split()[4].shift(0.1*DOWN)
@@ -362,7 +362,7 @@ class SystemOfEquations(Scene):
                 eq.split()[i]
                 for eq in equations.split()
             ])
-            for i in 1, 4, 7
+            for i in (1, 4, 7)
         ]
         ys.words = "Vertically align variables"
         colors = [PINK, YELLOW, BLUE_B, BLUE_C, BLUE_D]
@@ -379,7 +379,7 @@ class SystemOfEquations(Scene):
             Circle().replace(mob).scale_in_place(1.3)
             for mob in [
                 VMobject(*equations.split()[i].split()[j:j+2])
-                for i, j in (1, 3), (2, 6)
+                for i, j in ((1, 3), (2, 6))
             ]
         ])
         zero_circles.set_color(PINK)
@@ -432,7 +432,7 @@ class SystemOfEquations(Scene):
         ax_equals_v.to_edge(RIGHT)
         all_brackets = [
             mob.get_brackets()
-            for mob in matrix, x_array, v_array
+            for mob in (matrix, x_array, v_array)
         ]
 
         self.play(equations.to_edge, LEFT)
@@ -442,7 +442,7 @@ class SystemOfEquations(Scene):
         self.play(*it.chain(*[
             [
                 Transform(
-                    m1.copy(), m2, 
+                    m1.copy(), m2,
                     run_time = 2,
                     path_arc = -np.pi/2
                 )
@@ -465,7 +465,7 @@ class SystemOfEquations(Scene):
         ])
         self.wait()
         self.label_matrix_product(matrix, x_array, v_array)
-        
+
     def label_matrix_product(self, matrix, x_array, v_array):
         matrix.words = "Coefficients"
         matrix.symbol = "A"
@@ -509,7 +509,7 @@ class SystemOfEquations(Scene):
         compact_equation.target.to_edge(UP)
 
         self.play(Transform(
-            compact_equation.copy(), 
+            compact_equation.copy(),
             compact_equation.target
         ))
         self.wait()
@@ -651,7 +651,7 @@ class ShowBijectivity(LinearTransformationScene):
             Vector([x, y])
             for x, y in it.product(*[
                 np.arange(-int(val)+0.5, int(val)+0.5)
-                for val in FRAME_X_RADIUS, FRAME_Y_RADIUS
+                for val in (FRAME_X_RADIUS, FRAME_Y_RADIUS)
             ])
         ])
         vectors.set_submobject_colors_by_gradient(BLUE_E, PINK)
@@ -704,7 +704,7 @@ class LabeledExample(LinearSystemTransformationScene):
         title.next_to(self.equation, DOWN, buff = 1)
         title.add_background_rectangle()
         title.shift_onto_screen()
-        self.add_foreground_mobject(title)        
+        self.add_foreground_mobject(title)
         self.title = title
         if self.show_square:
             self.add_unit_square()
@@ -792,7 +792,7 @@ class DescribeInverse(LinearTransformationScene):
             inv_matrix = matrix.copy()
             neg_1 = TexMobject("-1")
             neg_1.move_to(
-                inv_matrix.get_corner(UP+RIGHT), 
+                inv_matrix.get_corner(UP+RIGHT),
                 aligned_edge = LEFT
             )
             neg_1.shift(0.1*RIGHT)
@@ -928,7 +928,7 @@ class TwoDInverseFormula(Scene):
 class SymbolicInversion(Scene):
     def construct(self):
         vec = lambda s : "\\vec{\\textbf{%s}}"%s
-        
+
         words = TextMobject("Once you have this:")
         words.to_edge(UP, buff = 2)
         inv = TexMobject("A^{-1}")
@@ -970,7 +970,7 @@ class SymbolicInversion(Scene):
         self.wait()
         self.play(*[
             ApplyMethod(m.set_color, BLACK)
-            for m in product, product.brace, product.words
+            for m in (product, product.brace, product.words)
         ])
         self.wait()
         self.play(ApplyFunction(
@@ -1113,7 +1113,7 @@ class OneInputMultipleOutputs(InvertNonInvertable):
         single_input = TextMobject("Single vector")
         single_input.add_background_rectangle()
         single_input.next_to(output_vector.get_end(), UP)
-        single_input.set_color(YELLOW) 
+        single_input.set_color(YELLOW)
         self.play(Write(single_input))
         self.wait()
         self.remove(single_input, output_vector)
@@ -1138,7 +1138,7 @@ class OneInputMultipleOutputs(InvertNonInvertable):
 class SolutionsCanStillExist(TeacherStudentsScene):
     def construct(self):
         words = TextMobject("""
-            Solutions can still 
+            Solutions can still
             exist when""",  "$\\det(A) = 0$"
         )
         words[1].set_color(TEAL)
@@ -1193,7 +1193,7 @@ class DefineRank(Scene):
         rank.set_color(TEAL)
         arrow = DoubleArrow(LEFT, RIGHT)
         dims = TextMobject(
-            "Number of\\\\", "dimensions \\\\", 
+            "Number of\\\\", "dimensions \\\\",
             "in the output"
         )
         dims[1].set_color(rank.get_color())
@@ -1239,7 +1239,7 @@ class ColumnsRepresentBasisVectors(Scene):
         matrix.shift(UP)
         i_hat_words, j_hat_words = [
             TextMobject("Where $\\hat{\\%smath}$ lands"%char)
-            for char in "i", "j"
+            for char in ("i", "j")
         ]
         i_hat_words.set_color(X_COLOR)
         i_hat_words.next_to(ORIGIN, LEFT).to_edge(UP)
@@ -1367,7 +1367,7 @@ class NameColumnSpace(Scene):
         col_arrays = map(Matrix, cols)
 
         span_text = TexMobject(
-            "\\text{Span}", 
+            "\\text{Span}",
             "\\Big(",
             matrix_to_tex_string([1, 2, 3]),
             ",",
@@ -1379,7 +1379,7 @@ class NameColumnSpace(Scene):
         for i in 1, -1:
             span_text[i].stretch(1.5, 1)
             span_text[i].do_in_place(
-                span_text[i].scale_to_fit_height, 
+                span_text[i].scale_to_fit_height,
                 span_text.get_height()
             )
         for col_array, index in zip(col_arrays, [2, 4, 6]):
@@ -1418,9 +1418,9 @@ class NameColumnSpace(Scene):
         self.add(text)
 
         words = TextMobject(
-            "To solve", 
+            "To solve",
             "$A\\vec{\\textbf{x}} = \\vec{\\textbf{v}}$,\\\\",
-            "$\\vec{\\textbf{v}}$", 
+            "$\\vec{\\textbf{v}}$",
             "must be in \\\\ the",
             "column space."
         )
@@ -1462,7 +1462,7 @@ class NameColumnSpace(Scene):
         two_d_span.move_to(span_text, aligned_edge = RIGHT)
         mob_matrix = np.array([
             two_d_span[i].get_entries().split()
-            for i in 2, 4
+            for i in (2, 4)
         ])
 
         self.play(Transform(span_text, two_d_span))
@@ -1482,7 +1482,7 @@ class NameColumnSpace(Scene):
         self.add(span_text)
         mob_matrix = np.array([
             span_text[i].get_entries().split()
-            for i in 2, 4, 6
+            for i in (2, 4, 6)
         ])
         self.replace_number_matrix(mob_matrix, [[1, 1, 0], [0, 1, 1], [1, 0, 1]])
         self.wait()
@@ -1557,7 +1557,7 @@ class RankNumber0(RankNumber):
     CONFIG = {
         "number" : 0,
         "color" : GREY
-    }  
+    }
 
 class NameFullRank(Scene):
     def construct(self):
@@ -1629,7 +1629,7 @@ class FullRankCase(LinearTransformationScene):
         for mob in title:
             mob.add_to_back(BackgroundRectangle(mob))
         arrow = Arrow(vector.get_bottom(), ORIGIN)
-        dot = Dot(ORIGIN, color = YELLOW) 
+        dot = Dot(ORIGIN, color = YELLOW)
 
         words_on = False
         for t_matrix in t_matrices:
@@ -1672,13 +1672,13 @@ class NameNullSpace(LinearTransformationScene):
         )
         self.wait()
         self.play(
-            vectors.restore, 
-            self.plane.restore, 
+            vectors.restore,
+            self.plane.restore,
             *map(Animation, self.foreground_mobjects),
             run_time = 2
         )
         self.play(Transform(
-            vectors, line, 
+            vectors, line,
             run_time = 2,
             submobject_mode = "lagged_start"
         ))
@@ -1724,7 +1724,7 @@ class NullSpaceSolveForVEqualsZero(NameNullSpace):
         zero_vector.scale(0.7)
         zero_vector.move_to(v, aligned_edge = LEFT)
         VMobject(equation, zero_vector).next_to(ORIGIN, LEFT).to_edge(UP)
-        zero_vector_rect = BackgroundRectangle(zero_vector)        
+        zero_vector_rect = BackgroundRectangle(zero_vector)
         equation.add_background_rectangle()
 
         self.play(Write(equation))
@@ -1753,7 +1753,7 @@ class OffsetNullSpace(NameNullSpace):
         circle = Circle(color = YELLOW).replace(dot)
         circle.scale_in_place(5)
         words = TextMobject("""
-            All vectors still land 
+            All vectors still land
             on the same spot
         """)
         words.set_color(YELLOW)
@@ -1785,7 +1785,7 @@ class OffsetNullSpace(NameNullSpace):
             self.t_matrix,
             added_anims = [Transform(vectors, dot)]
         )
-        self.wait()        
+        self.wait()
         self.play(
             ShowCreation(circle),
             Write(words)
@@ -1949,7 +1949,7 @@ class NullSpaceOffsetRule(Scene):
         A_text.shift_onto_screen()
         A_arrow = Arrow(A_text.get_bottom(), A, color = WHITE)
         v_text = TextMobject(
-            "If", "$%s$"%vec("v"), "is in the", 
+            "If", "$%s$"%vec("v"), "is in the",
             "column space", "of $A$"
         )
         v_text[1].set_color(YELLOW)
@@ -2010,7 +2010,7 @@ class NextVideo(Scene):
 
         self.add(title)
         self.play(ShowCreation(rect))
-        self.wait()  
+        self.wait()
 
 class WhatAboutNonsquareMatrices(TeacherStudentsScene):
     def construct(self):
@@ -2020,20 +2020,3 @@ class WhatAboutNonsquareMatrices(TeacherStudentsScene):
         )
         self.play(self.get_students()[0].change_mode, "confused")
         self.random_blink(6)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eola/chapter7.py
+++ b/old_projects/eola/chapter7.py
@@ -304,7 +304,7 @@ class GeometricInterpretation(VectorScene):
         dot_product = np.dot(self.v.get_end(), self.w.get_end())
         v_norm, w_norm = [
             np.linalg.norm(vect.get_end())
-            for vect in self.v, self.w
+            for vect in (self.v, self.w)
         ]
         projected = Vector(
             self.stable_vect.get_end()*dot_product/(
@@ -348,7 +348,7 @@ class GeometricInterpretation(VectorScene):
 
         proj_brace, stable_brace = braces = [
             Brace(Line(ORIGIN, vect.get_length()*RIGHT*sgn), UP)
-            for vect in self.proj_vect, self.stable_vect
+            for vect in (self.proj_vect, self.stable_vect)
             for sgn in [np.sign(np.dot(vect.get_end(), self.stable_vect.get_end()))]
         ]
         proj_brace.put_at_tip(proj_words.start)
@@ -581,7 +581,7 @@ class SymmetricVAndW(VectorScene):
             color = GREY
         )
 
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in ("v", "w")]
         equation = TexMobject(
             "(", "2", v_tex, ")", "\\cdot", w_tex,
             "=",
@@ -600,7 +600,7 @@ class SymmetricVAndW(VectorScene):
         v.proj_line.save_state()
         self.play(Transform(*[
             VGroup(mob, mob.label)
-            for mob in v, new_v
+            for mob in (v, new_v)
         ]), run_time = 2)
         last_mob = self.get_mobjects_from_last_animation()[0] 
         self.remove(last_mob)
@@ -700,7 +700,7 @@ class Introduce2Dto1DLinearTransformations(TwoDToOneDScene):
         self.apply_transposed_matrix(self.t_matrix)
         self.play(
             ShowCreation(number_line),
-            *[Animation(v) for v in self.i_hat, self.j_hat]
+            *[Animation(v) for v in (self.i_hat, self.j_hat)]
         )
         self.play(*map(Write, [numbers, number_line_words]))
         self.wait()
@@ -778,7 +778,7 @@ class OkayToIgnoreFormalProperties(Scene):
         title.to_edge(UP)
         h_line = Line(LEFT, RIGHT).scale(FRAME_X_RADIUS)
         h_line.next_to(title, DOWN)
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in ("v", "w")]
         additivity = TexMobject(
             "L(", v_tex, "+", w_tex, ") = ",
             "L(", v_tex, ") + L(", w_tex, ")",
@@ -829,7 +829,7 @@ class FormalVsVisual(Scene):
         formal.next_to(line, DOWN).shift(FRAME_X_RADIUS*LEFT/2)
         visual.next_to(line, DOWN).shift(FRAME_X_RADIUS*RIGHT/2)
 
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in ("v", "w")]
         additivity = TexMobject(
             "L(", v_tex, "+", w_tex, ") = ",
             "L(", v_tex, ")+", "L(", w_tex, ")"
@@ -900,13 +900,13 @@ class AdditivityProperty(TwoDToOneDScene):
         sum_vect.target = sum_vect
         self.play(*[
             Transform(mob, mob.target)
-            for mob in v, w, sum_vect
+            for mob in (v, w, sum_vect)
         ])
         self.add_vector(sum_vect, animate = False)
         return sum_vect
 
     def get_symbols(self):
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in ("v", "w")]
         if self.sum_before:
             tex_mob = TexMobject(
                 "L(", v_tex, "+", w_tex, ")"
@@ -1029,7 +1029,7 @@ class NonLinearFailsDotTest(TwoDTo1DTransformWithDots):
 
 class AlwaysfollowIHatJHat(TeacherStudentsScene):
     def construct(self):
-        i_tex, j_tex = ["$\\hat{\\%smath}$"%c for c in "i", "j"]
+        i_tex, j_tex = ["$\\hat{\\%smath}$"%c for c in ("i", "j")]
         words = TextMobject(
             "Always follow", i_tex, "and", j_tex
         )
@@ -1131,7 +1131,7 @@ class FollowVectorViaCoordinates(TwoDToOneDScene):
         self.play(
             *map(FadeOut, to_fade) + [
                 vect.restore
-                for vect in self.i_hat, self.j_hat
+                for vect in (self.i_hat, self.j_hat)
             ]
         )
 
@@ -1149,7 +1149,7 @@ class FollowVectorViaCoordinates(TwoDToOneDScene):
         else:
             new_labels = [
                 TexMobject("L(\\hat{\\%smath})"%char)
-                for char in "i", "j"
+                for char in ("i", "j")
             ]
             
         new_labels[0].set_color(X_COLOR)
@@ -1609,7 +1609,7 @@ class AskAboutProjectionMatrix(Scene):
         VMobject(words, matrix).arrange_submobjects(buff = MED_SMALL_BUFF).shift(UP)
         basis_words = [
             TextMobject("Where", "$\\hat{\\%smath}$"%char, "lands")
-            for char in "i", "j"
+            for char in ("i", "j")
         ]
         for b_words, q_mark, direction in zip(basis_words, matrix.get_entries(), [UP, DOWN]):
             b_words.next_to(q_mark, direction, buff = 1.5)
@@ -1650,7 +1650,7 @@ class ProjectBasisVectors(ProjectOntoUnitVectorNumberline):
             for vector in basis_vectors
         ])
 
-        i_tex, j_tex = ["$\\hat{\\%smath}$"%char for char in "i", "j"]
+        i_tex, j_tex = ["$\\hat{\\%smath}$"%char for char in ("i", "j")]
         question = TextMobject(
             "Where do", i_tex, "and", j_tex, "land?"
         )
@@ -1698,7 +1698,7 @@ class ProjectBasisVectors(ProjectOntoUnitVectorNumberline):
         # self.show_u_coords(u_label)
         u_x, u_y = [
             TexMobject("u_%s"%c).set_color(self.u_hat.get_color())
-            for c in "x", "y"
+            for c in ("x", "y")
         ]
         matrix_x, matrix_y = matrix.get_entries()
         self.remove(j_hat, j_label)
@@ -2160,7 +2160,7 @@ class TranslateToTheWorldOfTransformations(TwoDOneDMatrixMultiplication):
     def construct(self):
         v1, v2 = [
             Matrix(["x_%d"%n, "y_%d"%n])
-            for n in 1, 2
+            for n in (1, 2)
         ]
         v1.set_color_columns(V_COLOR)
         v2.set_color_columns(W_COLOR)

--- a/old_projects/eola/chapter8.py
+++ b/old_projects/eola/chapter8.py
@@ -43,7 +43,7 @@ class LastVideo(Scene):
 
         self.add(title)
         self.play(ShowCreation(rect))
-        self.wait()  
+        self.wait()
 
 class DoTheSameForCross(TeacherStudentsScene):
     def construct(self):
@@ -113,7 +113,7 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
     def construct(self):
         self.add_vectors()
         self.show_area()
-        self.write_area_words()        
+        self.write_area_words()
         self.show_sign()
         self.swap_v_and_w()
 
@@ -131,7 +131,7 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
     def show_area(self):
         self.add_unit_square()
         transform = self.get_matrix_transformation(np.array([
-            self.v_coords, 
+            self.v_coords,
             self.w_coords,
         ]))
         self.square.apply_function(transform)
@@ -160,7 +160,7 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
             vect.label.target.save_state()
         cross = VGroup(self.v.label.target, times, self.w.label.target)
         cross.arrange_submobjects(aligned_edge = DOWN)
-        cross.scale(1.5)        
+        cross.scale(1.5)
         cross.shift(2.5*UP).to_edge(LEFT)
         cross_rect = BackgroundRectangle(cross)
         equals = TexMobject("=")
@@ -170,20 +170,20 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
         words.add_background_rectangle()
         words.next_to(equals, buff = MED_SMALL_BUFF/2)
         arrow = Arrow(
-            words.get_bottom(), 
+            words.get_bottom(),
             self.square.get_center(),
             color = WHITE
         )
 
         self.play(
-            FadeIn(cross_rect),            
+            FadeIn(cross_rect),
             Write(times),
             *[
                 ApplyMethod(
-                    vect.label.target.restore, 
+                    vect.label.target.restore,
                     rate_func = lambda t : smooth(1-t)
                 )
-                for vect in self.v, self.w
+                for vect in (self.v, self.w)
             ]
         )
         self.wait()
@@ -201,7 +201,7 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
         self.area_words = words
         self.cross = cross
 
-    def show_sign(self):        
+    def show_sign(self):
         for vect, angle in (self.v, -np.pi/2), (self.w, np.pi/2):
             vect.add(vect.label)
             vect.save_state()
@@ -230,8 +230,8 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
                 color = word.get_color()
             )
             VGroup(word, word.arrow).next_to(
-                self.area_words, DOWN, 
-                aligned_edge = LEFT, 
+                self.area_words, DOWN,
+                aligned_edge = LEFT,
                 buff = SMALL_BUFF
             )
         minus_sign = TexMobject("-")
@@ -248,9 +248,9 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
         self.play(Write(positive), ShowCreation(positive.arrow))
         self.remove(arc)
         self.play(
-            FadeOut(positive), 
+            FadeOut(positive),
             FadeOut(positive.arrow),
-            *[mob.restore for mob in square, self.v, self.w]
+            *[mob.restore for mob in (square, self.v, self.w)]
         )
         arc = self.get_arc(self.v, self.w, radius = 1.5)
         arc.set_color(RED)
@@ -284,7 +284,7 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
         )
         self.square.target = self.square.copy().apply_function(transform)
         self.play(
-            MoveToTarget(self.square),            
+            MoveToTarget(self.square),
             Transform(self.v, self.w),
             Transform(self.w, self.v),
             rate_func = there_and_back,
@@ -336,7 +336,7 @@ class CrossBasisVectors(LinearTransformationScene):
         eq.next_to(cross, RIGHT)
 
         self.play(
-            ShowCreation(cross_rect),            
+            ShowCreation(cross_rect),
             MoveToTarget(i_label.copy()),
             MoveToTarget(j_label.copy()),
             Write(times),
@@ -394,13 +394,13 @@ class VisualExample(SimpleDefine2dCrossProduct):
         self.wait()
 
     def show_coords(self):
-        for vect, edge in (self.v, DOWN), (self.w, UP):        
+        for vect, edge in (self.v, DOWN), (self.w, UP):
             color = vect.get_color()
             vect.coord_array = vector_coordinate_label(
                 vect, color = color,
             )
             vect.coord_array.move_to(
-                vect.coord_array.get_center(), 
+                vect.coord_array.get_center(),
                 aligned_edge = edge
             )
             self.play(Write(vect.coord_array, run_time = 1))
@@ -484,7 +484,7 @@ class ContrastDotAndCross(Scene):
                 Write(dot_prod.syms),
                 *[
                     Transform(
-                        e.copy(), e.target, 
+                        e.copy(), e.target,
                         path_arc = -np.pi/6
                     )
                     for e in dot_prod.entries
@@ -586,7 +586,7 @@ class ContrastDotAndCross(Scene):
         entries = [x1, x2, x3, x4]
         for entry in entries:
             entry.target = entry.copy()
-        eq, dot1, minus, dot2 = syms = map(TexMobject, 
+        eq, dot1, minus, dot2 = syms = map(TexMobject,
             ["=", "\\cdot", "-", "\\cdot"]
         )
         result = VGroup(
@@ -640,7 +640,7 @@ class PrereqDeterminant(Scene):
 
         self.add(title)
         self.play(ShowCreation(rect))
-        self.wait()  
+        self.wait()
 
 class Define2dCrossProduct(LinearTransformationScene):
     CONFIG = {
@@ -673,7 +673,7 @@ class Define2dCrossProduct(LinearTransformationScene):
             vect.coords = vect.coord_array.get_entries()
         for vect, edge in (v, DOWN), (w, UP):
             vect.coord_array.move_to(
-                vect.coord_array.get_center(), 
+                vect.coord_array.get_center(),
                 aligned_edge = edge
             )
             self.play(Write(vect.coord_array, run_time = 1))
@@ -698,7 +698,7 @@ class Define2dCrossProduct(LinearTransformationScene):
         equation.to_corner(UP+LEFT)
 
         matrix_background = BackgroundRectangle(matrix)
-        cross_background = BackgroundRectangle(cross_product)        
+        cross_background = BackgroundRectangle(cross_product)
 
         disclaimer = TextMobject("$^*$ See ``Note on conventions'' in description")
         disclaimer.scale(0.7)
@@ -716,8 +716,8 @@ class Define2dCrossProduct(LinearTransformationScene):
         )
         self.wait()
         self.play(
-            ShowCreation(matrix_background),            
-            Write(matrix.get_brackets()), 
+            ShowCreation(matrix_background),
+            Write(matrix.get_brackets()),
             run_time = 1
         )
         self.play(Transform(v.coords.copy(), v.coords.target))
@@ -750,7 +750,7 @@ class Define2dCrossProduct(LinearTransformationScene):
         self.play(
             *map(FadeOut, everything) + [
             Animation(self.background_plane),
-            self.plane.restore,            
+            self.plane.restore,
             Animation(matrix),
         ])
         i_hat, j_hat = self.get_basis_vectors()
@@ -770,7 +770,7 @@ class Define2dCrossProduct(LinearTransformationScene):
 
         col1, col2 = [
             VGroup(*matrix.get_mob_matrix()[i,:])
-            for i in 0, 1
+            for i in (0, 1)
         ]
 
         both_words = []
@@ -836,7 +836,7 @@ class Define2dCrossProduct(LinearTransformationScene):
 
         vect_stuffs = VGroup(*it.chain(*[
             [m, m.label, m.coord_array]
-            for m in self.v, self.w
+            for m in (self.v, self.w)
         ]))
         to_restore = [self.plane, self.i_hat, self.j_hat]
         for mob in to_restore:
@@ -866,7 +866,7 @@ class Define2dCrossProduct(LinearTransformationScene):
         area_words = det_text_brace.get_text("Area of this parallelogram")
         area_words.add_background_rectangle()
         area_arrow = Arrow(
-            area_words.get_bottom(), 
+            area_words.get_bottom(),
             self.square.get_center(),
             color = WHITE
         )
@@ -917,10 +917,10 @@ class Define2dCrossProduct(LinearTransformationScene):
         self.play(Transform(movers, movers.target))
         self.wait()
 
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in ("v", "w")]
         positive_words, negative_words = words_list = [
             TexMobject(v_tex, "\\times", w_tex, "\\text{ is }", word)
-            for word in "\\text{positive}", "\\text{negative}"
+            for word in ("\\text{positive}", "\\text{negative}")
         ]
         for words in words_list:
             words.set_color_by_tex(v_tex, V_COLOR)
@@ -1014,7 +1014,7 @@ class TwoDCrossProductExample(Define2dCrossProduct):
             list(v.coords.copy().get_entries()),
             list(w.coords.copy().get_entries()),
         ]).T)
-        matrix_background = BackgroundRectangle(matrix)        
+        matrix_background = BackgroundRectangle(matrix)
         col1, col2 = it.starmap(Group, matrix.get_mob_matrix().T)
         det_text = get_det_text(matrix)
         v_tex, w_tex = get_vect_tex("v", "w")
@@ -1023,7 +1023,7 @@ class TwoDCrossProductExample(Define2dCrossProduct):
         cross_product.set_color_by_tex(w_tex, W_COLOR)
         cross_product.add_background_rectangle()
         equation_start = VGroup(
-            cross_product, 
+            cross_product,
             VGroup(matrix_background, det_text, matrix)
         )
         equation_start.arrange_submobjects()
@@ -1060,7 +1060,7 @@ class TwoDCrossProductExample(Define2dCrossProduct):
         ))
 
         equation_end = VGroup(
-            equals, v1.target, dot1, w2.target, 
+            equals, v1.target, dot1, w2.target,
             minus, w1.target, dot2, v2.target, equals_result
         )
         equation_end.arrange_submobjects()
@@ -1068,10 +1068,10 @@ class TwoDCrossProductExample(Define2dCrossProduct):
         syms_rect = BackgroundRectangle(syms)
         syms.add_to_back(syms_rect)
         equation_end.add_to_back(syms_rect)
-        syms.remove(equals_result)        
+        syms.remove(equals_result)
 
         self.play(
-            Write(syms),            
+            Write(syms),
             Transform(
                 VGroup(v1, w2).copy(), VGroup(v1.target, w2.target),
                 rate_func = squish_rate_func(smooth, 0, 1./3),
@@ -1113,9 +1113,9 @@ class TwoDCrossProductExample(Define2dCrossProduct):
 
 class PlayAround(TeacherStudentsScene):
     def construct(self):
-        self.teacher_says(""" \\centering 
+        self.teacher_says(""" \\centering
             Play with the idea if
-            you wish to understand it 
+            you wish to understand it
         """)
         self.change_student_modes("pondering", "happy", "happy")
         self.random_blink(2)
@@ -1159,7 +1159,7 @@ class BiggerWhenPerpendicular(LinearTransformationScene):
         w.target = w.copy().rotate(np.pi/5)
         transforms = [
             self.get_matrix_transformation([v1.get_end()[:2], v2.get_end()[:2]])
-            for v1, v2 in (v, w), (v.target, w.target)
+            for v1, v2 in ((v, w), (v.target, w.target))
         ]
         start_square, end_square = [
             square.copy().apply_function(transform)
@@ -1170,14 +1170,14 @@ class BiggerWhenPerpendicular(LinearTransformationScene):
             self.play(ShowCreation(vect))
         group.remove(bigger)
         self.play(
-            FadeIn(group), 
+            FadeIn(group),
             ShowCreation(start_square),
             *map(Animation, [v, w])
         )
         self.play(GrowFromCenter(bigger))
         self.wait()
         self.play(
-            Transform(start_square, end_square),            
+            Transform(start_square, end_square),
             Transform(v, v.target),
             Transform(w, w.target),
         )
@@ -1301,7 +1301,7 @@ class WriteCrossProductProperties(Scene):
         vector = brace.get_text("vector")
         vector.set_color(P_COLOR)
         length_words = TextMobject(
-            "Length of ", p_cash, "\\\\ = ", 
+            "Length of ", p_cash, "\\\\ = ",
             "(parallelogram's area)"
         )
         length_words.set_color_by_tex(p_cash, P_COLOR)
@@ -1312,7 +1312,7 @@ class WriteCrossProductProperties(Scene):
             "\\centering Perpendicular to",
             v_cash, "and", w_cash
         )
-        perpendicular.scale_to_fit_width(FRAME_X_RADIUS - 1)        
+        perpendicular.scale_to_fit_width(FRAME_X_RADIUS - 1)
         perpendicular.set_color_by_tex(v_cash, V_COLOR)
         perpendicular.set_color_by_tex(w_cash, W_COLOR)
         perpendicular.next_to(length_words, DOWN, buff = LARGE_BUFF)
@@ -1351,7 +1351,7 @@ class LabelingExampleVectors(Scene):
             TexMobject(v_tex, "=%s"%matrix_to_tex_string([0, 0, 2])),
             TexMobject(w_tex, "=%s"%matrix_to_tex_string([0, 2, 0])),
             TexMobject(
-                v_tex, "\\times", w_tex, 
+                v_tex, "\\times", w_tex,
                 "=%s"%matrix_to_tex_string([-4, 0, 0])
             ),
         ]
@@ -1365,7 +1365,7 @@ class LabelingExampleVectors(Scene):
         for mob in equations[:2] + [area_words, equations[2]]:
             self.fade_in_out(mob)
 
-    def fade_in_out(self, mob):            
+    def fade_in_out(self, mob):
         self.play(FadeIn(mob))
         self.wait()
         self.play(FadeOut(mob))
@@ -1382,7 +1382,7 @@ class ShowCrossProductFormula(Scene):
 
         arrays = [
             ["%s_%d"%(s, i) for i in range(1, 4)]
-            for s in "v", "w"
+            for s in ("v", "w")
         ]
         matrices = map(Matrix, arrays)
         for matrix in matrices:
@@ -1402,7 +1402,7 @@ class ShowCrossProductFormula(Scene):
                 e.target = e.copy()
             dot = TexMobject("\\cdot")
             syms = VGroup(dot)
-            
+
             if sign < 0:
                 minus = TexMobject("-")
                 syms.add(minus)
@@ -1448,7 +1448,7 @@ class ShowCrossProductFormula(Scene):
                 Transform(e1.copy(), e1_target),
                 Transform(e2.copy(), e2_target),
                 Write(syms),
-                e1.restore, 
+                e1.restore,
                 e2.restore,
                 path_arc = -np.pi/2
             )
@@ -1457,7 +1457,7 @@ class ShowCrossProductFormula(Scene):
 class ThisGetsWeird(TeacherStudentsScene):
     def construct(self):
         self.teacher_says(
-            "This gets weird...", 
+            "This gets weird...",
             target_mode = "sassy"
         )
         self.random_blink(2)
@@ -1466,7 +1466,7 @@ class DeterminantTrick(Scene):
     def construct(self):
         v_terms, w_terms = [
             ["%s_%d"%(s, d) for d in range(1, 4)]
-            for s in "v", "w"
+            for s in ("v", "w")
         ]
         v = Matrix(v_terms)
         w = Matrix(w_terms)
@@ -1475,7 +1475,7 @@ class DeterminantTrick(Scene):
         matrix = Matrix(np.array([
             [
                 TexMobject("\\hat{%s}"%s)
-                for s in "\\imath", "\\jmath", "k"
+                for s in ("\\imath", "\\jmath", "k")
             ],
             list(v.get_entries().copy()),
             list(w.get_entries().copy()),
@@ -1583,15 +1583,15 @@ class DeterminantTrick(Scene):
                 [mob.scale_in_place, 1.2]
                 for mob in quint
             ]))
-            self.wait() 
+            self.wait()
             self.play(*[
-                Transform(mob.copy(), mob.t) 
+                Transform(mob.copy(), mob.t)
                 for mob in quint
             ] + [
                 mob.restore for mob in quint
             ] + [
                 Write(syms)
-            ], 
+            ],
                 run_time = 2
             )
             self.wait()
@@ -1615,7 +1615,7 @@ class ThereIsAReason(TeacherStudentsScene):
         )
         self.random_blink(2)
         words = TextMobject(
-            "\\centering but there is a\\\\", 
+            "\\centering but there is a\\\\",
             "reason", "for doing it"
         )
         words.set_color_by_tex("reason", YELLOW)
@@ -1694,13 +1694,3 @@ class CrossAndDualWords(Scene):
         self.wait()
         self.play(Transform(det_text, dot_with_cross))
         self.wait()
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eola/chapter8p2.py
+++ b/old_projects/eola/chapter8p2.py
@@ -106,7 +106,7 @@ class BruteForceVerification(Scene):
                 "(", v_tex, "\\times", w_tex, ")",
                 "= 0"
             )
-            for tex in v_tex, w_tex
+            for tex in (v_tex, w_tex)
         ]
         theta_def = TexMobject(
             "\\theta", 
@@ -149,7 +149,7 @@ class Prerequisites(Scene):
         rect.scale_to_fit_width(FRAME_X_RADIUS - 1)
         left_rect, right_rect = [
             rect.copy().shift(DOWN/2).to_edge(edge)
-            for edge in LEFT, RIGHT
+            for edge in (LEFT, RIGHT)
         ]
         chapter5 = TextMobject("""
             \\centering 
@@ -293,7 +293,7 @@ class ThreeStepPlan(Scene):
         v_tex, w_tex = get_vect_tex(*"vw")
         v_text, w_text, cross_text = [
             "$%s$"%s 
-            for s in v_tex, w_tex, v_tex + "\\times" + w_tex
+            for s in (v_tex, w_tex, v_tex + "\\times" + w_tex)
         ]
         steps = [
             TextMobject(
@@ -413,7 +413,7 @@ class DefineDualTransform(Scene):
         det_text = get_det_text(matrix, background_rect = False)
         syms = times1, times2, equals = [
             TexMobject(sym) 
-            for sym in "\\times", "\\times", "=",
+            for sym in ("\\times", "\\times", "=",)
         ]
         triple_cross = VGroup(
             u_tex.target, times1, v_tex.target, times2, w_tex.target, equals
@@ -509,7 +509,7 @@ class DefineDualTransform(Scene):
         func_tex[0].scale_in_place(1.5)
 
         func_tex = VGroup(
-            VGroup(*[func_tex[i] for i in 0, 1, 2, -2, -1]),
+            VGroup(*[func_tex[i] for i in (0, 1, 2, -2, -1)]),
             func_input
         )
         func_tex.next_to(self.equals, LEFT)
@@ -528,7 +528,7 @@ class DefineDualTransform(Scene):
         ])
         self.play(*[
             Write(VGroup(vect_brace, vect_brace.tex))
-            for vect_brace in v_brace, w_brace
+            for vect_brace in (v_brace, w_brace)
         ])
         self.wait()
         self.play(Write(func_tex))

--- a/old_projects/eola/chapter9.py
+++ b/old_projects/eola/chapter9.py
@@ -559,9 +559,9 @@ class IntroduceJennifer(JenniferScene):
             ]),
             [
                 ApplyMethod(pi.change_mode, "plain") 
-                for pi in self.jenny, self.you
+                for pi in (self.jenny, self.you)
             ],
-            [mob.restore for mob in b1, b2, b1.label, b2.label]
+            [mob.restore for mob in (b1, b2, b1.label, b2.label)]
         ))
         self.jenny.bubble.restore()
 
@@ -1548,7 +1548,7 @@ class JennyWatchesRotation(JenniferScene):
         self.play(*it.chain(
             [
                 Rotate(mob, np.pi/2, run_time = 3)
-                for mob in self.jenny_plane, self.b1, self.b2
+                for mob in (self.jenny_plane, self.b1, self.b2)
             ],
             map(Animation, [jenny, jenny.bubble, matrix])
         ))
@@ -1757,7 +1757,7 @@ class JennyWatchesRotationWithMatrixAndVector(JenniferScene):
         self.play(*it.chain(
             [
                 Rotate(mob, np.pi/2, run_time = 3) 
-                for mob in self.jenny_plane, self.b1, self.b2, vector
+                for mob in (self.jenny_plane, self.b1, self.b2, vector)
             ],
             map(Animation, [self.jenny, matrix, vector_array]),
         ))

--- a/old_projects/eola/footnote.py
+++ b/old_projects/eola/footnote.py
@@ -1,4 +1,5 @@
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 class OpeningQuote(Scene):
     def construct(self):

--- a/old_projects/eola/footnote2.py
+++ b/old_projects/eola/footnote2.py
@@ -37,7 +37,7 @@ class ColumnsRepresentBasisVectors(Scene):
         matrix = Matrix([[3, 1], [4, 1], [5, 9]])
         i_hat_words, j_hat_words = [
             TextMobject("Where $\\hat{\\%smath}$ lands"%char)
-            for char in "i", "j"
+            for char in ("i", "j")
         ]
         i_hat_words.set_color(X_COLOR)
         i_hat_words.next_to(ORIGIN, LEFT).to_edge(UP)
@@ -166,7 +166,7 @@ class DescribeColumnsInSpecificTransformation(Scene):
         ])
         matrix.set_color_columns(X_COLOR, Y_COLOR)
         mob_matrix = matrix.get_mob_matrix()
-        i_col, j_col = [VMobject(*mob_matrix[:,i]) for i in 0, 1]
+        i_col, j_col = [VMobject(*mob_matrix[:,i]) for i in (0, 1)]
         for col, char, vect in zip([i_col, j_col], ["i", "j"], [UP, DOWN]):
             color = col[0].get_color()
             col.words = TextMobject("Where $\\hat\\%smath$ lands"%char)
@@ -572,7 +572,7 @@ class DotProductPreview(VectorScene):
         dot_product = np.dot(self.v.get_end(), self.w.get_end())
         v_norm, w_norm = [
             np.linalg.norm(vect.get_end())
-            for vect in self.v, self.w
+            for vect in (self.v, self.w)
         ]
         projected_w = Vector(
             self.v.get_end()*dot_product/(v_norm**2),
@@ -595,7 +595,7 @@ class DotProductPreview(VectorScene):
                 Line(ORIGIN, norm*RIGHT), 
                 UP
             )
-            for norm in 1, self.v.get_length(), dot_product
+            for norm in (1, self.v.get_length(), dot_product)
         ]
         length_texs = list(it.starmap(TexMobject, [
             ("1",),

--- a/old_projects/eulers_characteristic_formula.py
+++ b/old_projects/eulers_characteristic_formula.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -13,7 +14,7 @@ from mobject.region import  *
 import displayer as disp
 from scene.scene import Scene, GraphScene
 from scene.graphs import *
-from moser_main import EulersFormula
+from .moser_main import EulersFormula
 from script_wrapper import command_line_create_scene
 
 MOVIE_PREFIX = "ecf_graph_scenes/"
@@ -726,7 +727,7 @@ class ExamplesOfGraphs(GraphScene):
             found = False
             while True:
                 try:
-                    cycle1, cycle2 = region_pairs.next()
+                    cycle1, cycle2 = next(region_pairs)
                 except:
                     return
                 shared = set(cycle1).intersection(cycle2)

--- a/old_projects/fourier.py
+++ b/old_projects/fourier.py
@@ -35,7 +35,7 @@ def get_fourier_graph(
     graph.set_color(color)
     f_min, f_max = [
         axes.x_axis.point_to_number(graph.points[i])
-        for i in 0, -1
+        for i in (0, -1)
     ]
     graph.underlying_function = lambda f : axes.y_axis.point_to_number(
         graph.point_from_proportion((f - f_min)/(f_max - f_min))
@@ -43,7 +43,7 @@ def get_fourier_graph(
     return graph
 
 def get_fourier_transform(
-    func, t_min, t_max, 
+    func, t_min, t_max,
     complex_to_real_func = DEFAULT_COMPLEX_TO_REAL_FUNC,
     use_almost_fourier = USE_ALMOST_FOURIER_BY_DEFAULT,
     **kwargs ##Just eats these
@@ -130,7 +130,7 @@ class OtherContexts(PiCreatureScene):
                 LaggedStart(
                     ApplyMethod, item,
                     lambda m : (m.set_fill, {"opacity" : 1}),
-                ), 
+                ),
                 morty.change, "thinking",
             )
             self.wait()
@@ -209,7 +209,7 @@ class AddingPureFrequencies(PiCreatureScene):
         graph.set_color(self.A_color)
         pressure = TextMobject("Pressure")
         time = TextMobject("Time")
-        for label in pressure, time:
+        for label in (pressure, time):
             label.scale_in_place(0.8)
         pressure.next_to(axes.y_axis, UP)
         pressure.to_edge(LEFT, buff = MED_SMALL_BUFF)
@@ -291,7 +291,7 @@ class AddingPureFrequencies(PiCreatureScene):
             self.pi_creature.change, "thinking",
             *[
                 ShowCreation(graph, run_time = 4, rate_func = None)
-                for graph in self.A_graph, self.D_graph
+                for graph in (self.A_graph, self.D_graph)
             ]
         )
         self.wait()
@@ -322,7 +322,7 @@ class AddingPureFrequencies(PiCreatureScene):
             map(MoveToTarget, movers),
             [
                 ApplyMethod(mob.shift, FRAME_Y_RADIUS*DOWN, remover = True)
-                for mob in  randy, speaker
+                for mob in (randy, speaker)
             ]
         ))
         self.wait()
@@ -358,7 +358,7 @@ class AddingPureFrequencies(PiCreatureScene):
         self.wait(2)
         # self.play(*[
         #     Transform(
-        #         line, 
+        #         line,
         #         VectorizedPoint(axes.coords_to_point(0, self.equilibrium_height)),
         #         remover = True
         #     )
@@ -410,7 +410,7 @@ class AddingPureFrequencies(PiCreatureScene):
         )
         self.remove(thin_sum_graph)
         self.wait()
-        for x in 2.85, 3.57:
+        for x in (2.85, 3.57):
             rect.move_to(D_axes.coords_to_point(x, 0))
             self.play(GrowFromPoint(rect, rect.get_top()))
             self.wait()
@@ -448,7 +448,7 @@ class AddingPureFrequencies(PiCreatureScene):
 
         F_label = TextMobject("F349")
         C_label = TextMobject("C523")
-        for label, graph in (F_label, F_graph), (C_label, C_graph):
+        for label, graph in ((F_label, F_graph), (C_label, C_graph)):
             label.scale(0.5)
             label.set_color(graph.get_stroke_color())
             label.next_to(graph, UP, SMALL_BUFF)
@@ -462,7 +462,7 @@ class AddingPureFrequencies(PiCreatureScene):
             result *= 0.5
             return result + self.equilibrium_height
         new_sum_graph = self.axes.get_graph(
-            new_sum_func, 
+            new_sum_func,
             num_graph_points = 200
         )
         new_sum_graph.set_color(BLUE_C)
@@ -760,7 +760,7 @@ class MachineThatTreatsOneFrequencyDifferently(Scene):
                 graph, self.get_signal_update_func(graph, frequency),
             ),
             ChangingDecimal(
-                frequency_mob, 
+                frequency_mob,
                 lambda a : 440*interpolate(curr_frequency, frequency, a)
             ),
             run_time = run_time,
@@ -853,7 +853,7 @@ class FourierMachineScene(Scene):
         for label in labels:
             label.scale(self.text_scale_val)
         time_label.next_to(
-            time_axes.coords_to_point(self.time_label_t,0), 
+            time_axes.coords_to_point(self.time_label_t,0),
             DOWN
         )
         intensity_label.next_to(time_axes.y_axis.get_top(), RIGHT)
@@ -893,7 +893,7 @@ class FourierMachineScene(Scene):
         frequency_label = TextMobject("Frequency")
         frequency_label.scale(self.text_scale_val)
         frequency_label.next_to(
-            frequency_axes.x_axis.get_right(), DOWN, 
+            frequency_axes.x_axis.get_right(), DOWN,
             buff = MED_LARGE_BUFF,
             aligned_edge = RIGHT,
         )
@@ -963,7 +963,7 @@ class FourierMachineScene(Scene):
         p_mob = self.get_polarized_mobject(mobject, freq = freq)
         def update_p_mob(p_mob):
             Transform(
-                p_mob, 
+                p_mob,
                 self.get_polarized_mobject(mobject, freq = freq)
             ).update(1)
             mobject.polarized_mobject = p_mob
@@ -1015,7 +1015,7 @@ class FourierMachineScene(Scene):
         origin = self.circle_plane.coords_to_point(0, 0)
         graph_copy = polarized_graph.copy()
         def update_vector(vector, alpha):
-            # Not sure why this is needed, but without smoothing 
+            # Not sure why this is needed, but without smoothing
             # out the alpha like this, the vector would occasionally
             # jump around
             point = center_of_mass([
@@ -1057,7 +1057,7 @@ class FourierMachineScene(Scene):
             v_line.move_to(ctp(0, 0), DOWN)
             self.play(
                 ApplyMethod(
-                    v_line.move_to, 
+                    v_line.move_to,
                     ctp(t_max, 0), DOWN
                 ),
                 self.get_polarized_animation(v_line, freq = freq),
@@ -1114,7 +1114,7 @@ class WrapCosineGraphAroundCircle(FourierMachineScene):
             DashedLine(
                 ORIGIN, 2*UP, color = RED
             ).move_to(axes.coords_to_point(x, 0), DOWN)
-            for x in 1, 2
+            for x in (1, 2)
         ])
         words = self.get_bps_label()
         words.save_state()
@@ -1243,7 +1243,7 @@ class WrapCosineGraphAroundCircle(FourierMachineScene):
         for target_freq in [1.23, 0.2, 0.79, 1.55, self.signal_frequency]:
             self.play(
                 Transform(
-                    v_lines, 
+                    v_lines,
                     self.get_v_lines_indicating_periods(target_freq)
                 ),
                 ChangeDecimalToValue(freq_label, target_freq),
@@ -1255,7 +1255,7 @@ class WrapCosineGraphAroundCircle(FourierMachineScene):
                 self.play(LaggedStart(
                     ApplyFunction, v_lines,
                     lambda mob : (
-                        lambda m : m.shift(0.25*UP).set_color(YELLOW), 
+                        lambda m : m.shift(0.25*UP).set_color(YELLOW),
                         mob
                     ),
                     rate_func = there_and_back
@@ -1328,7 +1328,7 @@ class DrawFrequencyPlot(WrapCosineGraphAroundCircle, PiCreatureScene):
         ))
         self.add(self.get_winding_frequency_label())
         self.beats_per_second_label = self.get_bps_label()
-        self.add(self.beats_per_second_label)        
+        self.add(self.beats_per_second_label)
         self.v_lines_indicating_periods = self.get_v_lines_indicating_periods(
             self.initial_winding_frequency
         )
@@ -1544,7 +1544,7 @@ class DrawFrequencyPlot(WrapCosineGraphAroundCircle, PiCreatureScene):
         self.change_frequency(3.0, run_time = 15, rate_func = None)
         self.wait()
         self.play(
-            graph.restore, 
+            graph.restore,
             time_axes.restore,
             self.get_frequency_change_animation(
                 self.graph, 3.0
@@ -1625,7 +1625,7 @@ class DrawFrequencyPlot(WrapCosineGraphAroundCircle, PiCreatureScene):
         origin = self.circle_plane.coords_to_point(0, 0)
         com = self.get_pol_graph_center_of_mass
         self.center_of_mass_dot_anim = UpdateFromFunc(
-            self.center_of_mass_dot, 
+            self.center_of_mass_dot,
             lambda d : d.move_to(
                 multiplier*(com()-origin)+origin
             )
@@ -1714,7 +1714,7 @@ class ShowLowerFrequency(DrawFrequencyPlot):
             DashedLine(ORIGIN, 1.5*UP).move_to(
                 axes.coords_to_point(x, 0), DOWN
             )
-            for x in 1, 2
+            for x in (1, 2)
         ])
         bps_label = self.get_bps_label(2)
         bps_label.save_state()
@@ -1862,11 +1862,11 @@ class ShowLinearity(DrawFrequencyPlot):
         axes_copy = axes.copy()
         low_freq_graph, high_freq_graph = [
             self.get_cosine_wave(
-                freq = freq, 
+                freq = freq,
                 scale_val = 0.5,
                 shift_val = 0.55,
             )
-            for freq in low_freq, high_freq
+            for freq in (low_freq, high_freq)
         ]
         sum_graph = self.get_time_graph(
             lambda t : sum([
@@ -1885,7 +1885,7 @@ class ShowLinearity(DrawFrequencyPlot):
             "%d Hz"%int(high_freq)
         )
         trips = [
-            (low_freq_label, low_freq_graph, self.low_freq_color), 
+            (low_freq_label, low_freq_graph, self.low_freq_color),
             (high_freq_label, high_freq_graph, self.high_freq_color),
             (sum_label, sum_graph, self.sum_color),
         ]
@@ -1956,7 +1956,7 @@ class ShowLinearity(DrawFrequencyPlot):
             "``Almost-Fourier transform''"
         )
 
-        self.generate_fourier_dot_transform(fourier_graph)                
+        self.generate_fourier_dot_transform(fourier_graph)
 
         self.play(LaggedStart(
             FadeIn, VGroup(
@@ -2013,7 +2013,7 @@ class ShowCommutativeDiagram(ShowLinearity):
                 "tick_frequency" : 0.5,
             },
         }
-    } 
+    }
     def construct(self):
         self.show_diagram()
         self.point_out_spikes()
@@ -2058,7 +2058,7 @@ class ShowCommutativeDiagram(ShowLinearity):
         ]
         funcs.append(lambda t : funcs[0](t)+funcs[1](t))
         colors = [
-            self.low_freq_color, 
+            self.low_freq_color,
             self.high_freq_color,
             self.sum_color,
         ]
@@ -2081,7 +2081,7 @@ class ShowCommutativeDiagram(ShowLinearity):
             fourier_graph.set_color(self.center_of_mass_color)
 
             arrow = Arrow(
-                ta.x_axis.main_line, fa.x_axis.main_line, 
+                ta.x_axis.main_line, fa.x_axis.main_line,
                 color = WHITE,
                 buff = MED_LARGE_BUFF,
             )
@@ -2120,7 +2120,7 @@ class ShowCommutativeDiagram(ShowLinearity):
                 ReplacementTransform(
                     getattr(ta, attr), getattr(fa, attr)
                 )
-                for attr in "x_axis", "y_axis", "graph"
+                for attr in ("x_axis", "y_axis", "graph")
             ]
             anims += [
                 GrowArrow(ta.arrow),
@@ -2157,7 +2157,7 @@ class ShowCommutativeDiagram(ShowLinearity):
             Write(sum_arrows[0].words),
             *[
                 ReplacementTransform(
-                    mob.copy(), ta_group[2], 
+                    mob.copy(), ta_group[2],
                     run_time = 1
                 )
                 for mob in ta_group[:2]
@@ -2265,7 +2265,7 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
                 ApplyMethod, randy.look_at, self.speaker,
                 Animation, randy,
                 ApplyMethod, randy.change, "telepath", randy,
-                Animation, randy, 
+                Animation, randy,
                 Blink, randy,
                 Animation, randy, {"run_time" : 2},
             ),
@@ -2295,12 +2295,12 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
         labels = VGroup(time_label, intensity_label)
         labels.scale(0.75)
         time_label.next_to(
-            axes.x_axis, DOWN, 
+            axes.x_axis, DOWN,
             aligned_edge = RIGHT,
             buff = SMALL_BUFF
         )
         intensity_label.next_to(
-            axes.y_axis, RIGHT, 
+            axes.y_axis, RIGHT,
             aligned_edge = UP,
             buff = SMALL_BUFF
         )
@@ -2308,17 +2308,17 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
 
         func = lambda t : sum([
             np.cos(TAU*f*t)
-            for f in 0.5, 0.7, 1.0, 1.2, 3.0,
+            for f in (0.5, 0.7, 1.0, 1.2, 3.0,)
         ])
         graph = axes.get_graph(func)
         graph.set_color(BLUE)
 
         self.play(
-            FadeIn(axes), 
-            FadeIn(axes.labels), 
+            FadeIn(axes),
+            FadeIn(axes.labels),
             randy.change, "pondering", axes,
             ShowCreation(
-                graph, run_time = 4, 
+                graph, run_time = 4,
                 rate_func = bezier([0, 0, 1, 1])
             ),
             *self.get_broadcast_anims(run_time = 6)
@@ -2350,7 +2350,7 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
         frequency_axes.label = freq_label
 
         fourier_func = get_fourier_transform(
-            time_graph.underlying_function, 
+            time_graph.underlying_function,
             t_min = 0, t_max = 30,
         )
         # def alt_fourier_func(t):
@@ -2387,7 +2387,7 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
         self.spike_rect = spike_rect
         self.to_fourier_arrow = arrow
 
-    def filter_out_high_pitch(self): 
+    def filter_out_high_pitch(self):
         fourier_graph = self.fourier_graph
         spike_rect = self.spike_rect
         frequency_axes = self.frequency_axes
@@ -2457,7 +2457,7 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
                 start_stroke_width = 5,
                 **kwargs
             )
-            for n in 5, 7, 10, 12
+            for n in (5, 7, 10, 12)
         ]
 
 class AskAboutInverseFourier(TeacherStudentsScene):
@@ -2526,7 +2526,7 @@ class ApplyFourierToFourier(DrawFrequencyPlot):
         self.remove(fourier_graph)
         self.play(
             ReplacementTransform(
-                fourier_graph.copy(), 
+                fourier_graph.copy(),
                 new_fourier_graph
             ),
             ApplyMethod(
@@ -2611,10 +2611,10 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
 
         time_axes = self.get_time_axes()
         time_axes.background_rectangle = BackgroundRectangle(
-            time_axes, 
+            time_axes,
             fill_opacity = 0.9,
             buff = MED_SMALL_BUFF,
-        ) 
+        )
         time_axes.add_to_back(time_axes.background_rectangle)
         time_axes.scale(self.time_axes_scale_val)
         time_axes.to_corner(UP+LEFT, buff = 0)
@@ -2668,7 +2668,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
         self.add(lines_update_anim)
 
         self.change_frequency(
-            2.04, 
+            2.04,
             added_anims = [
                 self.center_of_mass_dot_anim,
             ],
@@ -2693,7 +2693,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
             0, include_background_rectangle = True,
         )
         number_label_update_anim = ContinualChangingDecimal(
-            number_label, 
+            number_label,
             lambda a : plane.point_to_number(dot.get_center()),
             position_update_func = lambda l : l.next_to(
                 dot, DOWN+RIGHT,
@@ -2717,7 +2717,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
         self.play(FadeIn(number_label))
         self.add(number_label_update_anim)
         self.play(MoveAlongPath(
-            dot, flower_path, 
+            dot, flower_path,
             run_time = 10,
             rate_func = bezier([0, 0, 1, 1])
         ))
@@ -2788,7 +2788,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
         #Show arc
         arc, circle = [
             Line(ORIGIN, t*UP)
-            for t in get_t(), TAU
+            for t in (get_t(), TAU)
         ]
         for mob in arc, circle:
             mob.insert_n_anchor_points(20)
@@ -2824,7 +2824,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
         self.play(
             ghost_dot.move_to, TAU*RIGHT,
             ShowCreation(
-                circle, 
+                circle,
                 rate_func = lambda a : interpolate(
                     2.0/TAU, 1, smooth(a)
                 ),
@@ -2837,7 +2837,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
         exp_expression = TexMobject("e", "^{-", "2\\pi i", "f", "t}")
         e, minus, two_pi_i, f, t = exp_expression
         exp_expression.next_to(
-            plane.coords_to_point(1, 1), 
+            plane.coords_to_point(1, 1),
             UP+RIGHT
         )
         f.set_color(RED)
@@ -2878,7 +2878,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
             ghost_dot, rate = TAU
         )
         self.add(ambient_ghost_dot_movement)
-        
+
         self.play(
             Write(time_label),
             GrowArrow(time_label.arrow),
@@ -3277,7 +3277,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
         origin = plane.coords_to_point(0, 0)
         com_dot = self.center_of_mass_dot
         com_vector = Arrow(
-            origin, com_dot.get_center(), 
+            origin, com_dot.get_center(),
             buff = 0
         )
         com_vector.match_style(com_dot)
@@ -3315,7 +3315,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
             axes.get_graph(
                 graph.underlying_function, x_min = 0, x_max = t_max,
             ).match_style(graph)
-            for t_max in 3, 6
+            for t_max in (3, 6)
         ]
         for g in short_graph, long_graph:
             self.get_polarized_mobject(g, freq = self.initial_winding_frequency)
@@ -3340,7 +3340,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
         )
         self.remove(graph.polarized_mobject)
         self.play(
-            com_dot.move_to, 
+            com_dot.move_to,
             center_of_mass(short_graph.polarized_mobject.points),
             com_vector_update,
             time_span.restore,
@@ -3365,14 +3365,14 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
 
         #Squish_graph
         to_squish = VGroup(
-            axes, graph, 
+            axes, graph,
             time_span,
         )
         to_squish.generate_target()
         squish_factor = 0.75
         to_squish.target.stretch(squish_factor, 0, about_edge = LEFT)
         pairs = zip(
-            to_squish.family_members_with_points(), 
+            to_squish.family_members_with_points(),
             to_squish.target.family_members_with_points()
         )
         to_unsquish = list(axes.x_axis.numbers) + list(axes.labels)
@@ -3389,7 +3389,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
         )
         long_graph.move_to(graph, LEFT)
         self.play(
-            com_dot.move_to, 
+            com_dot.move_to,
             center_of_mass(long_graph.polarized_mobject.points),
             com_vector_update,
             time_span.stretch, 2, 0, {"about_edge" : LEFT},
@@ -3400,7 +3400,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
                         0.5, 1, smooth(a)
                     )
                 )
-                for mob in long_graph, long_graph.polarized_mobject
+                for mob in (long_graph, long_graph.polarized_mobject)
             ],
             run_time = 2
         )
@@ -3458,7 +3458,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
         )
         # com_vector_copies = get_com_vector_copies(11)
         # self.play(ReplacementTransform(
-        #     VGroup(com_vector.copy()), 
+        #     VGroup(com_vector.copy()),
         #     com_vector_copies,
         #     path_arc = TAU/10,
         #     run_time = 1.5,
@@ -3472,7 +3472,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
 
     def comment_on_current_signal(self):
         graph = self.graph
-        com_dot = self.center_of_mass_dot 
+        com_dot = self.center_of_mass_dot
         com_vector = self.com_vector
         com_vector_update = self.com_vector_update
         axes = self.time_axes
@@ -3552,8 +3552,8 @@ class SimpleCosineWrappingAroundCircle(WriteComplexExponentialExpression):
         self.generate_center_of_mass_dot_update_anim()
 
         self.change_frequency(
-            2.0, 
-            rate_func = None, 
+            2.0,
+            rate_func = None,
             run_time = 30
         )
         self.wait()
@@ -3592,7 +3592,7 @@ class SummarizeTheFullTransform(DrawFrequencyPlot):
         time_axes = self.get_time_axes()
         time_label, intensity_label = time_axes.labels
         time_label.next_to(
-            time_axes.x_axis.get_right(), 
+            time_axes.x_axis.get_right(),
             DOWN, SMALL_BUFF
         )
         intensity_label.next_to(time_axes.y_axis, UP, buff = SMALL_BUFF)
@@ -3619,7 +3619,7 @@ class SummarizeTheFullTransform(DrawFrequencyPlot):
         def func(t):
             return 0.5*(2+np.cos(2*TAU*t) + np.cos(3*TAU*t))
         fourier_func = get_fourier_transform(
-            func, 
+            func,
             t_min = time_axes.x_min,
             t_max = time_axes.x_max,
             use_almost_fourier = False,
@@ -3762,11 +3762,11 @@ class SummarizeTheFullTransform(DrawFrequencyPlot):
         self.generate_center_of_mass_dot_update_anim(multiplier = 4.5)
         self.generate_fourier_dot_transform(fourier_graph)
         self.change_frequency(
-            5.0, 
-            rate_func = None, 
+            5.0,
+            rate_func = None,
             run_time = winding_run_time,
             added_anims = [
-                g_hat_f_indication, 
+                g_hat_f_indication,
                 update_pol_graph,
                 Animation(frequency_axes.x_axis.numbers),
                 Animation(self.fourier_graph_dot),
@@ -3785,7 +3785,7 @@ class SummarizeFormula(Scene):
                 expression.get_part_by_tex(p1),
                 expression.get_part_by_tex(p2),
             ))
-            for p1, p2 in ("e", "t}"), ("g({}", "t}"), ("\\int", "dt")
+            for p1, p2 in (("e", "t}"), ("g({}", "t}"), ("\\int", "dt"))
         ]
 
         self.add(expression)
@@ -3820,7 +3820,7 @@ class OneSmallNote(TeacherStudentsScene):
     def construct(self):
         self.teacher_says(
             "Just one \\\\ small note...",
-            # target_mode = 
+            # target_mode =
         )
         self.change_student_modes("erm", "happy", "sassy")
         self.wait(2)
@@ -3843,7 +3843,7 @@ class BoundsAtInfinity(SummarizeFormula):
         bound_rects.set_color(TEAL)
         inf_bounds = VGroup(*[
             VGroup(TexMobject(s + "\\infty"))
-            for s in "-", "+"
+            for s in ("-", "+")
         ])
         decimal_bounds = VGroup(*[DecimalNumber(0) for x in range(2)])
         for bound, inf_bound, d_bound in zip(bounds, inf_bounds, decimal_bounds):
@@ -3889,7 +3889,7 @@ class BoundsAtInfinity(SummarizeFormula):
             VGroup(axes, graph).stretch, 0.05, 0,
             Transform(time_interval, wide_interval),
             UpdateFromAlphaFunc(
-                axes.x_axis.numbers, 
+                axes.x_axis.numbers,
                 lambda m, a : m.set_fill(opacity = 1-a)
             ),
             *decimal_updates,
@@ -3903,7 +3903,7 @@ class BoundsAtInfinity(SummarizeFormula):
         axes = Axes(
             x_min = -140,
             x_max = 140,
-            y_min = -2, 
+            y_min = -2,
             y_max = 2,
             number_line_config = {
                 "include_tip" : False,
@@ -3928,7 +3928,7 @@ class BoundsAtInfinity(SummarizeFormula):
     def get_time_interval(self, t1, t2):
         line = Line(*[
             self.axes.coords_to_point(t, 0)
-            for t in t1, t2
+            for t in (t1, t2)
         ])
         rect = Rectangle(
             stroke_width = 0,
@@ -4008,7 +4008,7 @@ class ShowUncertaintyPrinciple(Scene):
         self.wait(2)
         self.add(*[
             ContinualUpdateFromFunc(graph, get_update_func(axes))
-            for graph, axes in (top_graph, top_axes), (bottom_graph, bottom_axes)
+            for graph, axes in ((top_graph, top_axes), (bottom_graph, bottom_axes))
         ])
         for factor in factors:
             self.play(
@@ -4050,7 +4050,7 @@ class SubscribeOrBinge(PiCreatureScene):
             video.set_color(color)
         videos.move_to(binge.get_bottom(), UP)
         video_anim = LaggedStart(
-            Succession, videos, 
+            Succession, videos,
             lambda v : (
                 FadeIn, v,
                 ApplyMethod, v.shift, 5*DOWN, {"run_time" : 6},
@@ -4275,18 +4275,3 @@ class Thumbnail(Scene):
         graph.next_to(title, UP)
         fourier_graph.next_to(title, DOWN)
         self.add(pol_graphs, title, graph, fourier_graph)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/fractal_dimension.py
+++ b/old_projects/fractal_dimension.py
@@ -1,4 +1,6 @@
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 def break_up(mobject, factor = 1.3):
     mobject.scale_in_place(factor)
@@ -498,7 +500,7 @@ class ExamplesOfDimension(Scene):
     def construct(self):
         labels = VGroup(*[
             TextMobject("%s-dimensional"%s)
-            for s in "1.585", "1.262", "1.21"
+            for s in ("1.585", "1.262", "1.21")
         ])
         fractals = VGroup(*[
             Sierpinski(order = 7),
@@ -548,7 +550,7 @@ class DimensionForNaturalNumbers(Scene):
     def construct(self):
         labels = VGroup(*[
             TextMobject("%d-dimensional"%d)
-            for d in 1, 2, 3
+            for d in (1, 2, 3)
         ])
         for label, vect in zip(labels, [LEFT, ORIGIN, RIGHT]):
             label.to_edge(vect)
@@ -2380,7 +2382,7 @@ class DifferentSlopesAtDifferentScales(IntroduceLogLogPlot):
         words.to_edge(RIGHT)
         arrows = VGroup(*[
             Arrow(words.get_left(), self.input_to_graph_point(x))
-            for x in 1, 7, 12
+            for x in (1, 7, 12)
         ])
 
 
@@ -2567,7 +2569,7 @@ class WhatSlopeDoesLogLogPlotApproach(IntroduceLogLogPlot):
         words = TextMobject(self.words)
         p1, p2 = [
             data_dots[int(alpha*len(data_dots))].get_center()
-            for alpha in 0.3, 0.5
+            for alpha in (0.3, 0.5)
         ]
         words.rotate(Line(p1, p2).get_angle())
         words.next_to(p1, RIGHT, aligned_edge = DOWN, buff = 1.5)
@@ -2639,7 +2641,7 @@ class SmoothBritainLogLogPlot(IntroduceLogLogPlot):
 
         p1, p2, p3, p4 = [
             self.input_to_graph_point(x)
-            for x in 1, 2, 7, 8
+            for x in (1, 2, 7, 8)
         ]
         interim_point1 = p2[0]*RIGHT + p1[1]*UP
         interim_point2 = p4[0]*RIGHT + p3[1]*UP
@@ -2742,7 +2744,7 @@ class CompareBritainAndNorway(Scene):
                 mob.set_stroke, None, 0,
                 mob.set_fill, BLUE, 1
             ]
-            for mob in britain, norway
+            for mob in (britain, norway)
         ]))
         self.wait(2)
 

--- a/old_projects/generate_logo.py
+++ b/old_projects/generate_logo.py
@@ -43,7 +43,7 @@ class LogoGeneration(Scene):
             self.interpolation_factor
         )
         for mob, color in [(iris, self.sphere_brown), (circle, self.circle_brown)]:
-            mob.set_color(color, lambda (x, y, z) : x < 0 and y > 0)
+            mob.set_color(color, lambda x_y_z : x_y_z[0] < 0 and x_y_z[1] > 0)
             mob.set_color(
                 "black", 
                 lambda point: np.linalg.norm(point) < \

--- a/old_projects/hanoi.py
+++ b/old_projects/hanoi.py
@@ -13,7 +13,7 @@ class CountingScene(Scene):
     }
     def setup(self):
         self.dots = VGroup()
-        self.number = 0        
+        self.number = 0
         self.number_mob = VGroup(TexMobject(str(self.number)))
         self.number_mob.scale(self.num_scale_factor)
         self.number_mob.shift(self.num_start_location)
@@ -39,7 +39,7 @@ class CountingScene(Scene):
         down_right = (0.5)*RIGHT + (np.sqrt(3)/2)*DOWN
         dots = VGroup(*[
             Dot(
-                point, 
+                point,
                 radius = 0.25,
                 fill_opacity = 0,
                 stroke_width = 2,
@@ -91,9 +91,9 @@ class CountingScene(Scene):
         self.number += 1
         added_anims = list(added_anims) #Silly python objects...
         added_anims += self.get_new_configuration_animations()
-        while continue_rolling_over:          
+        while continue_rolling_over:
             moving_dot.target.replace(
-                self.dot_template_iterators[place].next()
+                next(self.dot_template_iterators[place])
             )
             if run_all_at_once:
                 denom = float(num_rollovers+1)
@@ -107,8 +107,8 @@ class CountingScene(Scene):
                         anim.original_rate_func = anim.rate_func
                     anim.rate_func = get_modified_rate_func(anim)
             self.play(
-                MoveToTarget(moving_dot), 
-                *added_anims, 
+                MoveToTarget(moving_dot),
+                *added_anims,
                 run_time = run_time_per_anim
             )
             self.curr_configurations[place].add(moving_dot)
@@ -259,7 +259,7 @@ class TowersOfHanoiScene(Scene):
     def add_pegs(self):
         peg = Rectangle(
             height = self.peg_height,
-            width = self.peg_width, 
+            width = self.peg_width,
             stroke_width = 0,
             fill_color = GREY_BROWN,
             fill_opacity = 1,
@@ -267,7 +267,7 @@ class TowersOfHanoiScene(Scene):
         peg.move_to(self.middle_peg_bottom, DOWN)
         self.pegs = VGroup(*[
             peg.copy().shift(vect)
-            for vect in self.peg_spacing*LEFT, ORIGIN, self.peg_spacing*RIGHT
+            for vect in (self.peg_spacing*LEFT, ORIGIN, self.peg_spacing*RIGHT)
         ])
         self.add(self.pegs)
         if self.include_peg_labels:
@@ -288,7 +288,7 @@ class TowersOfHanoiScene(Scene):
             )
             for width, color in zip(
                 np.linspace(
-                    self.disk_min_width, 
+                    self.disk_min_width,
                     self.disk_max_width,
                     self.num_disks
                 ),
@@ -314,7 +314,7 @@ class TowersOfHanoiScene(Scene):
         self.disks.target.arrange_submobjects(DOWN, buff = 0)
         self.disks.target.move_to(self.pegs[0], DOWN)
         self.play(
-            MoveToTarget(self.disks), 
+            MoveToTarget(self.disks),
             **kwargs
         )
         self.disk_tracker = [
@@ -389,7 +389,7 @@ class TowersOfHanoiScene(Scene):
                 run_time = self.default_disk_run_time_off_peg
         disks = VGroup(*[self.disks[index] for index in disk_indices])
         max_disk_index = max(disk_indices)
-        next_peg = self.pegs[next_peg_index]        
+        next_peg = self.pegs[next_peg_index]
         curr_peg_index = self.disk_index_to_peg_index(max_disk_index)
         curr_peg = self.pegs[curr_peg_index]
         if self.min_disk_index_on_peg(curr_peg_index) != max_disk_index:
@@ -423,7 +423,7 @@ class ConstrainedTowersOfHanoiScene(TowersOfHanoiScene):
     def get_next_disk_0_peg(self):
         if not hasattr(self, "total_disk_0_movements"):
             self.total_disk_0_movements = 0
-        curr_peg_index = self.disk_index_to_peg_index(0)        
+        curr_peg_index = self.disk_index_to_peg_index(0)
         if (self.total_disk_0_movements/2)%2 == 0:
             result = curr_peg_index + 1
         else:
@@ -463,7 +463,7 @@ class Keith(PiCreature):
     CONFIG = {
         "color" : GREEN_D
     }
-        
+
 def get_binary_tex_mobs(num_list):
     result = VGroup()
     zero_width = TexMobject("0").get_width()
@@ -519,7 +519,7 @@ class IntroduceKeith(Scene):
         bubble = keith.get_bubble(SpeechBubble, width = 7)
         bubble.write("01101011 $\\Rightarrow$ Towers of Hanoi")
         zero_width = bubble.content[0].get_width()
-        one_width = bubble.content[1].get_width()        
+        one_width = bubble.content[1].get_width()
         for mob in bubble.content[:8]:
             if abs(mob.get_width() - zero_width) < 0.01:
                 mob.set_color(GREEN)
@@ -620,7 +620,7 @@ class IntroduceTowersOfHanoi(TowersOfHanoiScene):
         self.pegs.move_to(bottom)
         self.play(
             ApplyMethod(
-                self.pegs.restore, 
+                self.pegs.restore,
                 submobject_mode = "lagged_start",
                 run_time = 2
             ),
@@ -654,10 +654,10 @@ class IntroduceTowersOfHanoi(TowersOfHanoiScene):
             disk_groups.add(group)
         disk_groups.arrange_submobjects()
         disk_groups.next_to(self.peg_labels, DOWN)
-        
+
         self.play(FadeIn(
-            disk_groups, 
-            run_time = 2, 
+            disk_groups,
+            run_time = 2,
             submobject_mode = "lagged_start"
         ))
         for group in reversed(list(disk_groups)):
@@ -867,7 +867,7 @@ class IntroduceBase10(Scene):
             "3(10) + ",
             "7"
         )
-        expansion.next_to(number, DOWN, buff = LARGE_BUFF, aligned_edge = RIGHT)        
+        expansion.next_to(number, DOWN, buff = LARGE_BUFF, aligned_edge = RIGHT)
         arrows = VGroup()
         number.generate_target()
 
@@ -981,7 +981,7 @@ class DecimalCountingAtHundredsScale(CountingScene):
         VGroup(self.number_mob, added_zeros).to_edge(RIGHT, buff = LARGE_BUFF)
         VGroup(self.dot_templates[0], self.curr_configurations[0]).to_edge(RIGHT)
         Transform(
-            self.arrows[0], 
+            self.arrows[0],
             Arrow(self.number_mob, self.dot_templates[0], color = self.power_colors[0])
         ).update(1)
 
@@ -1165,7 +1165,7 @@ class BinaryCountingAtEveryScale(Scene):
         def get_run_through(mobs):
             return Succession(*[
                 Transform(
-                    curr_bits, mob, 
+                    curr_bits, mob,
                     rate_func = squish_rate_func(smooth, 0, 0.5)
                 )
                 for mob in mobs
@@ -1277,7 +1277,7 @@ class IntroduceSolveByCounting(TowersOfHanoiScene):
         self.play(FadeIn(cross))
         self.wait()
         self.move_disk_to_peg(
-            1, 2, stay_on_peg = False, 
+            1, 2, stay_on_peg = False,
             added_anims = [FadeOut(cross)]
         )
         self.play(
@@ -1288,7 +1288,7 @@ class IntroduceSolveByCounting(TowersOfHanoiScene):
             Transform(words, word_list[0]),
         )
         self.move_disk(
-            0, 
+            0,
             added_anims = [self.get_increment_animation()],
             run_time = 2
         )
@@ -1357,7 +1357,7 @@ class IntroduceSolveByCounting(TowersOfHanoiScene):
         ])
         bit_mobs.scale(2)
         self.bit_mobs_iter = it.cycle(bit_mobs)
-        self.curr_bit_mob = self.bit_mobs_iter.next()
+        self.curr_bit_mob = next(self.bit_mobs_iter)
 
         for bit_mob in bit_mobs:
             bit_mob.align_data(self.curr_bit_mob)
@@ -1370,7 +1370,7 @@ class IntroduceSolveByCounting(TowersOfHanoiScene):
     def get_increment_animation(self):
         return Succession(
             Transform(
-                self.curr_bit_mob, self.bit_mobs_iter.next(),
+                self.curr_bit_mob, next(self.bit_mobs_iter),
                 submobject_mode = "lagged_start",
                 path_arc = -np.pi/3
             ),
@@ -1454,7 +1454,7 @@ class RecursiveSolution(TowersOfHanoiScene):
         sub_sub_steps[1].set_color(RED)
         sub_sub_steps_brace = Brace(sub_sub_steps, UP)
         steps = VGroup(
-            title, sub_step_brace, sub_steps, 
+            title, sub_step_brace, sub_steps,
             sub_sub_steps_brace, sub_sub_steps
         )
         steps.arrange_submobjects(DOWN)
@@ -1470,7 +1470,7 @@ class RecursiveSolution(TowersOfHanoiScene):
             big_disk.set_fill, GREEN,
             big_disk.label.set_fill, BLACK,
         )
-        big_disk.add(self.eyes)        
+        big_disk.add(self.eyes)
         self.blink()
         self.wait()
         self.change_mode("angry")
@@ -1778,7 +1778,7 @@ class SolveTwoDisksByCounting(SolveSixDisksByCounting):
         for disk_index in 0, 1, 0:
             self.play(self.get_increment_animation())
             self.move_disk(
-                disk_index, 
+                disk_index,
                 stay_on_peg = False,
             )
             self.wait()
@@ -1796,7 +1796,7 @@ class ShowFourDiskFourBitsParallel(IntroduceSolveByCounting):
         self.wait()
         self.play(self.get_increment_animation())
         self.move_disk(
-            self.num_disks-1, 
+            self.num_disks-1,
             stay_on_peg = False,
         )
         self.wait()
@@ -1810,7 +1810,7 @@ class ShowFourDiskFourBitsParallel(IntroduceSolveByCounting):
         run_time = float(self.subtask_run_time)/len(sequence)
         for disk_index in get_ruler_sequence(self.num_disks-2):
             self.move_disk(
-                disk_index, 
+                disk_index,
                 run_time = run_time,
                 stay_on_peg = False,
             )
@@ -1836,10 +1836,10 @@ class ShowFourDiskFourBitsParallel(IntroduceSolveByCounting):
 
     def get_increment_animation(self):
         return Transform(
-            self.curr_bit_mob, self.bit_mobs_iter.next(),
+            self.curr_bit_mob, next(self.bit_mobs_iter),
             path_arc = -np.pi/3,
         )
- 
+
 class ShowThreeDiskThreeBitsParallel(ShowFourDiskFourBitsParallel):
     CONFIG = {
         "num_disks" : 3,
@@ -2030,7 +2030,7 @@ class RecursiveSolutionToConstrained(RecursiveSolution):
                 "Move disk %d,"%d,
                 "Move %d-tower"%d,
             ).set_color_by_tex("Move disk %d,"%d, color)
-            for d, color in (3, GREEN), (2, RED), (1, BLUE_C)
+            for d, color in ((3, GREEN), (2, RED), (1, BLUE_C))
         ]
         sub_steps, sub_sub_steps = subdivisions[:2]
         for steps in subdivisions:
@@ -2149,7 +2149,7 @@ class RecursiveSolutionToConstrained(RecursiveSolution):
             big_disk.set_fill, RED,
             big_disk.label.set_fill, BLACK,
         )
-        big_disk.add(self.eyes)        
+        big_disk.add(self.eyes)
         self.blink()
 
         #Solve subproblem
@@ -2192,7 +2192,7 @@ class RecursiveSolutionToConstrained(RecursiveSolution):
             last_subdivisions.append(group)
         smaller_subdivision.set_fill(opacity = 0)
         self.play(
-            steps.shift, 
+            steps.shift,
             (FRAME_Y_RADIUS-sub_sub_steps.get_top()[1]-MED_SMALL_BUFF)*UP,
             self.eyes.look_at_anim(steps)
         )
@@ -2224,7 +2224,7 @@ class RecursiveSolutionToConstrained(RecursiveSolution):
         ]
         for disk_index, peg_index in movements:
             self.move_disk_to_peg(
-                disk_index, peg_index, 
+                disk_index, peg_index,
                 stay_on_peg = False
             )
         self.wait()
@@ -2259,7 +2259,7 @@ class SolveConstrainedByCounting(ConstrainedTowersOfHanoiScene):
             ternary_mobs.add(ternary_mob)
         ternary_mobs.next_to(self.peg_labels, DOWN)
         self.ternary_mob_iter = it.cycle(ternary_mobs)
-        self.curr_ternary_mob = self.ternary_mob_iter.next()
+        self.curr_ternary_mob = next(self.ternary_mob_iter)
         self.add(self.curr_ternary_mob)
 
         for index in get_ternary_ruler_sequence(self.num_disks-1):
@@ -2270,7 +2270,7 @@ class SolveConstrainedByCounting(ConstrainedTowersOfHanoiScene):
     def increment_animation(self):
         return Succession(
             Transform(
-                self.curr_ternary_mob, self.ternary_mob_iter.next(),
+                self.curr_ternary_mob, next(self.ternary_mob_iter),
                 submobject_mode = "lagged_start",
                 path_arc = np.pi/6,
             ),
@@ -2429,7 +2429,7 @@ class TernaryCountingSelfSimilarPattern(Scene):
         ])
         ternary_mobs.scale(2)
         ternary_mob_iter = it.cycle(ternary_mobs)
-        curr_ternary_mob = ternary_mob_iter.next()
+        curr_ternary_mob = next(ternary_mob_iter)
 
         for trits in ternary_mobs:
             trits.align_data(curr_ternary_mob)
@@ -2437,7 +2437,7 @@ class TernaryCountingSelfSimilarPattern(Scene):
                 trit.set_color(color)
         def get_increment():
             return Transform(
-                curr_ternary_mob, ternary_mob_iter.next(),
+                curr_ternary_mob, next(ternary_mob_iter),
                 submobject_mode = "lagged_start",
                 path_arc = -np.pi/3
             )
@@ -2473,7 +2473,7 @@ class CountInTernary(IntroduceTernaryCounting):
 class SolveConstrainedWithTernaryCounting(ConstrainedTowersOfHanoiScene):
     CONFIG = {
         "num_disks" : 4,
-    }    
+    }
     def construct(self):
         for x in range(3**self.num_disks-1):
             self.increment(run_time = 0.75)
@@ -2491,8 +2491,8 @@ class SolveConstrainedWithTernaryCounting(ConstrainedTowersOfHanoiScene):
         for trits in ternary_mobs:
             trits.align_data(ternary_mobs[0])
             trits.set_color_by_gradient(*self.disk_start_and_end_colors)
-        self.ternary_mob_iter = it.cycle(ternary_mobs)            
-        self.curr_ternary_mob = self.ternary_mob_iter.next().copy()            
+        self.ternary_mob_iter = it.cycle(ternary_mobs)
+        self.curr_ternary_mob = self.ternary_mob_iter.next().copy()
         self.disk_index_iter = it.cycle(
             get_ternary_ruler_sequence(self.num_disks-1)
         )
@@ -2504,15 +2504,15 @@ class SolveConstrainedWithTernaryCounting(ConstrainedTowersOfHanoiScene):
 
     def increment_number(self, run_time = 1):
         self.play(Transform(
-            self.curr_ternary_mob, self.ternary_mob_iter.next(),
+            self.curr_ternary_mob, next(self.ternary_mob_iter),
             path_arc = -np.pi/3,
-            submobject_mode = "lagged_start", 
+            submobject_mode = "lagged_start",
             run_time = run_time,
         ))
 
     def move_next_disk(self, run_time = None, stay_on_peg = False):
         self.move_disk(
-            self.disk_index_iter.next(), 
+            next(self.disk_index_iter),
             run_time = run_time,
             stay_on_peg = stay_on_peg
         )
@@ -2538,7 +2538,7 @@ class DescribeSolutionByCountingToConstrained(SolveConstrainedWithTernaryCountin
         brace = braces[0]
         word = words[0]
         words[0].set_color(color)
-        self.increment_number()        
+        self.increment_number()
         self.play(
             FadeIn(brace),
             Write(word, run_time = 1),
@@ -2555,7 +2555,7 @@ class DescribeSolutionByCountingToConstrained(SolveConstrainedWithTernaryCountin
         self.increment_number()
         self.move_next_disk(stay_on_peg = True)
         self.wait()
-        
+
         #Count 10
         color = MAROON_B
         words[1].set_color(color)
@@ -2781,7 +2781,7 @@ class ShowSomeGraph(Scene):
         title.to_edge(UP)
 
         nodes = VGroup(*map(Dot, [
-            2*LEFT, 
+            2*LEFT,
             UP,
             DOWN,
             2*RIGHT,
@@ -2801,15 +2801,15 @@ class ShowSomeGraph(Scene):
         edges = VGroup()
         for i, j in edge_pairs:
             edges.add(Line(
-                nodes[i].get_center(), 
-                nodes[j].get_center(), 
+                nodes[i].get_center(),
+                nodes[j].get_center(),
             ))
 
         self.play(Write(title))
         for mob in nodes, edges:
             mob.set_color_by_gradient(YELLOW, MAROON_B)
             self.play(ShowCreation(
-                mob, 
+                mob,
                 submobject_mode = "lagged_start",
                 run_time = 2,
             ))
@@ -2890,7 +2890,7 @@ class SierpinskiGraphScene(Scene):
             towers.move_to(node)
             node.towers = towers
             node.add(towers)
-            towers_scene.move_disk(disk_index, run_time = 0)            
+            towers_scene.move_disk(disk_index, run_time = 0)
 
     def distance_between_nodes(self, i, j):
         return np.linalg.norm(
@@ -2955,7 +2955,7 @@ class SierpinskiGraphScene(Scene):
 
 class IntroduceGraphStructure(SierpinskiGraphScene):
     CONFIG = {
-        "include_towers" : True, 
+        "include_towers" : True,
         "graph_stroke_width" : 3,
         "num_disks" : 3,
     }
@@ -2986,7 +2986,7 @@ class IntroduceGraphStructure(SierpinskiGraphScene):
             vect = -vect
 
     def define_edges(self):
-        nodes = [self.nodes[i] for i in 12, 14]
+        nodes = [self.nodes[i] for i in (12, 14)]
         for node, vect in zip(nodes, [LEFT, RIGHT]):
             node.save_state()
             node.generate_target()
@@ -3096,7 +3096,7 @@ class DescribeTriforcePattern(SierpinskiGraphScene):
         ]
         def wiggle_island(island):
             return ApplyMethod(
-                island.rotate_in_place, np.pi/12, 
+                island.rotate_in_place, np.pi/12,
                 run_time = 1,
                 rate_func = wiggle
             )
@@ -3205,10 +3205,10 @@ class PatreonThanks(Scene):
         special_thanks.set_color(YELLOW)
         special_thanks.shift(3*UP)
 
-        left_patrons = VGroup(*map(TextMobject, 
+        left_patrons = VGroup(*map(TextMobject,
             self.specific_patrons[:n_patrons/2]
         ))
-        right_patrons = VGroup(*map(TextMobject, 
+        right_patrons = VGroup(*map(TextMobject,
             self.specific_patrons[n_patrons/2:]
         ))
         for patrons, vect in (left_patrons, LEFT), (right_patrons, RIGHT):
@@ -3287,7 +3287,7 @@ class ShowSierpinskiCurvesOfIncreasingOrder(Scene):
         self.add(graph)
         self.wait()
         self.play(ShowCreation(path, run_time = 3, rate_func = None))
-        self.wait()   
+        self.wait()
         self.play(graph.fade, 0.5, Animation(path))
         for other_graph in graphs[1:]:
             other_graph.fade(0.5)
@@ -3343,7 +3343,7 @@ class Part1Thumbnail(Scene):
             max_order = self.sierpinski_order,
             skip_animations = True,
         )
-        sierpinski_scene.path.set_stroke(width = 10)        
+        sierpinski_scene.path.set_stroke(width = 10)
         sierpinski = VGroup(*sierpinski_scene.get_mobjects())
         sierpinski.scale(0.9)
         sierpinski.to_corner(DOWN+RIGHT)
@@ -3370,21 +3370,3 @@ class Part2Thumbnail(Part1Thumbnail):
     CONFIG = {
         "part_number" : 2
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/highD.py
+++ b/old_projects/highD.py
@@ -52,12 +52,12 @@ class Slider(NumberLine):
         self.label = label
 
     def add_real_estate_ticks(
-        self, 
+        self,
         re_per_tick = 0.05,
         colors = [BLUE, RED],
         max_real_estate = 1,
         ):
-        self.real_estate_ticks = VGroup(*[   
+        self.real_estate_ticks = VGroup(*[
             self.get_tick(self.center_value + u*np.sqrt(x + re_per_tick))
             for x in np.arange(0, max_real_estate, re_per_tick)
             for u in [-1, 1]
@@ -143,7 +143,7 @@ class SliderScene(Scene):
             self.center_point[0] + np.sqrt(self.total_real_estate)
         )
         self.sliders = sliders
-        
+
         self.add_labels_to_sliders()
         self.add(sliders)
 
@@ -178,7 +178,7 @@ class SliderScene(Scene):
         ], run_time = run_time)
 
     def get_target_vect_from_subset_of_values(self, values, fixed_indices = None):
-        if fixed_indices is None: 
+        if fixed_indices is None:
             fixed_indices = []
         curr_vector = self.get_vector()
         target_vector = np.array(self.center_point, dtype = 'float')
@@ -351,7 +351,7 @@ class MathIsATease(Scene):
         eye_bottom_y = randy.eyes.get_bottom()[1]
         self.play(
             ApplyMethod(
-                lashes.apply_function, 
+                lashes.apply_function,
                 lambda p : [p[0], eye_bottom_y, p[2]],
                 rate_func = Blink.CONFIG["rate_func"],
             ),
@@ -360,7 +360,7 @@ class MathIsATease(Scene):
         )
         self.play(
             ApplyMethod(
-                lashes.apply_function, 
+                lashes.apply_function,
                 lambda p : [p[0], eye_bottom_y, p[2]],
                 rate_func = Blink.CONFIG["rate_func"],
             ),
@@ -392,7 +392,7 @@ class CircleToPairsOfPoints(Scene):
         equation.to_corner(UP+LEFT)
         equation.add_background_rectangle()
 
-        coord_pair = TexMobject("(", "-%.02f"%x, ",", "-%.02f"%y, ")") 
+        coord_pair = TexMobject("(", "-%.02f"%x, ",", "-%.02f"%y, ")")
         fixed_numbers = coord_pair.get_parts_by_tex("-")
         fixed_numbers.set_fill(opacity = 0)
         coord_pair.add_background_rectangle()
@@ -485,7 +485,7 @@ class CircleToPairsOfPoints(Scene):
         plane.remove(*plane.coordinate_labels)
         self.play(
             Rotate(
-                plane, np.pi/3, 
+                plane, np.pi/3,
                 run_time = 4,
                 rate_func = there_and_back
             ),
@@ -600,7 +600,7 @@ class TODOTease(TODOStub):
 class AskAboutLongerLists(TeacherStudentsScene):
     def construct(self):
         question = TextMobject(
-            "What about \\\\", 
+            "What about \\\\",
             "$(x_1, x_2, x_3, x_4)?$"
         )
         tup = question[1]
@@ -666,7 +666,7 @@ class Professionals(PiCreatureScene):
 
     def add_equation(self):
         quaternion = TexMobject(
-            "\\frac{1}{2}", "+", 
+            "\\frac{1}{2}", "+",
             "0", "\\textbf{i}", "+",
             "\\frac{\\sqrt{6}}{4}", "\\textbf{j}", "+",
             "\\frac{\\sqrt{6}}{4}", "\\textbf{k}",
@@ -745,7 +745,7 @@ class Professionals(PiCreatureScene):
                 rate_func = squish_rate_func(smooth, a, a+0.5)
             )
             for pi, mode, a in zip(
-                self.pi_creatures, 
+                self.pi_creatures,
                 ["confused", "sassy", "erm"],
                 np.linspace(0, 0.5, len(self.pi_creatures))
             )
@@ -821,7 +821,7 @@ class RotatingSphereWithWanderingPoint(ExternallyAnimatedScene):
     pass
 
 class DismissProjection(PiCreatureScene):
-    CONFIG = { 
+    CONFIG = {
         "screen_rect_color" : WHITE,
         "example_vect" : np.array([0.52, 0.26, 0.53, 0.60]),
     }
@@ -831,7 +831,7 @@ class DismissProjection(PiCreatureScene):
         self.discuss_4d_sphere_definition()
         self.talk_through_animation()
         self.transition_to_next_scene()
-        
+
     def show_all_spheres(self):
         equations = VGroup(*map(TexMobject, [
             "x^2 + y^2 = 1",
@@ -850,7 +850,7 @@ class DismissProjection(PiCreatureScene):
             self.get_sphere_screen(equations[1], DOWN),
             self.get_sphere_screen(equations[2], DOWN),
         )
-        
+
         for equation, sphere in zip(equations, spheres):
             self.play(
                 Write(equation),
@@ -888,12 +888,12 @@ class DismissProjection(PiCreatureScene):
         sphere_words = TextMobject("``4-dimensional sphere''")
         sphere_words.next_to(sphere, DOWN+LEFT, buff = LARGE_BUFF)
         arrow = Arrow(
-            sphere_words.get_right(), sphere.get_bottom(), 
-            path_arc = np.pi/3, 
+            sphere_words.get_right(), sphere.get_bottom(),
+            path_arc = np.pi/3,
             color = BLUE
         )
         descriptor = TexMobject(
-            "\\text{Just lists of numbers like }", 
+            "\\text{Just lists of numbers like }",
             "(%.02f \\,, %.02f \\,, %.02f \\,, %.02f \\,)"%tuple(self.example_vect)
         )
         descriptor[1].set_color(BLUE)
@@ -1002,9 +1002,9 @@ class Introduce4DSliders(SliderScene):
         equation = TexMobject("x^2 + y^2 + z^2 + w^2 = 1")
         x, y, z, w = self.start_vect
         tup = TexMobject(
-            "(", "%.02f \\,"%x, 
-            ",", "%.02f \\,"%y, 
-            ",", "%.02f \\,"%z, 
+            "(", "%.02f \\,"%x,
+            ",", "%.02f \\,"%y,
+            ",", "%.02f \\,"%z,
             ",", "%.02f \\,"%w, ")"
         )
         equation.center().to_edge(UP)
@@ -1037,7 +1037,7 @@ class Introduce4DSliders(SliderScene):
                 remover = True
             )
             for num, dial, a in zip(
-                numbers, dial_copies, 
+                numbers, dial_copies,
                 np.linspace(0, 0.5, len(numbers))
             )
         ])
@@ -1126,7 +1126,7 @@ class TwoDimensionalCase(Introduce4DSliders):
         rects = VGroup(x_rect, y_rect)
 
         decimals = VGroup(*[
-            DecimalNumber(num**2) 
+            DecimalNumber(num**2)
             for num in self.get_vector()
         ])
         decimals.arrange_submobjects(RIGHT, buff = LARGE_BUFF)
@@ -1309,7 +1309,7 @@ class TwoDimensionalCaseIntro(TwoDimensionalCase):
         self.wait(10)
 
 class ThreeDCase(TwoDimensionalCase):
-    CONFIG = { 
+    CONFIG = {
         "n_sliders" : 3,
         "slider_config" : {
             "include_real_estate_ticks" : True,
@@ -1656,7 +1656,7 @@ class TwoDBoxExample(Scene):
 
     def compute_radius(self):
         triangle = Polygon(
-            ORIGIN, 
+            ORIGIN,
             self.plane.coords_to_point(1, 0),
             self.plane.coords_to_point(1, 1),
             fill_color = BLUE,
@@ -1746,8 +1746,8 @@ class ThreeDCubeCorners(Scene):
 class ShowDistanceFormula(TeacherStudentsScene):
     def construct(self):
         rule = TexMobject(
-            "||(", "x_1", ", ", "x_2", "\\dots, ", "x_n", ")||", 
-            "=", 
+            "||(", "x_1", ", ", "x_2", "\\dots, ", "x_n", ")||",
+            "=",
             "\\sqrt", "{x_1^2", " + ", "x_2^2", " +\\cdots", "x_n^2", "}"
         )
         rule.set_color_by_tex_to_color_map({
@@ -1843,7 +1843,7 @@ class GeneralizePythagoreanTheoremBeyondTwoD(ThreeDScene):
         full_group = VGroup(group, z_line, z, three_d_diag, dot)
         self.play(Rotating(
             full_group, radians = -np.pi/6,
-            axis = UP, 
+            axis = UP,
             run_time = 10,
         ))
         self.wait()
@@ -1927,7 +1927,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
         for number in x_slider.numbers:
             value = int(number.get_tex_string())
             number.next_to(
-                x_slider.number_to_point(value), 
+                x_slider.number_to_point(value),
                 LEFT, MED_SMALL_BUFF
             )
         self.plane.axes.set_color(BLUE)
@@ -1937,7 +1937,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
             self.circle.copy().move_to(
                 self.plane.coords_to_point(*coords)
             ).set_color(GREY)
-            for coords in (1, 1), (-1, 1), (-1, -1)
+            for coords in ((1, 1), (-1, 1), (-1, -1))
         ])
         line = Line(
             self.plane.coords_to_point(-1, -1),
@@ -1984,7 +1984,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
                     slider.number_to_point(0)-slider.number_to_point(slider.center_value)
                 )
                 for slider in self.sliders
-                for mob in slider.real_estate_ticks, slider.dial
+                for mob in (slider.real_estate_ticks, slider.dial)
             ]
         )
         self.center_point = [0, 0]
@@ -1994,7 +1994,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
         self.wait(7)
         self.wind_down_ambient_movement()
         self.play(
-            self.circle.move_to, 
+            self.circle.move_to,
                 self.plane.coords_to_point(*original_center_point),
             Animation(self.sliders),
             *[
@@ -2003,7 +2003,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
                     slider.number_to_point(x)-slider.number_to_point(0)
                 )
                 for x, slider in zip(original_center_point, self.sliders)
-                for mob in slider.real_estate_ticks, slider.dial
+                for mob in (slider.real_estate_ticks, slider.dial)
             ]
         )
         self.center_point = original_center_point
@@ -2055,7 +2055,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
                     mob.shift,
                     slider.number_to_point(1) - slider.number_to_point(-1)
                 )
-                for mob in slider.real_estate_ticks, slider.dial
+                for mob in (slider.real_estate_ticks, slider.dial)
             ]
         )
         slider.center_value = 1
@@ -2115,7 +2115,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
             slider.dial.copy()
             for slider in self.sliders
         ])
-        ghost_dials.set_fill(WHITE, opacity = 0.75)
+        ghost_dials.set_fill(WHITE, opacity=0.75)
 
         self.add_foreground_mobjects(ghost_dials)
         self.reset_dials(target_vector)
@@ -2181,10 +2181,10 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
         #Return to original position
         target_vector = np.array(2*[1-np.sqrt(0.5)])
         self.play(LaggedStart(FadeOut, VGroup(*[
-            ghost_dials, 
-            x_words, y_words, 
-            x_arrow, y_arrow, 
-            crosses, new_words, 
+            ghost_dials,
+            x_words, y_words,
+            x_arrow, y_arrow,
+            crosses, new_words,
         ])))
         self.remove_foreground_mobjects(ghost_dials)
         self.reset_dials(target_vector)
@@ -2303,7 +2303,7 @@ class ThreeDBoxExampleWithSliders(SliderScene):
         re_words.to_corner(UP+LEFT)
         re_line = DashedLine(*[
             self.sliders[i].number_to_point(target_x) + MED_SMALL_BUFF*vect
-            for i, vect in (0, LEFT), (2, RIGHT)
+            for i, vect in ((0, LEFT), (2, RIGHT))
         ])
         new_arrow = Arrow(
             re_words.get_corner(DOWN+RIGHT), re_line.get_left(),
@@ -2329,7 +2329,7 @@ class ThreeDBoxExampleWithSliders(SliderScene):
     def compare_to_halfway_point(self):
         half_line = Line(*[
             self.sliders[i].number_to_point(0.5)+MED_SMALL_BUFF*vect
-            for i, vect in (0, LEFT), (2, RIGHT)
+            for i, vect in ((0, LEFT), (2, RIGHT))
         ])
         half_line.set_stroke(MAROON_B, 6)
         half_label = TexMobject("0.5")
@@ -2514,7 +2514,7 @@ class FourDBoxExampleWithSliders(ThreeDBoxExampleWithSliders):
         target_vector = 0.5*np.ones(4)
         re_line = DashedLine(*[
             self.sliders[i].number_to_point(0.5)+MED_SMALL_BUFF*vect
-            for i, vect in (0, LEFT), (-1, RIGHT)
+            for i, vect in ((0, LEFT), (-1, RIGHT))
         ])
         half_label = TexMobject("0.5")
         half_label.scale(self.sliders[0].number_scale_val)
@@ -2603,7 +2603,7 @@ class FourDBoxExampleWithSliders(ThreeDBoxExampleWithSliders):
 
     def compute_inner_radius_numerically(self):
         computation = TexMobject(
-            "R_\\text{Inner}", 
+            "R_\\text{Inner}",
             "&= ||(1, 1, 1, 1)|| - 1 \\\\",
             # "&= \\sqrt{1^2 + 1^2 + 1^2 + 1^2} - 1 \\\\",
             "&= \\sqrt{4} - 1 \\\\",
@@ -2657,12 +2657,12 @@ class TwoDInnerSphereTouchingBox(TwoDBoxWithSliders, PiCreatureScene):
                 radius = radius*self.plane.x_unit_size,
                 color = GREEN
             ).move_to(self.plane.coords_to_point(0, 0))
-            for radius in np.sqrt(2)-1, 1
+            for radius in (np.sqrt(2)-1, 1)
         ]
         randy = self.randy
         tangency_points = VGroup(*[
             Dot(self.plane.coords_to_point(x, y))
-            for x, y in (1, 0), (0, 1), (-1, 0), (0, -1)
+            for x, y in ((1, 0), (0, 1), (-1, 0), (0, -1))
         ])
         tangency_points.set_fill(YELLOW, 0.5)
 
@@ -2754,7 +2754,7 @@ class FiveDBoxExampleWithSliders(FourDBoxExampleWithSliders):
         target_x = 1-np.sqrt(0.2)
         re_line = DashedLine(*[
             self.sliders[i].number_to_point(target_x)+MED_SMALL_BUFF*vect
-            for i, vect in (0, LEFT), (-1, RIGHT)
+            for i, vect in ((0, LEFT), (-1, RIGHT))
         ])
         re_words = TextMobject(
             "$0.2$", "units of real \\\\ estate each"
@@ -2772,7 +2772,7 @@ class FiveDBoxExampleWithSliders(FourDBoxExampleWithSliders):
             )
             rect.move_to(slider.number_to_point(1), UP)
             re_rects.add(rect)
-        
+
         self.wind_down_ambient_movement()
         self.reset_dials(5*[target_x])
         self.play(
@@ -2792,7 +2792,7 @@ class FiveDBoxExampleWithSliders(FourDBoxExampleWithSliders):
     def show_halfway_point(self):
         half_line = Line(*[
             self.sliders[i].number_to_point(0.5)+MED_SMALL_BUFF*vect
-            for i, vect in (0, LEFT), (-1, RIGHT)
+            for i, vect in ((0, LEFT), (-1, RIGHT))
         ])
         half_line.set_color(MAROON_B)
         half_label = TexMobject("0.5")
@@ -2868,7 +2868,7 @@ class FiveDBoxExampleWithSliders(FourDBoxExampleWithSliders):
         )
         self.play(
             MoveToTarget(
-                re_rects, 
+                re_rects,
                 run_time = 2,
                 submobject_mode = "lagged_start",
                 path_arc = np.pi
@@ -2950,7 +2950,7 @@ class TenDBoxExampleWithSliders(FiveDBoxExampleWithSliders):
         target_x = 1-np.sqrt(1./self.n_sliders)
         re_line = DashedLine(*[
             self.sliders[i].number_to_point(target_x)+MED_SMALL_BUFF*vect
-            for i, vect in (0, LEFT), (-1, RIGHT)
+            for i, vect in ((0, LEFT), (-1, RIGHT))
         ])
 
         re_rects = VGroup()
@@ -2964,7 +2964,7 @@ class TenDBoxExampleWithSliders(FiveDBoxExampleWithSliders):
             )
             rect.move_to(slider.number_to_point(1), UP)
             re_rects.add(rect)
-        
+
         self.wind_down_ambient_movement()
         self.reset_dials(self.n_sliders*[target_x])
         self.play(ShowCreation(re_line))
@@ -3002,7 +3002,7 @@ class TenDBoxExampleWithSliders(FiveDBoxExampleWithSliders):
         )
         self.play(
             MoveToTarget(
-                re_rects, 
+                re_rects,
                 run_time = 2,
                 submobject_mode = "lagged_start",
                 path_arc = np.pi
@@ -3038,7 +3038,7 @@ class TenDBoxExampleWithSliders(FiveDBoxExampleWithSliders):
         words.to_edge(LEFT)
         words.set_color(RED)
         arrow = Arrow(
-            words.get_top(), 
+            words.get_top(),
             self.sliders[0].dial,
             path_arc = -np.pi/3,
             color = words.get_color()
@@ -3524,7 +3524,7 @@ class Podcast(TeacherStudentsScene):
             LaggedStart(
                 ApplyMethod, self.pi_creatures,
                 lambda pi : (pi.change, "hooray", title)
-            ), 
+            ),
             Write(title)
         )
         self.wait(5)
@@ -3612,24 +3612,3 @@ class Thumbnail(SliderScene):
         title.scale(2)
         title.to_edge(UP)
         self.add(title)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/hilbert/fractal_porn.py
+++ b/old_projects/hilbert/fractal_porn.py
@@ -228,7 +228,7 @@ class FromKochToSpaceFilling(Scene):
         words.to_edge(UP)
         koch, sharper_koch, duller_koch = curves = [
             CurveClass(order = 1)
-            for CurveClass in StraightKoch, SharperKoch, DullerKoch
+            for CurveClass in (StraightKoch, SharperKoch, DullerKoch)
         ]
         arcs = [
             Arc(
@@ -276,11 +276,11 @@ class FromKochToSpaceFilling(Scene):
             text.to_edge(UP)
         sharper, duller, space_filling = [
             CurveClass(order = 1).shift(3*LEFT)
-            for CurveClass in SharperKoch, DullerKoch, SpaceFillingKoch
+            for CurveClass in (SharperKoch, DullerKoch, SpaceFillingKoch)
         ]
         shaper_f, duller_f, space_filling_f = [
             CurveClass(order = self.max_order).shift(3*RIGHT)
-            for CurveClass in SharperKoch, DullerKoch, SpaceFillingKoch
+            for CurveClass in (SharperKoch, DullerKoch, SpaceFillingKoch)
         ]
 
         self.add(words[0])

--- a/old_projects/hilbert/section1.py
+++ b/old_projects/hilbert/section1.py
@@ -101,7 +101,7 @@ class AboutSpaceFillingCurves(TransformOverIncreasingOrders):
         self.wait()
         self.play(*[
             ShimmerIn(mob)
-            for mob in infinity, rightarrow, N
+            for mob in (infinity, rightarrow, N)
         ] + [
             ApplyMethod(question_mark.next_to, rightarrow, UP),
         ])
@@ -540,11 +540,11 @@ class ThinkInTermsOfReverseMapping(Scene):
         arrow2 = Arrow(4*RIGHT+UP, dot2, color = color2, buff = 0.1)
         dot3, arrow3 = [
             mob.copy().shift(5*LEFT+UP)
-            for mob in dot1, arrow1
+            for mob in (dot1, arrow1)
         ]
         dot4, arrow4 = [
             mob.copy().shift(5*LEFT+0.9*UP)
-            for mob in dot2, arrow2
+            for mob in (dot2, arrow2)
         ]
 
         self.add(grid, freq_line, arrow)
@@ -659,7 +659,7 @@ class TellMathematicianFriend(Scene):
         mathy, bubble = get_mathy_and_bubble()
         squiggle_mouth = mathy.mouth.copy()
         squiggle_mouth.apply_function(
-            lambda (x, y, z) : (x, y+0.02*np.sin(50*x), z)
+            lambda x_y_z : (x_y_z[0], x_y_z[1]+0.02*np.sin(50*x_y_z[0]), x_y_z[2])
         )
         bubble.ingest_submobjects()        
         bubble.write("Why not use a Hilbert curve \\textinterrobang ")
@@ -898,7 +898,7 @@ class HilbertBetterThanSnakeQ(Scene):
                 CurveClass(order = n)
                 for n in range(2, 7)
             ]
-            for CurveClass in HilbertCurve, SnakeCurve
+            for CurveClass in (HilbertCurve, SnakeCurve)
         ]
         for curve in hilbert_curves+snake_curves:
             curve.scale(0.8)
@@ -949,7 +949,7 @@ class IncreaseResolution(Scene):
                 2**order, 2**order,
                 stroke_width = 1
             ).shift(0.3*DOWN)
-            for order in 6, 7
+            for order in (6, 7)
         ]
         grid = grids[0]
         side_brace = Brace(grid, LEFT)
@@ -995,7 +995,7 @@ class IncreasingResolutionWithSnakeCurve(Scene):
                     (0.7, RED)
                 ]
             ])
-            for curve in start_curve, end_curve
+            for curve in (start_curve, end_curve)
         ]
         self.add(start_curve)
         self.wait()

--- a/old_projects/hilbert/section2.py
+++ b/old_projects/hilbert/section2.py
@@ -190,7 +190,7 @@ class HistoryOfDiscover(Scene):
         peano_curve.to_corner(UP+LEFT)
         squares = Mobject(*[
             Square(side_length=3, color=WHITE).replace(curve)
-            for curve in hilbert_curve, peano_curve
+            for curve in (hilbert_curve, peano_curve)
         ])
 
 
@@ -499,15 +499,15 @@ class FormalDefinitionOfContinuity(Scene):
         self.input_dot = Dot(color = self.input_color)
         self.output_dot = self.input_dot.copy().set_color(self.output_color)
         left, right = self.interval.get_left(), self.interval.get_right()
-        self.input_homotopy = lambda (x, y, z, t) : (x, y, t) + interpolate(left, right, t)
+        self.input_homotopy = lambda x_y_z_t : (x_y_z_t[0], x_y_z_t[1], x_y_z_t[3]) + interpolate(left, right, x_y_z_t[3])
         output_size = self.output.get_num_points()-1
         output_points = self.output.points        
-        self.output_homotopy = lambda (x, y, z, t) : (x, y, z) + output_points[int(t*output_size)]
+        self.output_homotopy = lambda x_y_z_t1 : (x_y_z_t1[0], x_y_z_t1[1], x_y_z_t1[2]) + output_points[int(x_y_z_t1[3]*output_size)]
 
     def get_circles_and_points(self, min_input, max_input):
         input_left, input_right = [
             self.interval.number_to_point(num)
-            for num in min_input, max_input
+            for num in (min_input, max_input)
         ]
         input_circle = Circle(
             radius = np.linalg.norm(input_left-input_right)/2,
@@ -811,7 +811,7 @@ class WonderfulPropertyOfPseudoHilbertCurves(Scene):
             FadeOut(arrow),
             *[
                 FadeIn(func_parts[i])
-                for i in 0, 1, 2, 4
+                for i in (0, 1, 2, 4)
             ]
         )
         for num in range(2,9):

--- a/old_projects/inventing_math.py
+++ b/old_projects/inventing_math.py
@@ -9,6 +9,7 @@ from random import sample
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
+from functools import reduce
 
 # from inventing_math_images import *
 
@@ -351,7 +352,7 @@ class YouAsMathematician(Scene):
         bubble.clear()
         dot_pair = [
             Dot(density = 3*DEFAULT_POINT_DENSITY_1D).shift(x+UP)
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         self.add(you, explanation)
         self.play(
@@ -376,7 +377,7 @@ class YouAsMathematician(Scene):
         self.add(*dot_pair)
         two_arrows = [
             Arrow(x, direction = x).shift(UP).nudge()
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         self.play(*[ShowCreation(a) for a in two_arrows])
         self.play(BlinkPiCreature(you))
@@ -412,7 +413,7 @@ class DotsGettingCloser(Scene):
     def construct(self):
         dots = [
             Dot(radius = 3*Dot.DEFAULT_RADIUS).shift(3*x)
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         self.add(*dots)
         self.wait()
@@ -428,7 +429,7 @@ class ZoomInOnInterval(Scene):
         interval = zero_to_one_interval().split()
 
         new_line = deepcopy(number_line)
-        new_line.set_color("black", lambda (x,y,z) : x < 0 or x > 1 or y < -0.2)
+        new_line.set_color("black", lambda x_y_z1 : x_y_z1[0] < 0 or x_y_z1[0] > 1 or x_y_z1[1] < -0.2)
         # height = new_line.get_height()
         new_line.scale(2*INTERVAL_RADIUS)
         new_line.shift(INTERVAL_RADIUS*LEFT)
@@ -465,7 +466,7 @@ class DanceDotOnInterval(Scene):
         interval = zero_to_one_interval()
         dots = [
             Dot(radius = 3*Dot.DEFAULT_RADIUS).shift(INTERVAL_RADIUS*x+UP)
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         color_range = Color("green").range_to("yellow", num_written_terms)
         conv_sum = TexMobject(sum_terms, size = "\\large").split()
@@ -480,7 +481,7 @@ class DanceDotOnInterval(Scene):
             shift_val = 2*RIGHT*INTERVAL_RADIUS*(1-prop)*(prop**count)
             start = dots[0].get_center()
             line = Line(start, start + shift_val*RIGHT)
-            line.set_color(color_range.next())
+            line.set_color(next(color_range))
             self.play(
                 ApplyMethod(dots[0].shift, shift_val),
                 ShowCreation(line)
@@ -570,7 +571,7 @@ class SeeNumbersApproachOne(Scene):
             ).scale(1+1.0/2.0**x).shift(
                 INTERVAL_RADIUS*RIGHT +\
                 (INTERVAL_RADIUS/2.0**x)*LEFT
-            ).set_color(colors.next())
+            ).set_color(next(colors))
             for x in range(num_dots)
         ])
 
@@ -661,7 +662,7 @@ class ListOfPartialSums(Scene):
         ).split())
         numbers, equals, sums = [
             all_terms[range(k, 12, 3)]
-            for k in 0, 1, 2
+            for k in (0, 1, 2)
         ]
         dots = all_terms[12]
         one = all_terms[-3]
@@ -755,7 +756,7 @@ class CircleZoomInOnOne(Scene):
 
         self.play(*[
             DelayByOrder(FadeIn(mob))
-            for mob in arrow, curr_num
+            for mob in (arrow, curr_num)
         ])
         self.wait()
         for num in numbers[1:] + [text]:
@@ -775,16 +776,16 @@ class ZoomInOnOne(Scene):
     def construct(self):
         num_iterations = 8
         number_line = NumberLine(interval_size = 1, radius = FRAME_X_RADIUS+2)
-        number_line.filter_out(lambda (x, y, z):abs(y)>0.1)
+        number_line.filter_out(lambda x_y_z2:abs(x_y_z2[1])>0.1)
         nl_with_nums = deepcopy(number_line).add_numbers()
         self.play(ApplyMethod(nl_with_nums.shift, 2*LEFT))
         zero, one, two = [
             TexMobject(str(n)).scale(0.5).shift(0.4*DOWN+2*(-1+n)*RIGHT)
-            for n in 0, 1, 2
+            for n in (0, 1, 2)
         ]
         self.play(
             FadeOut(nl_with_nums),
-            *[Animation(mob) for mob in zero, one, two, number_line]
+            *[Animation(mob) for mob in (zero, one, two, number_line)]
         )
         self.remove(nl_with_nums, number_line, zero, two)
         powers_of_10 = [10**(-n) for n in range(num_iterations+1)]
@@ -796,7 +797,7 @@ class ZoomInOnOne(Scene):
 
     def zoom_with_numbers(self, numbers, next_numbers):
         all_numbers = map(
-            lambda (n, u): TexMobject(str(n)).scale(0.5).shift(0.4*DOWN+2*u*RIGHT),
+            lambda n_u: TexMobject(str(n_u[0])).scale(0.5).shift(0.4*DOWN+2*n_u[1]*RIGHT),
             zip(numbers+next_numbers, it.cycle([-1, 1]))
         )
 
@@ -807,7 +808,7 @@ class ZoomInOnOne(Scene):
                 interval_size = 1, 
                 density = scale_factor*DEFAULT_POINT_DENSITY_1D
             ).filter_out(
-                lambda (x, y, z):abs(y)>0.1
+                lambda x_y_z:abs(x_y_z[1])>0.1
             ).scale(1.0/scale_factor**x)
             for x in range(num_levels)
         ]
@@ -823,7 +824,7 @@ class ZoomInOnOne(Scene):
                 2*LEFT*(scale_factor-1)*(-1)**i, 
                 **kwargs
             )
-            for i in 0, 1
+            for i in (0, 1)
         ]+[
             Transform(Point(0.4*DOWN + u*0.2*RIGHT), num, **kwargs)
             for u, num in zip([-1, 1], all_numbers[2:])
@@ -917,7 +918,7 @@ class DefineInfiniteSum(Scene):
         ]
         self.play(*[
             Transform(lines[x], lines[x+1], run_time = 3.0)
-            for x in 0, 2
+            for x in (0, 2)
         ])
 
 
@@ -982,7 +983,7 @@ class ChopIntervalInProportions(Scene):
                     TexMobject("\\frac{%d}{%d}"%(k, (10**(count+1))))
                     for count in range(num_terms)
                 ]
-                for k in 9, 1
+                for k in (9, 1)
             ]
         if mode == "p":
             num_terms = 4         
@@ -1359,7 +1360,7 @@ class SumPowersOfTwoAnimation(Scene):
         topbrace = Underbrace(top_brace_left, right).rotate(np.pi, RIGHT)
         bottombrace = Underbrace(bottom_brace_left, right)
         colors = Color("yellow").range_to("purple", iterations)
-        curr_dots.set_color(colors.next())
+        curr_dots.set_color(next(colors))
         equation = TexMobject(
             "1+2+4+\\cdots+2^n=2^{n+1} - 1",
             size = "\\Huge"
@@ -1386,7 +1387,7 @@ class SumPowersOfTwoAnimation(Scene):
             shift_val = (2**n)*(dot_width+dot_buff)
             right += shift_val
             new_dots = Mobject(new_dot, curr_dots)
-            new_dots.set_color(colors.next()).shift(shift_val)
+            new_dots.set_color(next(colors)).shift(shift_val)
             alt_bottombrace = deepcopy(bottombrace).shift(shift_val)
             alt_bottom_num = deepcopy(bottom_num).shift(shift_val)
             alt_topbrace = deepcopy(alt_bottombrace).rotate(np.pi, RIGHT)
@@ -1655,9 +1656,9 @@ class TriangleInequality(Scene):
         self.play(ShowCreation(ac_line), FadeIn(ac_copy))
         self.wait()
         self.play(*[
-            ShowCreation(line) for line in ab_line, bc_line
+            ShowCreation(line) for line in (ab_line, bc_line)
         ]+[
-            FadeIn(dist) for dist in ab_copy, bc_copy
+            FadeIn(dist) for dist in (ab_copy, bc_copy)
         ])
         self.wait()
         self.play(*[
@@ -1665,7 +1666,7 @@ class TriangleInequality(Scene):
             for pair in zip(all_copies, all_dists)
         ]+[
             FadeIn(mob)
-            for mob in plus, greater_than
+            for mob in (plus, greater_than)
         ])
         self.wait()
 
@@ -1844,7 +1845,7 @@ class RoomsAndSubroomsWithNumbers(Scene):
                 return mob
             self.play(*[
                 ApplyFunction(transform, mob)
-                for mob in zero_copy, power_mob_copy
+                for mob in (zero_copy, power_mob_copy)
             ])
             last_left_mob = zero
             for n in range(power+1, 2*power):
@@ -1852,7 +1853,7 @@ class RoomsAndSubroomsWithNumbers(Scene):
                 shift_val = left_mob.get_center()-last_left_mob.get_center()
                 self.play(*[
                     ApplyMethod(mob.shift, shift_val)
-                    for mob in zero_copy, power_mob_copy
+                    for mob in (zero_copy, power_mob_copy)
                 ])
                 num_mobs[n] = TexMobject(str(n))
                 num_mobs[n].scale(1.0/(power_of_divisor(n, 2)+1))
@@ -1901,7 +1902,7 @@ class RoomsAndSubroomsWithNumbers(Scene):
             self.clear_way_for_text(text, cluster)
             self.add(*cluster)          
             pairs = filter(
-                lambda (a, b) : (a-b)%(2**count) == 0 and (a-b)%(2**(count+1)) != 0,
+                lambda a_b : (a_b[0]-a_b[1])%(2**count) == 0 and (a_b[0]-a_b[1])%(2**(count+1)) != 0,
                 it.combinations(range(16), 2)
             )
             for pair in sample(pairs, min(10, len(pairs))):
@@ -1922,7 +1923,8 @@ class RoomsAndSubroomsWithNumbers(Scene):
     def clear_way_for_text(text, mobjects):
         right, top, null = np.max(text.points, 0)
         left, bottom, null = np.min(text.points, 0)
-        def filter_func((x, y, z)):
+        def filter_func(xxx_todo_changeme):
+            (x, y, z) = xxx_todo_changeme
             return x>left and x<right and y>bottom and y<top
         for mobject in mobjects:
             mobject.filter_out(filter_func)
@@ -1957,7 +1959,7 @@ class DeduceWhereNegativeOneFalls(Scene):
             rest_time = 0.3 + 1.0/(n+1)
             new_args = [
                 TextMobject("$%d$"%k).scale(1.5)
-                for k in 2**n-1, 2**n
+                for k in (2**n-1, 2**n)
             ]
             for new_arg, old_arg in zip(new_args, last_args):
                 new_arg.shift(old_arg.get_center())
@@ -2015,7 +2017,7 @@ class PAdicMetric(Scene):
         self.add(curr, text)
         self.wait()        
         for prime, count in zip(primes, it.count()):
-            prime.scale(1.0).set_color(colors.next())
+            prime.scale(1.0).set_color(next(colors))
             prime.shift(center_of_mass([p_str.get_top(), p_str.get_center()]))
             self.play(DelayByOrder(Transform(curr, prime)))
             self.wait()

--- a/old_projects/inventing_math_images.py
+++ b/old_projects/inventing_math_images.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -7,7 +8,7 @@ import sys
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
-from inventing_math import divergent_sum, draw_you
+from .inventing_math import divergent_sum, draw_you
 
 
 

--- a/old_projects/leibniz.py
+++ b/old_projects/leibniz.py
@@ -1,4 +1,5 @@
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 # revert_to_original_skipping_status
 
@@ -113,7 +114,7 @@ class LatticePointScene(Scene):
                 ),
             )
             for dot, a in zip(
-                points, 
+                points,
                 np.linspace(0, 0.75, len(points))
             )
         ])
@@ -292,14 +293,14 @@ class ShowSum(TeacherStudentsScene):
         sum_point = line.number_to_point(np.pi/4)
 
         numbers = [0] + [
-            ((-1)**n)/(2.0*n + 1) 
+            ((-1)**n)/(2.0*n + 1)
             for n in range(self.num_terms_to_add)
         ]
         partial_sums = np.cumsum(numbers)
         points = map(line.number_to_point, partial_sums)
         arrows = [
             Arrow(
-                p1, p2, 
+                p1, p2,
                 tip_length = 0.2*min(1, np.linalg.norm(p1-p2)),
                 buff = 0
             )
@@ -308,14 +309,14 @@ class ShowSum(TeacherStudentsScene):
         dot = Dot(points[0])
 
         sum_mob = TexMobject(
-            "1", "-\\frac{1}{3}", 
+            "1", "-\\frac{1}{3}",
             "+\\frac{1}{5}", "-\\frac{1}{7}",
             "+\\frac{1}{9}", "-\\frac{1}{11}",
             "+\\cdots"
         )
         sum_mob.to_corner(UP+RIGHT)
         lhs = TexMobject(
-            "\\frac{\\pi}{4}", "=", 
+            "\\frac{\\pi}{4}", "=",
         )
         lhs.next_to(sum_mob, LEFT)
         lhs.set_color_by_tex("pi", YELLOW)
@@ -348,7 +349,7 @@ class ShowSum(TeacherStudentsScene):
                     target_mode = "raise_right_hand"
                 )
             ]
-            
+
         )
         run_time = 1
         for term, arrow, last_arrow, fading_term, last_fading_term in zip(
@@ -416,7 +417,7 @@ class ShowCalculus(PiCreatureScene):
             frac_sum.get_right() + MED_SMALL_BUFF*RIGHT \
             -int1[0].get_left()
         )
-        
+
         self.add(frac_sum)
         modes = it.chain(["plain"], it.cycle(["confused"]))
         for rhs, mode in zip(rhs_group, modes):
@@ -516,7 +517,7 @@ class Outline(PiCreatureScene):
             step.set_color_by_tex("i", RED, substring = False)
             step.set_color_by_tex("4", GREEN, substring = False)
         steps.arrange_submobjects(
-            DOWN, 
+            DOWN,
             buff = MED_LARGE_BUFF,
             aligned_edge = LEFT
         )
@@ -567,7 +568,7 @@ class Outline(PiCreatureScene):
         circle.move_to(plane_center)
         lattice_points = VGroup(*[
             Dot(
-                plane.coords_to_point(a, b), 
+                plane.coords_to_point(a, b),
                 radius = 0.05,
                 color = PINK,
             )
@@ -594,7 +595,7 @@ class Outline(PiCreatureScene):
                     )
                 )
                 for dot, a in zip(
-                    lattice_points, 
+                    lattice_points,
                     np.linspace(0, 0.75, len(lattice_points))
                 )
             ]
@@ -641,7 +642,7 @@ class Outline(PiCreatureScene):
         self.play(FadeIn(self.steps[3]))
         self.play(*[
             FadeIn(
-                mob, 
+                mob,
                 run_time = 3,
                 submobject_mode = "lagged_start"
             )
@@ -661,7 +662,7 @@ class Outline(PiCreatureScene):
             "\\sum_{n = 1}^N",
             "\\sum_{d | n} \\chi(d)",
         )
-        pi = self.pi 
+        pi = self.pi
         self.add(pi.copy())
         pi.generate_target()
         pi.target.next_to(self.steps[3], RIGHT, MED_LARGE_BUFF)
@@ -840,7 +841,7 @@ class CountLatticePoints(LatticePointScene):
                     "\\approx \\pi", "(", R, ")^2"
                 )
             ).arrange_submobjects(RIGHT)
-            for R in "10", "1{,}000{,}000", "R"
+            for R in ("10", "1{,}000{,}000", "R")
         ])
         radius_10_eq, radius_million_eq, radius_R_eq = equations
         for eq in equations:
@@ -945,7 +946,7 @@ class CountThroughRings(LatticePointScene):
             for r in radii
         ])
         circles.set_stroke(width = 2)
-    
+
         self.add_foreground_mobject(self.lattice_points)
         self.play(FadeIn(circles))
         self.play(LaggedStart(
@@ -1108,7 +1109,7 @@ class CountThroughRings(LatticePointScene):
 
     def show_ring_count(
         self, radius_squared, target,
-        added_anims = None,        
+        added_anims = None,
         run_time = 1
         ):
         added_anims = added_anims or []
@@ -1153,7 +1154,7 @@ class CountThroughRings(LatticePointScene):
             Transform(self.radial_line, radial_line),
             Transform(self.root, root),
             DrawBorderThenFill(
-                points, 
+                points,
                 stroke_width = 4,
                 stroke_color = PINK,
             ),
@@ -1162,7 +1163,7 @@ class CountThroughRings(LatticePointScene):
         )
         self.wait(run_time)
         if len(points) > 0:
-            mover = points.copy()  
+            mover = points.copy()
         else:
             mover = VectorizedPoint(self.plane_center)
         self.play(ReplacementTransform(mover, target, run_time = run_time))
@@ -1207,7 +1208,7 @@ class LookAtExampleRing(LatticePointScene):
 
         sums_of_squares = [
             TexMobject(
-                special_str(x), "^2", "+", 
+                special_str(x), "^2", "+",
                 special_str(y), "^2", "= 25"
             )
             for x, y in coords_list
@@ -1227,9 +1228,9 @@ class LookAtExampleRing(LatticePointScene):
         self.play(
             ShowCreation(circle),
             Rotating(
-                radius, 
+                radius,
                 about_point = self.plane_center,
-                rate_func = smooth, 
+                rate_func = smooth,
             ),
             FadeIn(points, submobject_mode = "lagged_start"),
             run_time = 2,
@@ -1278,14 +1279,14 @@ class LookAtExampleRing(LatticePointScene):
         points.target.next_to(circle, RIGHT)
 
         self.play(MoveToTarget(
-            points, 
+            points,
             run_time = 2,
         ))
         self.wait()
         self.play(points.restore, run_time = 2)
         self.wait()
         self.play(*map(FadeOut, [
-            curr_label, curr_sum_of_squares, 
+            curr_label, curr_sum_of_squares,
             circle, points,
             radius, root_label
         ]))
@@ -1308,9 +1309,9 @@ class LookAtExampleRing(LatticePointScene):
         self.play(
             ShowCreation(circle),
             Rotating(
-                radius, 
+                radius,
                 about_point = self.plane_center,
-                rate_func = smooth, 
+                rate_func = smooth,
             ),
             run_time = 2,
         )
@@ -1444,7 +1445,7 @@ class IntroduceComplexConjugate(LatticePointScene):
         self.play(*map(Write, [imag_coords, ticks]))
         self.wait()
         self.play(*map(FadeOut, [
-            v_arrow, h_arrow, 
+            v_arrow, h_arrow,
             x_coord, imag_y_coord,
         ]))
 
@@ -1549,7 +1550,7 @@ class IntroduceComplexConjugate(LatticePointScene):
         )
         expansion.arrange_submobjects(RIGHT, buff = SMALL_BUFF)
         expansion.next_to(
-            VGroup(*self.equation[-2:]), 
+            VGroup(*self.equation[-2:]),
             DOWN, LARGE_BUFF
         )
         alt_y_term = TexMobject("+", str(y), "^2")
@@ -1645,13 +1646,13 @@ class IntroduceComplexConjugate(LatticePointScene):
         top_dot, low_dot = dots
         for dot in dots:
             dot.line = Line(
-                self.plane_center, dot.get_center(), 
+                self.plane_center, dot.get_center(),
                 color = BLUE
             )
             dot.angle = dot.line.get_angle()
             dot.arc = Arc(
                 dot.angle,
-                radius = 0.75, 
+                radius = 0.75,
                 color = YELLOW
             )
             dot.arc.shift(self.plane_center)
@@ -1678,7 +1679,7 @@ class IntroduceComplexConjugate(LatticePointScene):
 
         self.play(ShowCreation(top_dot.line))
         mover = VGroup(
-            top_dot.line.copy().set_color(PINK), 
+            top_dot.line.copy().set_color(PINK),
             top_dot.copy()
         )
         self.play(FadeIn(
@@ -1698,7 +1699,7 @@ class IntroduceComplexConjugate(LatticePointScene):
         )
         self.play(
             Rotate(
-                mover, low_dot.angle, 
+                mover, low_dot.angle,
                 about_point = self.plane_center
             ),
             run_time = 2
@@ -1747,7 +1748,7 @@ class NameGaussianIntegers(LatticePointScene):
         integers.add_background_rectangle()
         arrows = VGroup(*[
             Arrow(integers.get_top(), mob, tip_length = 0.15)
-            for mob in a, b
+            for mob in (a, b)
         ])
         self.add_foreground_mobjects(label, integers, arrows)
 
@@ -1790,7 +1791,7 @@ class NameGaussianIntegers(LatticePointScene):
             FadeOut(self.lattice_points),
             ShowCreation(circle),
             Rotating(
-                radius, 
+                radius,
                 run_time = 1, rate_func = smooth,
                 about_point = self.plane_center
             ),
@@ -1809,7 +1810,7 @@ class NameGaussianIntegers(LatticePointScene):
             label = TexMobject(x_str, "+", y_str, "i")
             label.scale(0.8)
             label.next_to(
-                dot, 
+                dot,
                 dot.get_center()-self.plane_center + SMALL_BUFF*(UP+RIGHT),
                 buff = 0,
             )
@@ -1836,7 +1837,7 @@ class NameGaussianIntegers(LatticePointScene):
                     self.plane.coords_to_point(x, u*y),
                     color = PINK,
                 )
-                for u in 1, -1
+                for u in (1, -1)
             ])
             dot.conjugate_dot = self.circle_dots[-i]
 
@@ -1964,8 +1965,8 @@ class IntroduceGaussianPrimes(LatticePointScene, PiCreatureScene):
         dots = [
             Dot(self.plane.coords_to_point(*coords))
             for coords in [
-                (5, 0), 
-                (2, 1), (2, -1), 
+                (5, 0),
+                (2, 1), (2, -1),
                 (-1, 2), (-1, -2),
                 (-2, -1), (-2, 1),
             ]
@@ -1979,12 +1980,12 @@ class IntroduceGaussianPrimes(LatticePointScene, PiCreatureScene):
 
         labels = [
             TexMobject(tex).add_background_rectangle()
-            for tex in "5", "2+i", "2-i", "-1+2i", "-1-2i", "-2-i", "-2+i"
+            for tex in ("5", "2+i", "2-i", "-1+2i", "-1-2i", "-2-i", "-2+i")
         ]
         five_label, p1_label, p2_label, p3_label, p4_label, p5_label, p6_label = labels
         vects = [
-            DOWN, 
-            UP+RIGHT, DOWN+RIGHT, 
+            DOWN,
+            UP+RIGHT, DOWN+RIGHT,
             UP+LEFT, DOWN+LEFT,
             DOWN+LEFT, UP+LEFT,
         ]
@@ -1993,11 +1994,11 @@ class IntroduceGaussianPrimes(LatticePointScene, PiCreatureScene):
 
         arc_angle = 0.8*np.pi
         times_i_arc = Arrow(
-            p1_dot.get_top(), p3_dot.get_top(), 
+            p1_dot.get_top(), p3_dot.get_top(),
             path_arc = arc_angle
         )
         times_neg_i_arc = Arrow(
-            p2_dot.get_bottom(), p4_dot.get_bottom(), 
+            p2_dot.get_bottom(), p4_dot.get_bottom(),
             path_arc = -arc_angle
         )
         times_i = TexMobject("\\times i")
@@ -2045,7 +2046,7 @@ class IntroduceGaussianPrimes(LatticePointScene, PiCreatureScene):
 
         self.add(factorization)
         self.play(
-            DrawBorderThenFill(five_dot), 
+            DrawBorderThenFill(five_dot),
             FadeIn(five_label)
         )
         self.wait()
@@ -2069,7 +2070,7 @@ class IntroduceGaussianPrimes(LatticePointScene, PiCreatureScene):
         self.wait()
         self.play(RemovePiCreatureBubble(morty, target_mode = "pondering"))
 
-        #Show neg_alternate expression 
+        #Show neg_alternate expression
         movers = [p1_dot, p2_dot, p1_label, p2_label]
         for mover in movers:
             mover.save_state()
@@ -2165,7 +2166,7 @@ class FromIntegerFactorsToGaussianFactors(TeacherStudentsScene):
         ])
         self.wait(5)
         group = VGroup(
-            expression, 
+            expression,
             two.arrows, two.factors,
             five.arrows, five.factors,
         )
@@ -2249,7 +2250,7 @@ class FactorizationPattern(Scene):
             for mover in movers
         ])
         self.play(FadeIn(
-            factorizations, 
+            factorizations,
             run_time = 2,
             submobject_mode = "lagged_start"
         ))
@@ -2393,7 +2394,7 @@ class FactorTwo(LatticePointScene):
         two_dot.set_color(YELLOW)
         factor_dots = VGroup(*[
             Dot(self.plane.coords_to_point(1, u))
-            for u in 1, -1
+            for u in (1, -1)
         ])
         two_label = TexMobject("2").next_to(two_dot, DOWN)
         two_label.set_color(YELLOW)
@@ -2580,7 +2581,7 @@ class IntroduceRecipe(Scene):
         double_arrows = VGroup()
         for lf, rf in zip(left_factors.target, right_factors.target):
             arrow = DoubleArrow(
-                lf, rf, 
+                lf, rf,
                 buff = SMALL_BUFF,
                 tip_length = SMALL_BUFF,
                 color = GREEN
@@ -2645,7 +2646,7 @@ class IntroduceRecipe(Scene):
     def get_T_chart(self):
         T_chart = VGroup()
         h_lines = VGroup(*[
-            Line(ORIGIN, self.T_chart_width*RIGHT/2.0) 
+            Line(ORIGIN, self.T_chart_width*RIGHT/2.0)
             for x in range(2)
         ])
         h_lines.arrange_submobjects(RIGHT, buff = 0)
@@ -2745,7 +2746,7 @@ class IntroduceRecipe(Scene):
         final_step.scale(0.9)
         final_step.next_to(arrow.get_start(), DOWN, SMALL_BUFF)
         final_step.shift_onto_screen()
-        
+
         anims = [Write(final_step)]
         if arrow not in self.get_mobjects():
             # arrow = Arrow(
@@ -2784,7 +2785,7 @@ class ThreeOutputsAsLatticePoints(LatticePointScene):
         dots = VGroup(*[
             Dot(
                 self.plane.coords_to_point(*coords),
-                radius = self.dot_radius, 
+                radius = self.dot_radius,
                 color = self.colors[0],
             )
             for coords in self.coords_list
@@ -2810,7 +2811,7 @@ class ThreeOutputsAsLatticePoints(LatticePointScene):
             self.play(
                 FadeIn(label),
                 DrawBorderThenFill(
-                    dot, 
+                    dot,
                     stroke_color = PINK,
                     stroke_width = 4
                 )
@@ -2847,7 +2848,7 @@ class ShowAlternateFactorizationOfTwentyFive(IntroduceRecipe):
 
 class WriteAlternateLastStep(IntroduceRecipe):
     def construct(self):
-        self.force_skipping()        
+        self.force_skipping()
         self.add_title()
         self.show_ordinary_factorization()
         self.subfactor_ordinary_factorization()
@@ -2864,7 +2865,7 @@ class WriteAlternateLastStep(IntroduceRecipe):
         cross = TexMobject("\\times")
         cross.replace(output_words, stretch = True)
         cross.set_color(RED)
-        
+
         self.add(output_words, arrow)
         self.play(Write(cross))
         output_words.add(cross)
@@ -2888,7 +2889,7 @@ class ThreeOutputsAsLatticePointsContinued(ThreeOutputsAsLatticePoints):
             dot.add(line)
         words_group = VGroup(*[
             TextMobject("Multiply by $%s$"%s)
-            for s in "1", "i", "-1", "-i"
+            for s in ("1", "i", "-1", "-i")
         ])
         for words, color in zip(words_group, self.colors):
             words.add_background_rectangle()
@@ -2917,8 +2918,8 @@ class RecipeFor125(IntroduceRecipe):
         "N_string" : "125",
         "integer_factors" : [5, 5, 5],
         "gaussian_factors" : [
-            complex(2, -1), complex(2, 1), 
-            complex(2, -1), complex(2, 1), 
+            complex(2, -1), complex(2, 1),
+            complex(2, -1), complex(2, 1),
             complex(2, -1), complex(2, 1),
         ],
     }
@@ -2928,7 +2929,7 @@ class RecipeFor125(IntroduceRecipe):
         self.add_title()
         self.show_ordinary_factorization()
         self.subfactor_ordinary_factorization()
-        
+
         self.revert_to_original_skipping_status()
         self.organize_factors_into_columns()
         # self.take_product_of_columns()
@@ -2968,8 +2969,8 @@ class Show125Circle(ThreeOutputsAsLatticePointsContinued):
         self.add_foreground_mobject(root_label)
         self.play(
             Rotating(
-                radial_line, 
-                rate_func = smooth, 
+                radial_line,
+                rate_func = smooth,
                 about_point = self.plane_center
             ),
             ShowCreation(circle),
@@ -2985,7 +2986,7 @@ class RecipeFor375(IntroduceRecipe):
         "N_string" : "375",
         "integer_factors" : [3, 5, 5, 5],
         "gaussian_factors" : [
-            3, 
+            3,
             complex(2, 1), complex(2, -1),
             complex(2, 1), complex(2, -1),
             complex(2, 1), complex(2, -1),
@@ -3007,7 +3008,7 @@ class RecipeFor375(IntroduceRecipe):
 
         self.play(FadeIn(morty))
         self.play(
-            MoveToTarget(three), 
+            MoveToTarget(three),
             morty.change, "angry", three.target
         )
         self.play(Blink(morty))
@@ -3079,7 +3080,7 @@ class RecipeFor1125(IntroduceRecipe):
 
     def write_last_step(self):
         words = TextMobject(
-            "Multiply by \\\\ ", 
+            "Multiply by \\\\ ",
             "$1$, $i$, $-1$ or $-i$"
         )
         words.scale(0.7)
@@ -3176,8 +3177,8 @@ class SummarizeCountingRule(Show125Circle):
         )
         self.play(
             Rotating(
-                radial_line, 
-                rate_func = smooth, 
+                radial_line,
+                rate_func = smooth,
                 about_point = self.plane_center
             ),
             ShowCreation(circle),
@@ -3202,7 +3203,7 @@ class SummarizeCountingRule(Show125Circle):
 
     def talk_through_rules(self):
         factorization = TexMobject(
-            "N =", 
+            "N =",
             "3", "^4", "\\cdot",
             "5", "^3", "\\cdot",
             "13", "^2"
@@ -3212,7 +3213,7 @@ class SummarizeCountingRule(Show125Circle):
 
         three, five, thirteen = [
             factorization.get_part_by_tex(str(n), substring = False)
-            for n in 3, 5, 13
+            for n in (3, 5, 13)
         ]
         three_power = factorization.get_part_by_tex("^4")
         five_power = factorization.get_part_by_tex("^3")
@@ -3378,7 +3379,7 @@ class RecipeFor10(IntroduceRecipe):
         self.play(curr_product.to_edge, LEFT)
         self.swap_factors_at_index(0)
         new_arrow = Arrow(
-            self.result_surrounding_rect, curr_product, 
+            self.result_surrounding_rect, curr_product,
             buff = SMALL_BUFF
         )
         self.play(
@@ -3445,7 +3446,7 @@ class IntroduceChi(FactorizationPattern):
     CONFIG = {
         "numbers_list" : [
             range(i, 36, d)
-            for i, d in (1, 4), (3, 4), (2, 2)
+            for i, d in ((1, 4), (3, 4), (2, 2))
         ],
         "colors" : [GREEN, RED, YELLOW]
     }
@@ -3496,10 +3497,10 @@ class IntroduceChi(FactorizationPattern):
         self.wait()
         self.play(
             Write(VGroup(*[
-                part 
+                part
                 for part in chi_expression
                 if part not in chi_expression.inputs
-            ])), 
+            ])),
         *[
             ReplacementTransform(label.copy(), num_mob)
             for label, num_mob in zip(
@@ -3539,7 +3540,7 @@ class IntroduceChi(FactorizationPattern):
 
         self.play(*[
             FadeIn(
-                mob, 
+                mob,
                 run_time = 3,
                 submobject_mode = "lagged_start"
             )
@@ -3578,12 +3579,12 @@ class IntroduceChi(FactorizationPattern):
                 "\\chi(%d)"%x,
                 "\\cdot",
                 "\\chi(%d)"%y,
-                "=", 
+                "=",
                 "\\chi(%d)"%(x*y)
             )
             braces = [
-                Brace(expression[i], UP) 
-                for i in 0, 2, 4
+                Brace(expression[i], UP)
+                for i in (0, 2, 4)
             ]
             for brace, n in zip(braces, [x, y, x*y]):
                 output = chi_func(n)
@@ -3692,7 +3693,7 @@ class WriteCountingRuleWithChi(SummarizeCountingRule):
 
     def add_factorization_and_rule(self):
         factorization = TexMobject(
-            "N", "=", 
+            "N", "=",
             "2", "^2", "\\cdot",
             "3", "^4", "\\cdot",
             "5", "^3",
@@ -3914,7 +3915,7 @@ class ExpandCountWith45(SummarizeCountingRule):
             expression.add(factor)
         expression.arrange_submobjects(RIGHT, buff = SMALL_BUFF)
         expression.next_to(
-            factorization[1], DOWN, 
+            factorization[1], DOWN,
             buff = LARGE_BUFF,
             aligned_edge = LEFT,
         )
@@ -4049,7 +4050,7 @@ class ExpandCountWith45(SummarizeCountingRule):
             Write(divisor_sum, run_time = 2)
         )
         self.play(LaggedStart(
-            MoveToTarget, prime_pairs, 
+            MoveToTarget, prime_pairs,
             run_time = 4,
             lag_ratio = 0.25,
         ))
@@ -4063,7 +4064,7 @@ class ExpandCountWith45(SummarizeCountingRule):
             rate_func = there_and_back
         ))
         self.play(FadeIn(
-            braces, 
+            braces,
             run_time = 2,
             submobject_mode = "lagged_start",
         ))
@@ -4306,14 +4307,14 @@ class AddUpGrid(Scene):
             radical.chi_sum = chi_sum
 
         self.play(LaggedStart(
-            Write, chi_sums, 
+            Write, chi_sums,
             run_time = 5,
             rate_func = lambda t : t,
         ))
         self.wait()
 
         digest_locals(self, [
-            "chi_sums", "chi_mobs", "plusses", 
+            "chi_sums", "chi_mobs", "plusses",
             "fours", "parens", "arrows",
         ])
 
@@ -4350,7 +4351,7 @@ class AddUpGrid(Scene):
                 rect.copy().move_to(self.radicals[N-1], LEFT)
                 for N in numbers
             ])
-            for numbers in [6, 12], [2, 3, 5, 7, 11]
+            for numbers in ([6, 12], [2, 3, 5, 7, 11])
         ]
         prime_rects.set_color(GREEN)
 
@@ -4518,7 +4519,7 @@ class AddUpGrid(Scene):
             R_movers.add(mover)
 
         self.play(*it.chain(
-            map(Write, [lp, rp, dots]), 
+            map(Write, [lp, rp, dots]),
             map(MoveToTarget, full_sum_parts),
         ), run_time = 2)
         self.remove(R_movers)
@@ -4536,7 +4537,7 @@ class AddUpGrid(Scene):
 
     def show_chi_sum_values(self):
         alt_rhs = TexMobject(
-            "\\approx", "4", "R^2", 
+            "\\approx", "4", "R^2",
             "\\left(1 - \\frac{1}{3} + \\frac{1}{5}" + \
             "-\\frac{1}{7} + \\frac{1}{9} - \\frac{1}{11}" + \
             "+ \\cdots \\right)",
@@ -4815,15 +4816,3 @@ class Thumbnail(Scene):
             ))
         self.add(prime_mobs)
         self.add(body_copy)
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/matrix_as_transform_2d.py
+++ b/old_projects/matrix_as_transform_2d.py
@@ -93,9 +93,11 @@ class ExamplesOfOneDimensionalLinearTransforms(ShowMultiplication):
 
 class ExamplesOfNonlinearOneDimensionalTransforms(NumberLineScene):
     def construct(self):
-        def sinx_plux_x((x, y, z)):
+        def sinx_plux_x(xxx_todo_changeme):
+            (x, y, z) = xxx_todo_changeme
             return (np.sin(x) + 1.2*x, y, z)
-        def shift_zero((x, y, z)):
+        def shift_zero(xxx_todo_changeme2):
+            (x, y, z) = xxx_todo_changeme2
             return (2*x+4, y, z)
         self.nonlinear = TextMobject("Not a Linear Transform")
         self.nonlinear.set_color(LIGHT_RED).to_edge(UP, buff = 1.5)
@@ -187,10 +189,10 @@ class TransformScene2D(Scene):
         )
         self.add(self.x_arrow, self.y_arrow)
         self.number_plane.filter_out(
-            lambda (x, y, z) : (0 < x) and (x < 1) and (abs(y) < 0.1)
+            lambda x_y_z : (0 < x_y_z[0]) and (x_y_z[0] < 1) and (abs(x_y_z[1]) < 0.1)
         )
         self.number_plane.filter_out(
-            lambda (x, y, z) : (0 < y) and (y < 1) and (abs(x) < 0.1)
+            lambda x_y_z1 : (0 < x_y_z1[1]) and (x_y_z1[1] < 1) and (abs(x_y_z1[0]) < 0.1)
         )
         return self
 
@@ -293,9 +295,11 @@ class ExamplesOfTwoDimensionalLinearTransformations(ShowMatrixTransform):
 class ExamplesOfNonlinearTwoDimensionalTransformations(Scene):
     def construct(self):
         Scene.construct(self)
-        def squiggle((x, y, z)):
+        def squiggle(xxx_todo_changeme3):
+            (x, y, z) = xxx_todo_changeme3
             return (x+np.sin(y), y+np.cos(x), z)
-        def shift_zero((x, y, z)):
+        def shift_zero(xxx_todo_changeme4):
+            (x, y, z) = xxx_todo_changeme4
             return (2*x + 3*y + 4, -1*x+y+2, z)
         self.nonlinear = TextMobject("Nonlinear Transform")
         self.nonlinear.set_color(LIGHT_RED)
@@ -382,10 +386,12 @@ class TrickyExamplesOfNonlinearTwoDimensionalTransformations(Scene):
             UP*FRAME_Y_RADIUS+RIGHT*FRAME_X_RADIUS,
             density = 10*DEFAULT_POINT_DENSITY_1D
         )
-        def sunrise((x, y, z)):
+        def sunrise(xxx_todo_changeme5):
+            (x, y, z) = xxx_todo_changeme5
             return ((FRAME_Y_RADIUS+y)*x, y, z)
 
-        def squished((x, y, z)):
+        def squished(xxx_todo_changeme6):
+            (x, y, z) = xxx_todo_changeme6
             return (x + np.sin(x), y+np.sin(y), z)
 
         self.get_blackness()
@@ -534,7 +540,7 @@ class Show90DegreeRotation(TransformScene2D):
         self.wait()
         self.play(*[
             RotationAsTransform(mob, run_time = 2.0)
-            for mob in self.number_plane, self.x_arrow, self.y_arrow
+            for mob in (self.number_plane, self.x_arrow, self.y_arrow)
         ])
         self.wait()
 

--- a/old_projects/moser_intro.py
+++ b/old_projects/moser_intro.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 import operator as op
@@ -12,13 +13,13 @@ CIRCLE_DENSITY = DEFAULT_POINT_DENSITY_1D*RADIUS
 
 
 def logo_to_circle():
-    from generate_logo import DARK_BROWN, LOGO_RADIUS
+    from .generate_logo import DARK_BROWN, LOGO_RADIUS
     sc = Scene()
     small_circle = Circle(
         density = CIRCLE_DENSITY,
         color = 'skyblue'
     ).scale(LOGO_RADIUS).set_color(
-        DARK_BROWN, lambda (x, y, z) : x < 0 and y > 0
+        DARK_BROWN, lambda x_y_z : x_y_z[0] < 0 and x_y_z[1] > 0
     )
     big_circle = Circle(density = CIRCLE_DENSITY).scale(RADIUS)
     sc.add(small_circle)

--- a/old_projects/moser_main.py
+++ b/old_projects/moser_main.py
@@ -10,6 +10,7 @@ import inspect
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
+from functools import reduce
 
 RADIUS            = FRAME_Y_RADIUS - 0.1
 CIRCLE_DENSITY    = DEFAULT_POINT_DENSITY_1D*RADIUS
@@ -677,7 +678,7 @@ class GraphsAndEulersFormulaJoke(Scene):
             lambda t : (10*t, ((10*t)**3 - 10*t), 0),
             expected_measure = 40.0
         )
-        graph.filter_out(lambda (x, y, z) : abs(y) > FRAME_Y_RADIUS)
+        graph.filter_out(lambda x_y_z : abs(x_y_z[1]) > FRAME_Y_RADIUS)
         self.add(axes)
         self.play(ShowCreation(graph), run_time = 1.0)
         eulers = TexMobject("e^{\pi i} = -1").shift((0, 3, 0))
@@ -1568,7 +1569,7 @@ class ExplainNChoose2Formula(Scene):
         ])
         self.play(*[
             ApplyMethod(mob.shift, (0, 1, 0))
-            for mob in parens, a_mob, b_mob
+            for mob in (parens, a_mob, b_mob)
         ])
         parens_copy = deepcopy(parens).shift((0, -2, 0))
         a_center = a_mob.get_center()

--- a/old_projects/mug.py
+++ b/old_projects/mug.py
@@ -1247,7 +1247,7 @@ class ShowRule(TeacherStudentsScene):
                 color = WHITE,
                 buff = SMALL_BUFF
             )
-            for mob in new_vertex, new_region
+            for mob in (new_vertex, new_region)
         ])
         for word, arrow in zip(["Either", "or"], arrows):
             word_mob = TextMobject(word)

--- a/old_projects/music_and_measure.py
+++ b/old_projects/music_and_measure.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -7,7 +8,7 @@ import sys
 from fractions import Fraction, gcd
 
 from big_ol_pile_of_manim_imports import *
-from inventing_math import Underbrace
+from .inventing_math import Underbrace
 
 import random
 
@@ -212,7 +213,7 @@ class IntervalScene(NumberLineScene):
         all_rationals = rationals()
         count = 0
         while True:
-            fraction = all_rationals.next()
+            fraction = next(all_rationals)
             count += 1
             if num_intervals >= num_fractions:
                 break
@@ -314,7 +315,7 @@ class ChallengeOne(Scene):
         top_vibrations = [
             Vibrate(
                 num_periods = freq, run_time = 3.0,
-                center = 2*UP, color = colors.next()
+                center = 2*UP, color = next(colors)
             )
             for freq in [1, 2, 5.0/3, 4.0/3, 2]
         ]
@@ -581,7 +582,7 @@ class PatternInFrequencies(Scene):
         )
         anims = [
             ApplyMethod(mob.shift, setup_width*LEFT, **kwargs)
-            for mob in top_lines, bottom_lines
+            for mob in (top_lines, bottom_lines)
         ]
         anim_mobs = [anim.mobject for anim in anims]
         self.play(
@@ -614,12 +615,12 @@ class CompareFractionComplexity(Scene):
         self.add(simple, complicated)
         self.play(*[
             ShowCreation(arrow)
-            for arrow in arrow1, arrow2
+            for arrow in (arrow1, arrow2)
         ])
         self.wait()
         self.play(*[
             DelayByOrder(ApplyMethod(frac[1].set_color, "yellow"))
-            for frac in frac0, frac1
+            for frac in (frac0, frac1)
         ])
         self.play(
             FadeIn(indicates),
@@ -851,7 +852,7 @@ class AllValuesBetween1And2(NumberLineScene):
         }
         self.play(*[
             ApplyMethod(mob.shift, RIGHT, **kwargs)
-            for mob in r, top_arrow
+            for mob in (r, top_arrow)
         ])
         self.wait() 
         self.remove(r, top_arrow)
@@ -930,10 +931,10 @@ class DefineOpenInterval(IntervalScene):
         left_arrow = Arrow(a.get_corner(DOWN+LEFT), left)
         right_arrow = Arrow(b.get_corner(DOWN+RIGHT), right)
 
-        self.play(*[ShimmerIn(mob) for mob in a, less_than1, x])
+        self.play(*[ShimmerIn(mob) for mob in (a, less_than1, x)])
         self.play(ShowCreation(left_arrow))
         self.wait()
-        self.play(*[ShimmerIn(mob) for mob in less_than2, b])
+        self.play(*[ShimmerIn(mob) for mob in (less_than2, b)])
         self.play(ShowCreation(right_arrow))
         self.wait()
 
@@ -1229,7 +1230,7 @@ class StepsToSolution(IntervalScene):
         arrow = Arrow(ORIGIN, RIGHT).next_to(dots)
         one = TexMobject("1").next_to(arrow)
         self.ones.append(one)
-        self.play(*[ShowCreation(mob) for mob in dots, arrow, one])
+        self.play(*[ShowCreation(mob) for mob in (dots, arrow, one)])
         self.wait()
 
     def multiply_by_epsilon(self):

--- a/old_projects/nn/network.py
+++ b/old_projects/nn/network.py
@@ -8,6 +8,7 @@ using backpropagation.  Note that I have focused on making the code
 simple, easily readable, and easily modifiable.  It is not optimized,
 and omits many desirable features.
 """
+from __future__ import print_function
 
 #### Libraries
 # Standard library
@@ -221,7 +222,7 @@ def test_network():
             n_right += 1
         else:
             n_wrong += 1
-    print(n_right, n_wrong, float(n_right)/(n_right + n_wrong))
+    print((n_right, n_wrong, float(n_right)/(n_right + n_wrong)))
 
 def layer_to_image_array(layer):
     w = int(np.ceil(np.sqrt(len(layer))))

--- a/old_projects/nn/part1.py
+++ b/old_projects/nn/part1.py
@@ -339,7 +339,7 @@ class ExampleThrees(PiCreatureScene):
         three_mob_copy = three_mob[1].copy()
         three_mob_copy.sort_submobjects(lambda p : np.dot(p, DOWN+RIGHT))
 
-        braces = VGroup(*[Brace(three_mob, v) for v in LEFT, UP])
+        braces = VGroup(*[Brace(three_mob, v) for v in (LEFT, UP)])
         brace_labels = VGroup(*[
             brace.get_text("28px")
             for brace in braces
@@ -1070,7 +1070,7 @@ class IntroduceEachLayer(PreviewMNistNetwork):
         neurons.space_out_submobjects(1.3)
         neurons.to_edge(DOWN)
 
-        braces = VGroup(*[Brace(neurons, vect) for vect in LEFT, UP])
+        braces = VGroup(*[Brace(neurons, vect) for vect in (LEFT, UP)])
         labels = VGroup(*[
             brace.get_tex("28", buff = SMALL_BUFF) 
             for brace in braces
@@ -1517,7 +1517,7 @@ class BreakUpMacroPatterns(IntroduceEachLayer):
         image_map = get_organized_images()
         two, three, five = mobs = [
             MNistMobject(image_map[n][0])
-            for n in 2, 3, 5
+            for n in (2, 3, 5)
         ]
         self.added_patterns = VGroup()
         for mob in mobs:
@@ -1846,7 +1846,7 @@ class BreakUpMicroPatterns(BreakUpMacroPatterns):
         image_map = get_organized_images()
         digits = VGroup(*[
             MNistMobject(image_map[n][1])
-            for n in 1, 4, 7
+            for n in (1, 4, 7)
         ])
         digits.arrange_submobjects(RIGHT)
         digits.next_to(randy, RIGHT)
@@ -1892,7 +1892,7 @@ class SecondLayerIsLittleEdgeLayer(IntroduceEachLayer):
         layers = self.network_mob.layers
         nine_im, loop_im, line_im = images = [
             Image.open(get_full_raster_image_path("handwritten_%s"%s))
-            for s in "nine", "upper_loop", "right_line"
+            for s in ("nine", "upper_loop", "right_line")
         ]
         nine_array, loop_array, line_array = [
             np.array(im)[:,:,0]/255.0
@@ -1929,7 +1929,7 @@ class SecondLayerIsLittleEdgeLayer(IntroduceEachLayer):
 
         loop, line = [
             ImageMobject(layer_to_image_array(array.flatten()))
-            for array in loop_array, line_array
+            for array in (loop_array, line_array)
         ]
         for mob, color in (loop, YELLOW), (line, RED):
             make_transparent(mob)
@@ -2571,7 +2571,7 @@ class IntroduceWeights(IntroduceEachLayer):
                 self.negative_weights_color,
                 0.5
             )
-            for y in 6, 10
+            for y in (6, 10)
             for x in range(14-4, 14+4)
         ])
         self.wait(2)
@@ -2597,7 +2597,7 @@ class IntroduceWeights(IntroduceEachLayer):
         d = int(np.sqrt(len(pixels)))
         return VGroup(*it.chain(*[
             pixels[d*n + d/2 - 4 : d*n + d/2 + 4]
-            for n in 6, 10
+            for n in (6, 10)
         ]))
 
     def make_edges_weighted(self, edges, weights):
@@ -2637,7 +2637,7 @@ class MotivateSquishing(Scene):
                 weighted_sum.get_bottom(),
                 number_line.number_to_point(n),
             )
-            for n in -3, 3
+            for n in (-3, 3)
         ]
 
         self.play(Write(number_line))
@@ -2761,7 +2761,7 @@ class IntroduceSigmoid(GraphScene):
                 x_max = x_max,
                 color = color,
             ).set_stroke(width = 4)
-            for func in lambda x : 0, sigmoid
+            for func in (lambda x : 0, sigmoid)
         ]
 
         self.play(ShowCreation(line))
@@ -3542,7 +3542,7 @@ class IntroduceWeightMatrix(NetworkScene):
         self.wait()
         self.play(*[
             LaggedStart(Indicate, mob, rate_func = there_and_back)
-            for mob in a_labels, a_labels_in_sum
+            for mob in (a_labels, a_labels_in_sum)
         ])
         self.wait()
 
@@ -3573,7 +3573,7 @@ class IntroduceWeightMatrix(NetworkScene):
                 "\\cdots",
                 "w_{%s, n}"%i,
             ]))
-            for i in "1", "k"
+            for i in ("1", "k")
         ]
         dots_row = VGroup(*map(TexMobject, [
             "\\vdots", "\\vdots", "\\ddots", "\\vdots"
@@ -3678,7 +3678,7 @@ class IntroduceWeightMatrix(NetworkScene):
     def show_meaning_of_lower_rows(self, arrow, brace, row_rect, result_terms):
         n1, n2, nk = neurons = VGroup(*[
             self.network_mob.layers[1].neurons[i]
-            for i in 0, 1, -1
+            for i in (0, 1, -1)
         ])
         for n in neurons:
             n.save_state()
@@ -4074,7 +4074,7 @@ class NeuronIsFunction(MoreHonestMNistNetworkPreview):
                 run_time = 2, 
                 submobject_mode = "lagged_start"
             )
-            for mob in self.network_mob.layers, self.network_mob.edge_groups
+            for mob in (self.network_mob.layers, self.network_mob.edge_groups)
         ]
         anims += [
             FadeOut(self.neuron_arrow),

--- a/old_projects/nn/part2.py
+++ b/old_projects/nn/part2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import os.path
 import cv2
@@ -460,7 +461,7 @@ class MNistDescription(Scene):
         ]
 
         for i, td_group in enumerate(training_data_groups):
-            print i
+            print(i)
             group = Group(*[
                 self.get_digit_pair(v_in, v_out)
                 for v_in, v_out in td_group
@@ -656,7 +657,7 @@ class IntroduceCostFunction(PreviewLearning):
         )
         symbols = VGroup(*[
             formula.get_parts_by_tex(tex)
-            for tex in "=", "+", "dots"
+            for tex in ("=", "+", "dots")
         ])
 
         w_labels.set_color(self.positive_edge_color)
@@ -774,7 +775,7 @@ class IntroduceCostFunction(PreviewLearning):
                 FadeIn, group,
                 run_time = 3,
             )
-            for group in neurons, edges
+            for group in (neurons, edges)
         ])
 
     def feed_in_example(self):
@@ -885,7 +886,7 @@ class IntroduceCostFunction(PreviewLearning):
         desired_layer = self.desired_last_layer
         decimal_groups = VGroup(*[
             self.num_vect_to_decimals(self.layer_to_num_vect(l))
-            for l in layer, desired_layer
+            for l in (layer, desired_layer)
         ])
 
         terms = VGroup()
@@ -1060,7 +1061,7 @@ class IntroduceCostFunction(PreviewLearning):
             random_v = np.random.random(10)
             new_decimal_groups = VGroup(*[
                 self.num_vect_to_decimals(v)
-                for v in random_v, out_vect
+                for v in (random_v, out_vect)
             ])
             for ds, nds in zip(decimal_groups, new_decimal_groups):
                 for old_d, new_d in zip(ds, nds):
@@ -1077,7 +1078,7 @@ class IntroduceCostFunction(PreviewLearning):
             self.add(new_image_group)
             image_group = new_image_group
 
-            self.wait(wait_times.next())
+            self.wait(next(wait_times))
 
     ####
 
@@ -1465,7 +1466,7 @@ class SingleVariableCostFunction(GraphScene):
             VGroup(cf[0], cf[2]).set_color(RED)
         big_brace, lil_brace = [
             Brace(cf[1], DOWN)
-            for cf in cf1, cf2
+            for cf in (cf1, cf2)
         ]
         big_brace_text = big_brace.get_text("Weights and biases")
         lil_brace_text = lil_brace.get_text("Single input")

--- a/old_projects/nn/part3.py
+++ b/old_projects/nn/part3.py
@@ -2255,7 +2255,7 @@ class SimplestNetworkExample(PreviewLearning):
     def label_neurons(self):
         neurons = VGroup(*[
             self.network_mob.layers[i].neurons[0]
-            for i in -1, -2
+            for i in (-1, -2)
         ])
         decimals = VGroup()
         a_labels = VGroup()
@@ -2374,7 +2374,7 @@ class SimplestNetworkExample(PreviewLearning):
         cost_equation.to_corner(UP+RIGHT)
         C0, a, y = [
             cost_equation.get_part_by_tex(tex)
-            for tex in "C_0", "a^{(L)}", "y"
+            for tex in ("C_0", "a^{(L)}", "y")
         ]
         y.set_color(YELLOW)
 
@@ -2577,7 +2577,7 @@ class SimplestNetworkExample(PreviewLearning):
         self.play(MoveToTarget(C0))
         self.play(*it.chain(*[
             [ShowCreation(line), line.flash]
-            for line in a_to_c_line, y_to_c_line
+            for line in (a_to_c_line, y_to_c_line)
         ]))
         self.wait(2)
 
@@ -2895,7 +2895,7 @@ class SimplestNetworkExample(PreviewLearning):
         dC_dw = self.dC_dw
         del_syms = [
             getattr(self, attr)
-            for attr in "del_wL", "del_zL", "del_aL", "del_C0"
+            for attr in ("del_wL", "del_zL", "del_aL", "del_C0")
         ]
 
         dz_dw = TexMobject(
@@ -3088,7 +3088,7 @@ class SimplestNetworkExample(PreviewLearning):
                 neuron.set_fill, None, target_o,
                 *[
                     ChangingDecimal(d, lambda a : neuron.get_fill_opacity())
-                    for d in decimal, moving_decimals[0]
+                    for d in (decimal, moving_decimals[0])
                 ]
             )
         self.play(*map(FadeOut, [double_arrow, moving_decimals]))
@@ -3726,8 +3726,8 @@ class GeneralFormulas(SimplestNetworkExample):
             all_subscript_rects.add(subscript_rects)
 
         start_labels, start_arrows = [
-            VGroup(*map(VGroup, [group[i][0] for i in 0, 1])).copy()
-            for group in all_labels, all_arrows
+            VGroup(*map(VGroup, [group[i][0] for i in (0, 1)])).copy()
+            for group in (all_labels, all_arrows)
         ]
         for label in start_labels:
             label[0][-1].set_color(BLACK)
@@ -3856,7 +3856,7 @@ class GeneralFormulas(SimplestNetworkExample):
 
         self.play(*[
             ReplacementTransform(mob, mob.target)
-            for mob in aj, yj
+            for mob in (aj, yj)
         ])
         self.play(LaggedStart(FadeIn, to_fade_in))
         self.wait(2)
@@ -4050,7 +4050,7 @@ class GeneralFormulas(SimplestNetworkExample):
         neurons = self.network_mob.layers[-1].neurons
         labels, arrows, decimals = [
             VGroup(*[getattr(n, attr) for n in neurons])
-            for attr in "label", "arrow", "decimal"
+            for attr in ("label", "arrow", "decimal")
         ]
         edges = VGroup(*[n.edges_in[1] for n in neurons])
         labels[0].generate_target()

--- a/old_projects/nn/playground.py
+++ b/old_projects/nn/playground.py
@@ -3,6 +3,7 @@
 
 import sys
 import os.path
+from functools import reduce
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from constants import *

--- a/old_projects/patreon.py
+++ b/old_projects/patreon.py
@@ -19,7 +19,7 @@ class SideGigToFullTime(Scene):
         dollar_sign = TexMobject("\\$")
         cross = VGroup(*[
             Line(vect, -vect, color = RED)
-            for vect in UP+RIGHT, UP+LEFT
+            for vect in (UP+RIGHT, UP+LEFT)
         ])
         cross.scale_to_fit_height(dollar_sign.get_height())
         no_money = VGroup(dollar_sign, cross)

--- a/old_projects/playground_counting_in_binary.py
+++ b/old_projects/playground_counting_in_binary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -12,6 +13,7 @@ from constants import *
 from mobject.region import  *
 from scene.scene import Scene, SceneFromVideo
 from script_wrapper import command_line_create_scene
+from functools import reduce
 
 MOVIE_PREFIX = "counting_in_binary/"
 

--- a/old_projects/putnam.py
+++ b/old_projects/putnam.py
@@ -25,7 +25,7 @@ class IntroducePutnam(Scene):
                 TextMobject("%s%d)"%(c, i))
                 for i in range(1, 7)
             ]).arrange_submobjects(DOWN, buff = MED_LARGE_BUFF)
-            for c in "A", "B"
+            for c in ("A", "B")
         ]).arrange_submobjects(RIGHT, buff = FRAME_X_RADIUS - MED_SMALL_BUFF)
         question_groups.to_edge(LEFT)
         question_groups.to_edge(DOWN, MED_LARGE_BUFF)

--- a/old_projects/pythagorean_proof.py
+++ b/old_projects/pythagorean_proof.py
@@ -324,7 +324,7 @@ class DrawCSquareWithAllTraingles(Scene):
             toggle_vector = [False]*4
         self.c_square = c_square().center()
         vertices = it.cycle(self.c_square.get_vertices())
-        last_vertex = vertices.next()
+        last_vertex = next(vertices)
         have_letters = False
         self.triangles = []
         for vertex, should_flip in zip(vertices, toggle_vector):
@@ -385,8 +385,8 @@ class ZoomInOnTroublePoint(Scene):
         circle = Circle(radius = 2.5, color = WHITE)
         angle1_arc = Circle(color = WHITE)
         angle2_arc = Circle(color = WHITE).scale(0.5)
-        angle1_arc.filter_out(lambda (x, y, z) : not (x > 0 and y > 0 and y < x/3))
-        angle2_arc.filter_out(lambda (x, y, z) : not (x < 0 and y > 0 and y < -3*x))
+        angle1_arc.filter_out(lambda x_y_z2 : not (x_y_z2[0] > 0 and x_y_z2[1] > 0 and x_y_z2[1] < x_y_z2[0]/3))
+        angle2_arc.filter_out(lambda x_y_z3 : not (x_y_z3[0] < 0 and x_y_z3[1] > 0 and x_y_z3[1] < -3*x_y_z3[0]))
 
         self.add_mobjects_among(locals().values())
         self.add_elbow()        
@@ -422,10 +422,10 @@ class DrawTriangleWithAngles(Scene):
         vertices = triangle.get_vertices()
         kwargs = {"color" : WHITE}
         angle1_arc = Circle(radius = 0.4, **kwargs).filter_out(
-            lambda (x, y, z) : not(x > 0 and y < 0 and y < -3*x)
+            lambda x_y_z : not(x_y_z[0] > 0 and x_y_z[1] < 0 and x_y_z[1] < -3*x_y_z[0])
         ).shift(vertices[1])
         angle2_arc = Circle(radius = 0.2, **kwargs).filter_out(
-            lambda (x, y, z) : not(x < 0 and y > 0 and y < -3*x)
+            lambda x_y_z1 : not(x_y_z1[0] < 0 and x_y_z1[1] > 0 and x_y_z1[1] < -3*x_y_z1[0])
         ).shift(vertices[2])
         alpha = TexMobject("\\alpha")
         beta = TexMobject("90-\\alpha")

--- a/old_projects/qa_round_two.py
+++ b/old_projects/qa_round_two.py
@@ -100,7 +100,7 @@ class PowersOfTwo(Scene):
                 two_to_ten.get_corner(vect+RIGHT),
                 mob[0].get_corner(vect+LEFT),
             )
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ])
         two_to_ten.save_state()
         two_to_ten.replace(mob[0])

--- a/old_projects/tattoo.py
+++ b/old_projects/tattoo.py
@@ -404,7 +404,7 @@ class ExplainTrigFunctionDistances(TrigRepresentationsScene, PiCreatureScene):
 
         sec_dot, csc_dot = [
             Dot(line.get_end(), color = line.get_color())
-            for line in sec_line, csc_line
+            for line in (sec_line, csc_line)
         ]
         sec_group.add(sec_dot)
         csc_group.add(csc_dot)

--- a/old_projects/tau_poem.py
+++ b/old_projects/tau_poem.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -7,7 +8,7 @@ import sys
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
-from generate_logo import LogoGeneration
+from .generate_logo import LogoGeneration
 
 POEM_LINES = """Fixed poorly in notation with that two,
 you shine so loud that you deserve a name.
@@ -388,7 +389,7 @@ class TauPoem(Scene):
         grid.add(TexMobject("e^{ix}").shift(grid_center+UP+RIGHT))
         circle.set_color("white")
         tau_line = Line(
-            *[np.pi*interval_size*vect for vect in LEFT, RIGHT],
+            *[np.pi*interval_size*vect for vect in (LEFT, RIGHT)],
             density = 5*DEFAULT_POINT_DENSITY_1D
         )
         tau_line.set_color("red")
@@ -475,7 +476,8 @@ class TauPoem(Scene):
         ])
         for index in range(circle.points.shape[0]):
             circle.rgbas
-        def trianglify((x, y, z)):
+        def trianglify(xxx_todo_changeme):
+            (x, y, z) = xxx_todo_changeme
             norm = np.linalg.norm((x, y, z))
             comp = complex(x, y)*complex(0, 1)
             return (

--- a/old_projects/triangle_of_power/intro.py
+++ b/old_projects/triangle_of_power/intro.py
@@ -20,7 +20,7 @@ class TrigAnimation(Animation):
         circle = Circle(color = WHITE)
         self.trig_lines = [
             Line(ORIGIN, RIGHT, color = color)
-            for color in self.sin_color, self.cos_color, self.tan_color
+            for color in (self.sin_color, self.cos_color, self.tan_color)
         ]
         mobject = VMobject(
             x_axis, y_axis, circle, 
@@ -348,7 +348,7 @@ class WhatTheHell(Scene):
             last = mob
         q_marks = VMobject(*[
             TexMobject("?!").next_to(arrow, RIGHT)
-            for arrow in arrow1, arrow2
+            for arrow in (arrow1, arrow2)
         ])
         q_marks.set_color(RED_D)
         everyone = VMobject(exp, rad, log, arrow1, arrow2, q_marks)
@@ -466,11 +466,11 @@ class HaveToShare(Scene):
         VMobject(*words).center()
         left_dot, top_dot, bottom_dot = [
             Dot(point, radius = 0.1)
-            for point in ORIGIN, RIGHT+0.5*UP, RIGHT+0.5*DOWN
+            for point in (ORIGIN, RIGHT+0.5*UP, RIGHT+0.5*DOWN)
         ]
         line1, line2 = [
             Line(left_dot.get_center(), dot.get_center(), buff = 0)
-            for dot in top_dot, bottom_dot
+            for dot in (top_dot, bottom_dot)
         ]
         share = VMobject(left_dot, top_dot, bottom_dot, line1, line2)
         share.next_to(words[1], RIGHT, buff = 1)

--- a/old_projects/triangle_of_power/triangle.py
+++ b/old_projects/triangle_of_power/triangle.py
@@ -1,5 +1,6 @@
 import numbers
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 OPERATION_COLORS = [YELLOW, GREEN, BLUE_B]
 
@@ -319,7 +320,7 @@ class SixDifferentInverses(Scene):
         assert(lil_top is not None and lil_symbol is not None)
         cancel_parts = [
             VMobject(top.triangle, top.values[symbol_index])
-            for top in lil_top, big_top
+            for top in (lil_top, big_top)
         ]
         new_symbol = lil_symbol.copy()
         new_symbol.replace(right_symbol)
@@ -608,7 +609,7 @@ class RightStaysConstantQ(Scene):
     def construct(self):
         top1, top2, top3 = old_tops = [
             TOP(None, s, "8")
-            for s in "x", "y", TexMobject("x?y")
+            for s in ("x", "y", TexMobject("x?y"))
         ]
         q_mark = TexMobject("?").scale(2)
         equation = VMobject(
@@ -617,11 +618,11 @@ class RightStaysConstantQ(Scene):
         equation.arrange_submobjects(buff = 0.7)
         symbols_at_top = VMobject(*[
             top.values[1]
-            for top in top1, top2, top3
+            for top in (top1, top2, top3)
         ])
         symbols_at_lower_right = VMobject(*[
             top.put_on_vertex(0, top.values[1].copy())
-            for top in top1, top2, top3
+            for top in (top1, top2, top3)
         ])
         old_style_eq1 = TexMobject("\\sqrt[x]{8} ? \\sqrt[y]{8} = \\sqrt[x?y]{8}")
         old_style_eq1.set_color(BLUE)

--- a/old_projects/triples.py
+++ b/old_projects/triples.py
@@ -25,7 +25,7 @@ class IntroduceTriples(TeacherStudentsScene):
         title.to_corner(UP + RIGHT)
 
         triples = [
-            (3, 4, 5), 
+            (3, 4, 5),
             (5, 12, 13),
             (8, 15, 17),
             (7, 24, 25),
@@ -98,7 +98,7 @@ class IntroduceTriples(TeacherStudentsScene):
                 equation.set_color_by_tex(str(num), color)
             equation.next_to(title, DOWN, MED_LARGE_BUFF)
             equation.shift_onto_screen()
-            
+
             self.play(
                 FadeIn(triangle),
                 self.teacher.change_mode, "raise_right_hand"
@@ -127,7 +127,7 @@ class CompareToFermatsLastTheorem(TeacherStudentsScene):
     def construct(self):
         expressions = [
             TexMobject(
-                "a", "^%d"%d, "+", "b", "^%d"%d, 
+                "a", "^%d"%d, "+", "b", "^%d"%d,
                 "=", "c", "^%d"%d
             )
             for d in range(2, 9)
@@ -258,9 +258,9 @@ class ShowManyTriples(Scene):
                 self.wait()
         self.play(FadeOut(triangle))
         self.play(LaggedStart(
-            FadeIn, 
+            FadeIn,
             VGroup(*[
-                title.target 
+                title.target
                 for title in titles[17:]
             ]),
             run_time = 5
@@ -354,16 +354,16 @@ class PythagoreanProof(Scene):
         self.add_labels_to_squares(squares, side_labels)
         self.wait()
         self.play(
-            VGroup(triangle_copy, a_square, b_square).move_to, 
+            VGroup(triangle_copy, a_square, b_square).move_to,
                 4*LEFT+2*DOWN, DOWN,
-            VGroup(triangle, c_square).move_to, 
+            VGroup(triangle, c_square).move_to,
                 4*RIGHT+2*DOWN, DOWN,
             run_time = 2,
             path_arc = np.pi/2,
         )
         self.wait()
         self.add_new_triangles(
-            triangle, 
+            triangle,
             self.get_added_triangles_to_c_square(triangle, c_square)
         )
         self.wait()
@@ -386,8 +386,8 @@ class PythagoreanProof(Scene):
         double_arrow.next_to(negative_space_words, DOWN)
 
         self.play(
-            FadeIn(big_squares), 
-            Write(negative_space_words), 
+            FadeIn(big_squares),
+            Write(negative_space_words),
             ShowCreation(double_arrow),
             *map(FadeOut, squares)
         )
@@ -464,7 +464,7 @@ class PythagoreanProof(Scene):
         c_square.scale_to_fit_width(hyp_line.get_length())
         c_square.move_to(hyp_line.get_center(), UP)
         c_square.rotate(
-            hyp_line.get_angle(), 
+            hyp_line.get_angle(),
             about_point = hyp_line.get_center()
         )
 
@@ -643,7 +643,7 @@ class ReframeOnLattice(PiCreatureScene):
         )
         self.remove(self.plane)
         self.plane = new_plane
-        self.plane.coordinate_labels = coordinate_labels 
+        self.plane.coordinate_labels = coordinate_labels
         self.add(self.plane, coordinate_labels)
         self.wait()
 
@@ -739,7 +739,7 @@ class ReframeOnLattice(PiCreatureScene):
         square_label.set_color(arrow.get_color())
         square_label.add_background_rectangle()
         square_label.next_to(
-            arrow.point_from_proportion(0.5), 
+            arrow.point_from_proportion(0.5),
             RIGHT, buff = SMALL_BUFF
         )
 
@@ -1011,7 +1011,7 @@ class OneMoreExample(Scene):
         number_label = TexMobject("3+2i")
         number_label.add_background_rectangle()
         number_label.next_to(dot, RIGHT, SMALL_BUFF)
-        distance_labels = VGroup() 
+        distance_labels = VGroup()
         for tex in "3^2 + 2^2", "13":
             pre_label = TexMobject("\\sqrt{%s}"%tex)
             label = VGroup(
@@ -1028,7 +1028,7 @@ class OneMoreExample(Scene):
             distance_labels.add(label)
 
         self.play(
-            FadeIn(number_label), 
+            FadeIn(number_label),
             ShowCreation(line),
             DrawBorderThenFill(dot)
         )
@@ -1087,16 +1087,16 @@ class OneMoreExample(Scene):
         index_alignment_lists = [
             [(0, 0, 0), (0, 1, 1), (1, 1, 2), (1, 5, 9)],
             [
-                (0, 2, 3), (1, 3, 4), (0, 3, 5), 
+                (0, 2, 3), (1, 3, 4), (0, 3, 5),
                 (0, 4, 6), (1, 4, 7), (1, 3, 8)
             ],
             [
-                (0, 2, 10), (0, 0, 11), (0, 1, 12), 
-                (1, 3, 13), (1, 3, 14), (1, 5, 19), 
+                (0, 2, 10), (0, 0, 11), (0, 1, 12),
+                (1, 3, 13), (1, 3, 14), (1, 5, 19),
                 (0, 4, 20), (1, 4, 20),
             ],
             [
-                (0, 2, 15), (0, 3, 16), 
+                (0, 2, 15), (0, 3, 16),
                 (1, 1, 17), (1, 1, 18),
             ],
         ]
@@ -1113,7 +1113,7 @@ class OneMoreExample(Scene):
             Transform(second_line[3], minus),
             FadeOut(VGroup(*[
                 second_line[i]
-                for i in 4, 6, 7
+                for i in (4, 6, 7)
             ])),
             second_line[5].shift, 0.35*RIGHT,
         )
@@ -1154,7 +1154,7 @@ class OneMoreExample(Scene):
         self.play(*[
             ReplacementTransform(m1.copy(), m2)
             for m1, m2 in [
-                (self.line, line), 
+                (self.line, line),
                 (self.distance_label, distance_label)
             ]
         ])
@@ -1171,7 +1171,7 @@ class OneMoreExample(Scene):
         self.play(
             FadeIn(triangle),
             Animation(VGroup(
-                self.line, self.dot, 
+                self.line, self.dot,
                 self.number_label[1], *self.distance_label[1:]
             )),
             run_time = 2
@@ -1221,7 +1221,7 @@ class GeneralExample(OneMoreExample):
         result_length_label.add_background_rectangle()
 
         arrow = Arrow(
-            z_point, square_point, 
+            z_point, square_point,
             # buff = SMALL_BUFF,
             path_arc = np.pi/2
         )
@@ -1230,7 +1230,7 @@ class GeneralExample(OneMoreExample):
         z_to_z_squared.set_color_by_tex("z", dot.get_color())
         z_to_z_squared.set_color_by_tex("z^2", square_dot.get_color())
         z_to_z_squared.next_to(
-            arrow.point_from_proportion(0.5), 
+            arrow.point_from_proportion(0.5),
             RIGHT, MED_SMALL_BUFF
         )
         z_to_z_squared.add_to_back(
@@ -1243,7 +1243,7 @@ class GeneralExample(OneMoreExample):
 
 
         self.play(
-            Write(label), 
+            Write(label),
             ShowCreation(line),
             DrawBorderThenFill(dot)
         )
@@ -1422,7 +1422,7 @@ class WriteGeneralFormula(GeneralExample):
         self.play(*map(FadeIn, [rect, top_line, second_line]))
         self.wait()
         self.play(
-            real_part.copy().next_to, real_part_line.copy(), 
+            real_part.copy().next_to, real_part_line.copy(),
                 DOWN, SMALL_BUFF,
             ShowCreation(real_part_line)
         )
@@ -1432,7 +1432,7 @@ class WriteGeneralFormula(GeneralExample):
                 self.example_label, self.example_dot, self.example_line,
                 self.z_to_z_squared, self.z_to_z_squared_arrow
             )),
-            imag_part.copy().next_to, imag_part_line.copy(), 
+            imag_part.copy().next_to, imag_part_line.copy(),
                 RIGHT, SMALL_BUFF,
             ShowCreation(imag_part_line)
         )
@@ -1478,7 +1478,7 @@ class WriteGeneralFormula(GeneralExample):
         uv_title.scale(0.75)
         triple_title.scale(0.75)
         uv_title.next_to(
-            h_line.point_from_proportion(1./6), 
+            h_line.point_from_proportion(1./6),
             UP, SMALL_BUFF
         )
         triple_title.next_to(
@@ -1505,16 +1505,16 @@ class WriteGeneralFormula(GeneralExample):
         triple_mobs.next_to(triple_title, DOWN, MED_LARGE_BUFF)
 
         self.play(*map(FadeIn, [
-            rect, h_line, v_line, 
+            rect, h_line, v_line,
             uv_title, triple_title
         ]))
         self.play(*[
             LaggedStart(
-                FadeIn, mob, 
+                FadeIn, mob,
                 run_time = 5,
                 lag_ratio = 0.2
             )
-            for mob in pair_mobs, triple_mobs
+            for mob in (pair_mobs, triple_mobs)
         ])
 
 class VisualizeZSquared(Scene):
@@ -1608,13 +1608,13 @@ class VisualizeZSquared(Scene):
         for z in z_list:
             z_point, square_point, mid_point = [
                 self.background_plane.number_to_point(z**p)
-                for p in 1, 2, 1.5
+                for p in (1, 2, 1.5)
             ]
             angle = Line(mid_point, square_point).get_angle()
             angle -= Line(z_point, mid_point).get_angle()
             angle *= 2
             arrow = Arrow(
-                z_point, square_point, 
+                z_point, square_point,
                 path_arc = angle,
                 color = WHITE,
                 tip_length = 0.15,
@@ -1671,7 +1671,7 @@ class VisualizeZSquared(Scene):
             self.background_plane.point_to_coords(
                 u*FRAME_X_RADIUS*RIGHT + u*FRAME_Y_RADIUS*UP
             )
-            for u in -1, 1
+            for u in (-1, 1)
         ]
         x_min, y_min = map(int, min_corner[:2])
         x_max, y_max = map(int, max_corner[:2])
@@ -1705,7 +1705,7 @@ class VisualizeZSquared(Scene):
         self.play(
             self.background_plane.main_lines.set_stroke, None, 1,
             LaggedStart(
-                FadeIn, color_grid, 
+                FadeIn, color_grid,
                 run_time = 2
             ),
             Animation(self.dots),
@@ -1744,7 +1744,7 @@ class VisualizeZSquared(Scene):
     def show_triangles(self):
         z_list = [
             complex(u, v)**2
-            for u, v in (2, 1), (3, 2), (4, 1)
+            for u, v in ((2, 1), (3, 2), (4, 1))
         ]
         triangles = self.get_triangles(z_list)
         triangle = triangles[0]
@@ -1844,7 +1844,7 @@ class VisualizeZSquared(Scene):
             c = int(abs(z))
             a_label, b_label, c_label = labels = [
                 TexMobject(str(num))
-                for num in a, b, c
+                for num in (a, b, c)
             ]
             for label in b_label, c_label:
                 label.add_background_rectangle()
@@ -1917,7 +1917,7 @@ class PointsWeMiss(VisualizeZSquared):
         z_list = [complex(6, 8), complex(9, 12), complex(3, 4)]
         points = map(
             self.background_plane.number_to_point,
-            z_list 
+            z_list
         )
         dots = VGroup(*map(Dot, points))
         for dot in dots[:2]:
@@ -1966,7 +1966,7 @@ class PointsWeMiss(VisualizeZSquared):
         z_list = [complex(4, 3), complex(8, 6)]
         points = map(
             self.background_plane.number_to_point,
-            z_list 
+            z_list
         )
         dots = VGroup(*map(Dot, points))
         dots[0].set_stroke(RED, 4)
@@ -2009,7 +2009,7 @@ class PointsWeMiss(VisualizeZSquared):
 
         self.play(FadeIn(morty))
         self.play(PiCreatureSays(
-            morty, 
+            morty,
             "Never need to scale \\\\ by less than $\\frac{1}{2}$"
         ))
         self.play(Blink(morty))
@@ -2048,7 +2048,7 @@ class DrawSingleRadialLine(PointsWeMiss):
         )
         added_dots = VGroup(*[
             Dot(self.background_plane.coords_to_point(3*k, 4*k))
-            for k in 2, 3, 5
+            for k in (2, 3, 5)
         ])
         added_dots.set_color(GREEN)
 
@@ -2240,7 +2240,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
             line.set_color(dot.get_color())
             label = TexMobject(
                 "{"+str(x), "\\over", str(int(norm))+"}",
-                "+", 
+                "+",
                 "{"+str(y), "\\over", str(int(norm))+"}",
                 "i"
             )
@@ -2307,7 +2307,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
                 run_time = 2,
                 path_arc = -np.pi/3
             )
-            for tex  in "a", "b", "c", "^2", "+", "="
+            for tex  in ("a", "b", "c", "^2", "+", "=")
         ] + [
             ReplacementTransform(
                 top_line.get_parts_by_tex("1"),
@@ -2320,7 +2320,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
                 run_time = 2,
                 rate_func = squish_rate_func(smooth, 0, 0.5)
             )
-            for tex in "(", ")", "over",
+            for tex in ("(", ")", "over",)
         ])
         self.wait(2)
         self.play(Write(circle_label))
@@ -2343,7 +2343,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
         self.wait(2)
         self.play(*[
             ApplyMethod(
-                mob.scale_about_point, 
+                mob.scale_about_point,
                 scale_factor,
                 self.plane_center
             )
@@ -2376,7 +2376,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
         distance_label.next_to(line.get_center(), UP+LEFT, SMALL_BUFF)
 
         self.play(ReplacementTransform(
-            rational_point_group, 
+            rational_point_group,
             integer_point_group
         ))
         self.play(Write(distance_label))
@@ -2387,7 +2387,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
     def get_unit_circle(self):
         template_line = Line(*[
             self.background_plane.number_to_point(z)
-            for z in -1, 1
+            for z in (-1, 1)
         ])
         circle = Circle(color = GREEN)
         circle.replace(template_line, dim_to_match = 0)
@@ -2415,7 +2415,7 @@ class ProjectPointsOntoUnitCircle(DrawRadialLines):
     def add_unit_circle(self):
         template_line = Line(*[
             self.background_plane.number_to_point(n)
-            for n in -1, 1
+            for n in (-1, 1)
         ])
         circle = Circle(color = BLUE)
         circle.replace(template_line, dim_to_match = 0)
@@ -2534,7 +2534,7 @@ class SupposeMissingPoint(PointsWeMiss):
         dot, line = self.dot, self.line
         template_line = Line(*[
             self.background_plane.number_to_point(n)
-            for n in -1, 1
+            for n in (-1, 1)
         ])
         circle = Circle(color = GREEN)
         circle.replace(template_line, dim_to_match = 0)
@@ -2746,7 +2746,7 @@ class FinalProof(RationalPointsOnUnitCircle):
         two_theta = TexMobject("2\\theta")
         two_theta.next_to(
             self.background_plane.coords_to_point(0, 1),
-            UP+RIGHT, SMALL_BUFF, 
+            UP+RIGHT, SMALL_BUFF,
         )
         two_theta_arrow = Arrow(
             two_theta.get_right(),
@@ -2759,7 +2759,7 @@ class FinalProof(RationalPointsOnUnitCircle):
         self.two_theta_group = VGroup(two_theta, two_theta_arrow)
 
         z_to_z_squared_arrow = Arrow(
-            point, square_point, 
+            point, square_point,
             path_arc = np.pi/3,
             color = WHITE
         )
@@ -2893,10 +2893,10 @@ class FinalProof(RationalPointsOnUnitCircle):
                 rhs.get_part_by_tex(tex),
                 run_time = 2
             )
-            for tex in "u", "v"
+            for tex in ("u", "v")
         ] + [
             Write(rhs.get_part_by_tex(tex))
-            for tex in "=", "over"
+            for tex in ("=", "over")
         ])
         self.wait(2)
         self.play(
@@ -2917,7 +2917,7 @@ class BitOfCircleGeometry(Scene):
         circle = Circle(color = BLUE, radius = 3)
         p0, p1, p2 = [
             circle.point_from_proportion(alpha)
-            for alpha in 0, 0.15, 0.55
+            for alpha in (0, 0.15, 0.55)
         ]
         O = circle.get_center()
         O_dot = Dot(O, color = WHITE)
@@ -2932,7 +2932,7 @@ class BitOfCircleGeometry(Scene):
             dot2 = Dot(p1)
             angle = line1.get_angle()
             arc = Arc(
-                angle = line2.get_angle()-line1.get_angle(), 
+                angle = line2.get_angle()-line1.get_angle(),
                 start_angle = line1.get_angle(),
                 radius = 0.75,
                 color = WHITE
@@ -3080,25 +3080,3 @@ class Poster(DrawRadialLines):
         # triples.arrange_submobjects(DOWN, buff = MED_LARGE_BUFF)
         # triples.next_to(rect.get_top(), DOWN)
         # self.add(rect, triples)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/uncertainty.py
+++ b/old_projects/uncertainty.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import scipy
 from big_ol_pile_of_manim_imports import *
 from old_projects.fourier import *
@@ -662,7 +663,7 @@ class ShowPlan(PiCreatureScene):
         )
         self.add(pulse)
         count = it.count() #TODO, this is not a great hack...
-        while not pulse.is_finished() and count.next() < 15:
+        while not pulse.is_finished() and next(count) < 15:
             self.play(
                 morty.look_at, pulse.mobject,
                 run_time = 0.5
@@ -1501,7 +1502,7 @@ class CenterOfMassDescription(FourierRecapScene):
                 angle = factor*angle,
                 radius = 0.5,
             )
-            for factor in 1, 2
+            for factor in (1, 2)
         ]
         theta = TexMobject("\\theta")
         theta.shift(1.5*arc.point_from_proportion(0.5))
@@ -2018,7 +2019,7 @@ class IntroduceDopplerRadar(Scene):
         )
         v_line_pair = VGroup(*[
             v_line.copy().shift(u*0.6*RIGHT)
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         v_line = VGroup(v_line)
 
@@ -2526,7 +2527,7 @@ class AmbiguityInLongEchos(IntroduceDopplerRadar, PiCreatureScene):
 
         noise_function = lambda t : np.sum([
             0.5*np.sin(f*t)/f 
-            for f in 2, 3, 5, 7, 11, 13
+            for f in (2, 3, 5, 7, 11, 13)
         ])
         noisy_graph = self.axes.get_graph(
             lambda t : sum_graph.underlying_function(t)*(1+noise_function(t)),
@@ -3337,7 +3338,7 @@ class AskPhysicists(PiCreatureScene):
 
         physies = VGroup(*[
             PiCreature(color = c).flip()
-            for c in GREY, LIGHT_GREY, DARK_GREY
+            for c in (GREY, LIGHT_GREY, DARK_GREY)
         ])
         physies.arrange_submobjects(RIGHT, buff = MED_SMALL_BUFF)
         physies.scale(scale_factor)
@@ -4183,7 +4184,7 @@ class ProbabalisticDetection(FourierTransformOfWaveFunction):
 
         v_lines = VGroup(*[
             DashedLine(ORIGIN, 3*UP).move_to(point, DOWN)
-            for point in rect.get_left(), rect.get_right()
+            for point in (rect.get_left(), rect.get_right())
         ])
         
         self.play(
@@ -4584,7 +4585,7 @@ class Promotion(PiCreatureScene):
             ),
             FadeOut(book),
         )
-        print self.num_plays
+        print(self.num_plays)
         self.play(
             FadeOut(words),
             ShowCreation(rect),
@@ -4766,7 +4767,7 @@ class Thumbnail(Scene):
         )
         graphs = VGroup(*[
             axes.get_graph(get_func(a))
-            for a in 10, 3, 1, 0.3, 0.1,
+            for a in (10, 3, 1, 0.3, 0.1,)
         ])
         graphs.arrange_submobjects(DOWN, buff = 0.6)
         graphs.to_corner(UP+LEFT)

--- a/old_projects/waves.py
+++ b/old_projects/waves.py
@@ -253,7 +253,7 @@ class PolarizingFilter(Circle):
             self.add(self.label)
 
         arrow = Arrow(
-            ORIGIN, self.arrow_length*UP, 
+            ORIGIN, self.arrow_length*UP,
             color = WHITE,
             buff = 0,
         )
@@ -378,7 +378,7 @@ class DirectionOfPolarizationScene(FilterScene):
         filters = sorted(
             self.pol_filters,
             lambda pf1, pf2 : cmp(
-                pf1.get_center()[0], 
+                pf1.get_center()[0],
                 pf2.get_center()[0],
             )
         )
@@ -427,7 +427,7 @@ class DirectionOfPolarizationScene(FilterScene):
 class WantToLearnQM(TeacherStudentsScene):
     def construct(self):
         question1 = TexMobject(
-            "\\text{What does }\\qquad \\\\", 
+            "\\text{What does }\\qquad \\\\",
             "|\\!\\psi \\rangle", "=",
             "\\frac{1}{\\sqrt{2}}", "|\\!\\uparrow \\rangle", "+",
             "\\frac{1}{\\sqrt{2}}", "|\\!\\downarrow \\rangle \\\\",
@@ -449,7 +449,7 @@ class WantToLearnQM(TeacherStudentsScene):
 
         for i, question in zip([1, 2, 0], questions):
             self.student_says(
-                question, 
+                question,
                 content_introduction_kwargs = {"run_time" : 2},
                 student_index = i,
                 bubble_kwargs = {"fill_opacity" : 1},
@@ -593,7 +593,7 @@ class IntroduceElectricField(PiCreatureScene):
         vector_field = self.get_vector_field()
         self.play(
             LaggedStart(
-                ShowCreation, vector_field, 
+                ShowCreation, vector_field,
                 run_time = 3
             ),
             self.title.center,
@@ -819,7 +819,7 @@ class IntroduceMagneticField(IntroduceElectricField, ThreeDScene):
         self.moving_particles = charges
         self.wait(5)
 
-        
+
     ###
 
     def continual_update(self, *args, **kwargs):
@@ -859,7 +859,7 @@ class CurlRelationBetweenFields(ThreeDScene):
         E_vects.shift(point)
 
         M_vect = Vector(
-            IN, 
+            IN,
             normal_vector = DOWN,
             color = M_COLOR
         )
@@ -936,12 +936,12 @@ class WriteCurlEquations(Scene):
     def construct(self):
         eq1 = TexMobject(
             "\\nabla \\times", "\\textbf{E}", "=",
-            "-\\frac{1}{c}", 
+            "-\\frac{1}{c}",
             "\\frac{\\partial \\textbf{B}}{\\partial t}"
         )
         eq2 = TexMobject(
             "\\nabla \\times", "\\textbf{B}", "=^*",
-            "\\frac{1}{c}", 
+            "\\frac{1}{c}",
             "\\frac{\\partial \\textbf{E}}{\\partial t}"
         )
         eqs = VGroup(eq1, eq2)
@@ -950,7 +950,7 @@ class WriteCurlEquations(Scene):
         eqs.to_edge(LEFT)
         for eq in eqs:
             eq.set_color_by_tex_to_color_map({
-                "E" : E_COLOR,            
+                "E" : E_COLOR,
                 "B" : M_COLOR,
             })
         footnote = TextMobject("*Ignoring currents")
@@ -1181,7 +1181,7 @@ class ShowVectorEquation(Scene):
         brackets.add_background_rectangle()
         group = VGroup(E_equals, brackets, components)
         group.next_to(
-            self.horizontally_polarized_words, 
+            self.horizontally_polarized_words,
             DOWN, MED_LARGE_BUFF, RIGHT
         )
 
@@ -1260,7 +1260,7 @@ class ShowVectorEquation(Scene):
                 x_max = 4/f,
                 num_steps = 20/f,
             )
-            for f in 1, 0.25,
+            for f in (1, 0.25,)
         ])
 
         group = VGroup(axes, t, cos, high_f_graph, *fx_group)
@@ -1415,7 +1415,7 @@ class ShowVectorEquation(Scene):
         )
         self.wait(4)
 
-        self.h_brace = h_brace 
+        self.h_brace = h_brace
         self.v_brace = v_brace
 
     def add_kets(self):
@@ -1433,7 +1433,7 @@ class ShowVectorEquation(Scene):
             ket.add_background_rectangle()
         plus = TextMobject("+")
         group = VGroup(
-            E_equals.target, 
+            E_equals.target,
             x.target, right_ket, plus,
             y.target, up_ket,
         )
@@ -1451,7 +1451,7 @@ class ShowVectorEquation(Scene):
         ])
         ket_rects = VGroup(*map(SurroundingRectangle, kets))
         ket_rects.set_color(WHITE)
-        unit_vectors = VGroup(*[Vector(2*vect) for vect in RIGHT, UP])
+        unit_vectors = VGroup(*[Vector(2*vect) for vect in (RIGHT, UP)])
         unit_vectors.set_fill(YELLOW)
 
         self.play(
@@ -1486,7 +1486,7 @@ class ShowVectorEquation(Scene):
             "A_y", "\\cos(", "2\\pi", "f_y", "t", "+", "\\phi_y", ")"
         )
         y.target.set_color_by_tex_to_color_map({
-            "A" : self.A_color,            
+            "A" : self.A_color,
             "f" : self.f_color,
             "phi" : self.phi_color,
         })
@@ -1522,7 +1522,7 @@ class ShowVectorEquation(Scene):
             self.h_brace.A.next_to, new_h_brace, RIGHT, SMALL_BUFF,
             Transform(self.horizontally_polarized_words, words),
             *map(FadeOut, [
-                self.corner_group, self.v_brace, 
+                self.corner_group, self.v_brace,
                 self.v_brace.A, self.low_f_graph,
             ])
         )
@@ -1548,7 +1548,7 @@ class ChangeFromHorizontalToVerticallyPolarized(DirectionOfPolarizationScene):
             vect.set_fill(opacity = 0.5)
         self.em_wave.E_vects[-1].set_fill(opacity = 1)
 
-        self.set_camera_position(0.9*np.pi/2, -0.05*np.pi)        
+        self.set_camera_position(0.9*np.pi/2, -0.05*np.pi)
 
     def construct(self):
         self.wait(3)
@@ -1640,11 +1640,11 @@ class ShowTipToTailSum(ShowVectorEquation):
                 "\\cos(", "2\\pi", "f", "t", ")",
                 "|\\!\\%sarrow\\rangle"%s
             )
-            for s in "right", "up"
+            for s in ("right", "up")
         ])
         for ket in kets:
             ket.set_color_by_tex_to_color_map({
-                "f" : self.f_color,    
+                "f" : self.f_color,
                 "rangle" : YELLOW,
             })
             ket.add_background_rectangle(opacity = 1)
@@ -1706,7 +1706,7 @@ class ShowTipToTailSum(ShowVectorEquation):
     def write_superposition(self):
         superposition_words = TextMobject(
             "``Superposition''", "of",
-            "$|\\!\\rightarrow\\rangle$", "and", 
+            "$|\\!\\rightarrow\\rangle$", "and",
             "$|\\!\\uparrow\\rangle$",
         )
         superposition_words.scale(0.8)
@@ -1772,12 +1772,12 @@ class ShowTipToTailSum(ShowVectorEquation):
                 UpdateFromAlphaFunc(
                     ov.vector,
                     self.generate_A_update(
-                        ov, 
-                        A*np.array(ov.A_vect), 
+                        ov,
+                        A*np.array(ov.A_vect),
                         np.array(ov.A_vect)
                     )
                 )
-                for ov, A in (h_ov, h_A), (v_ov, v_A)
+                for ov, A in ((h_ov, h_A), (v_ov, v_A))
             ]
         ))
         self.wait(4)
@@ -1815,8 +1815,8 @@ class ShowTipToTailSum(ShowVectorEquation):
             UpdateFromAlphaFunc(
                 v_ov.vector,
                 self.generate_phi_update(
-                    v_ov, 
-                    np.array([0, np.pi/2, 0]), 
+                    v_ov,
+                    np.array([0, np.pi/2, 0]),
                     np.array(v_ov.phi_vect)
                 )
             )
@@ -1827,8 +1827,8 @@ class ShowTipToTailSum(ShowVectorEquation):
             UpdateFromAlphaFunc(
                 h_ov.vector,
                 self.generate_A_update(
-                    h_ov, 
-                    0.25*np.array(h_ov.A_vect), 
+                    h_ov,
+                    0.25*np.array(h_ov.A_vect),
                     np.array(h_ov.A_vect),
                 )
             ),
@@ -1917,7 +1917,7 @@ class AlternateBasis(ShowTipToTailSum):
                 "(\\dots)",
                 "|\\!\\%sarrow\\rangle"%s2,
             )
-            for s1, s2 in ("right", "up"), ("ne", "nw")
+            for s1, s2 in (("right", "up"), ("ne", "nw"))
         ]
         for superposition in superpositions:
             superposition.set_color_by_tex("rangle", YELLOW)
@@ -2155,7 +2155,7 @@ class ShowPolarizingFilter(DirectionOfPolarizationScene):
                 decimal.align_data(new_decimal)
                 families = [
                     mob.family_members_with_points()
-                    for mob in decimal, new_decimal
+                    for mob in (decimal, new_decimal)
                 ]
                 for sm1, sm2 in zip(*families):
                     sm1.interpolate(sm1, sm2, 1)
@@ -2325,15 +2325,15 @@ class EnergyOfWavesTeacherPortion(TeacherStudentsScene):
 
         energy = TexMobject(
             "\\frac{\\text{Energy}}{\\text{Volume}}",
-            "=", 
+            "=",
             "\\epsilon_0", "A", "^2"
         )
         energy.set_color_by_tex("A", GREEN)
         energy.to_corner(UP+LEFT)
 
         component_energy = TexMobject(
-            "=", "\\epsilon_0", "A_x", "^2", 
-            "+", "\\epsilon_0", "A_y", "^2", 
+            "=", "\\epsilon_0", "A_x", "^2",
+            "+", "\\epsilon_0", "A_y", "^2",
         )
         for i in 2, 6:
             component_energy[i][0].set_color(GREEN)
@@ -2369,7 +2369,7 @@ class EnergyOfWavesTeacherPortion(TeacherStudentsScene):
         s1, s2 = self.get_students()[:2]
         b1, b2 = [
             ThoughtBubble(direction = v).scale(0.5)
-            for v in LEFT, RIGHT
+            for v in (LEFT, RIGHT)
         ]
         b1.pin_to(s1)
         b2.pin_to(s2)
@@ -2442,7 +2442,7 @@ class DescribePhoton(ThreeDScene):
 
     def add_ket_equation(self):
         equation = TexMobject(
-            "|\\!\\psi\\rangle", 
+            "|\\!\\psi\\rangle",
             "=",
             "\\alpha", "|\\!\\rightarrow \\rangle", "+",
             "\\beta", "|\\!\\uparrow \\rangle",
@@ -2506,7 +2506,7 @@ class DescribePhoton(ThreeDScene):
             ]
         )
         self.play(
-            Write(plane, run_time = 1), 
+            Write(plane, run_time = 1),
             Animation(self.equation)
         )
 
@@ -2515,11 +2515,11 @@ class DescribePhoton(ThreeDScene):
     def show_components(self):
         h_arrow, v_arrow = [
             Vector(
-                1.38*direction, 
+                1.38*direction,
                 color = color,
                 normal_vector = RIGHT,
             )
-            for color, direction in (self.x_color, UP), (self.y_color, OUT)
+            for color, direction in ((self.x_color, UP), (self.y_color, OUT))
         ]
         v_arrow.move_to(h_arrow.get_end(), IN)
         h_part = VGroup(*self.equation[1][2:4]).copy()
@@ -2551,7 +2551,7 @@ class DescribePhoton(ThreeDScene):
         alpha = self.h_part_tex[1]
         new_alpha = alpha.copy().shift(IN)
         rhs = TexMobject(
-            "=", "A_x", "e", 
+            "=", "A_x", "e",
             "^{i", "(2\\pi", "f", "t", "+", "\\phi_x)}"
         )
         A_rect = SurroundingRectangle(rhs.get_part_by_tex("A_x"), buff = 0.5*SMALL_BUFF)
@@ -2595,10 +2595,10 @@ class DescribePhoton(ThreeDScene):
         axes = self.axes
         movers = [
             plane, axes,
-            h_arrow, v_arrow, 
-            h_part, v_part, 
+            h_arrow, v_arrow,
+            h_part, v_part,
             self.equation,
-            superposition, 
+            superposition,
         ]
         for mob in movers:
             mob.save_state()
@@ -2672,7 +2672,7 @@ class DescribePhoton(ThreeDScene):
         )
         self.play(FadeIn(morty))
         self.play(Transform(
-            morty, blinked, 
+            morty, blinked,
             rate_func = squish_rate_func(there_and_back)
         ))
         self.wait()
@@ -2725,9 +2725,9 @@ class DescribePhoton(ThreeDScene):
 
     def describe_via_energy(self):
         energy = TexMobject(
-            "&\\text{Energy}", 
+            "&\\text{Energy}",
             "=", "(hf)", "(", "1", ")^2\\\\",
-            "&=", "(hf)", "\\left(", "\\sqrt{1/2}", "\\right)^2", 
+            "&=", "(hf)", "\\left(", "\\sqrt{1/2}", "\\right)^2",
             "+", "(hf)", "\\left(", "\\sqrt{1/2}", "\\right)^2",
         )
         energy.scale(0.8)
@@ -2739,7 +2739,7 @@ class DescribePhoton(ThreeDScene):
         indices = [0, 3, 6, len(energy)]
         parts = VGroup(*[
             VGroup(*energy[i1:i2])
-            for i1, i2 in zip(indices, indices[1:])    
+            for i1, i2 in zip(indices, indices[1:])
         ])
         for part in parts:
             bg_rect = BackgroundRectangle(part)
@@ -2852,7 +2852,7 @@ class DescribePhoton(ThreeDScene):
         self.play(*map(FadeOut, everything))
         self.move_camera(
             phi = 0.8*np.pi/2,
-            theta = -0.3*np.pi, 
+            theta = -0.3*np.pi,
             run_time = 2
         )
         self.play(
@@ -2923,7 +2923,7 @@ class ShootPhotonThroughFilter(DirectionOfPolarizationScene):
 
     def add_superposition_tex(self):
         superposition_tex = TexMobject(
-            "|\\!\\nearrow\\rangle", 
+            "|\\!\\nearrow\\rangle",
             "=",
             "(\\sqrt{1/2})", "|\\!\\rightarrow \\rangle", "+",
             "(\\sqrt{1/2})", "|\\!\\uparrow \\rangle",
@@ -3002,13 +3002,13 @@ class ShootPhotonThroughFilter(DirectionOfPolarizationScene):
         lines.rotate(np.pi/2, OUT)
 
         self.move_camera(
-            phi = np.pi/2, theta = 0, 
+            phi = np.pi/2, theta = 0,
             added_anims = [
                 Rotate(self.superposition_tex, np.pi/2),
             ] + [
                 ApplyMethod(
-                    v.rotate_in_place, 
-                    -np.pi/2, 
+                    v.rotate_in_place,
+                    -np.pi/2,
                     method_kwargs = {"axis" : v.get_vector()}
                 )
                 for v in self.frozen_photon.mobject
@@ -3019,7 +3019,7 @@ class ShootPhotonThroughFilter(DirectionOfPolarizationScene):
             self.superposition_tex.h_rect.set_stroke, RED, 3,
             *map(GrowFromCenter, lines)+\
             [
-                Animation(self.pol_filter), 
+                Animation(self.pol_filter),
                 Animation(self.frozen_photon.mobject)
             ]
         )
@@ -3032,15 +3032,15 @@ class ShootPhotonThroughFilter(DirectionOfPolarizationScene):
                 Rotate(self.superposition_tex, -np.pi/2),
             ] + [
                 ApplyMethod(
-                    v.rotate_in_place, 
-                    np.pi/2, 
+                    v.rotate_in_place,
+                    np.pi/2,
                     method_kwargs = {"axis" : v.get_vector()}
                 )
                 for v in self.frozen_photon.mobject
             ]
         )
         self.play(
-            FadeOut(lines), 
+            FadeOut(lines),
             FadeOut(self.question),
             self.superposition_tex.h_rect.fade, 1,
             Animation(self.pol_filter)
@@ -3076,7 +3076,7 @@ class ShootPhotonThroughFilter(DirectionOfPolarizationScene):
                 self.play(self.get_photon(), run_time = 1)
             else:
                 self.play(
-                    self.get_blocked_photon(), 
+                    self.get_blocked_photon(),
                     Animation(self.axes),
                     absorption,
                     run_time = 1
@@ -3220,12 +3220,12 @@ class ThreeFilters(ShootPhotonThroughFilter):
             ShowCreation(l3, **kwargs),
             Animation(VGroup(pf2, l2, pf1, l1)),
             FadeIn(label),
-            run_time = 0.5, 
+            run_time = 0.5,
         )
         self.wait(2)
         self.play(
             FadeOut(l3),
-            Animation(pf2), 
+            Animation(pf2),
             FadeOut(l2),
             Animation(pf1),
             FadeOut(l1)
@@ -3241,7 +3241,7 @@ class ThreeFilters(ShootPhotonThroughFilter):
         )
         brace = Brace(Line(1.5*LEFT, 1.5*RIGHT), DOWN)
         label = brace.get_text(
-            "Changed to", 
+            "Changed to",
             "$|\\!\\nearrow\\rangle$"
         )
         label.set_color_by_tex("rangle", BLUE)
@@ -3265,7 +3265,7 @@ class ThreeFilters(ShootPhotonThroughFilter):
                 Animation(VGroup(*self.pol_filters[:2]))
             ] + [
                 Rotate(
-                    v, np.pi/2, 
+                    v, np.pi/2,
                     axis = v.get_vector(),
                     in_place = True,
                     **kwargs
@@ -3274,7 +3274,7 @@ class ThreeFilters(ShootPhotonThroughFilter):
             ] + [
                 Animation(self.pol_filters[2]),
                 Rotate(
-                    label, np.pi/2, 
+                    label, np.pi/2,
                     axis = OUT,
                     in_place = True,
                     **kwargs
@@ -3329,7 +3329,7 @@ class ThreeFilters(ShootPhotonThroughFilter):
         pf1, pf2, pf3 = self.pol_filters
         mid_lines = self.A_to_C_lines
         mover = VGroup(
-            pf2, 
+            pf2,
             self.fifty_percent_arrow_group,
             self.second_fifty_percent_arrow_group,
         )
@@ -3388,7 +3388,7 @@ class ThreeFilters(ShootPhotonThroughFilter):
         n = self.n_lines
         start, end = [
             (f.point_from_proportion(0.75) if f is not None else None)
-            for f in filter1, filter2
+            for f in (filter1, filter2)
         ]
         if start is None:
             start = end + self.line_start_length*LEFT
@@ -3511,8 +3511,8 @@ class PhotonAtSlightAngle(ThreeFilters):
         v_label.next_to(v_arrow, RIGHT, SMALL_BUFF)
 
         state = TexMobject(
-            "|\\!\\psi\\rangle", 
-            "=", "\\sin(22.5^\\circ)", "|\\!\\rightarrow\\rangle", 
+            "|\\!\\psi\\rangle",
+            "=", "\\sin(22.5^\\circ)", "|\\!\\rightarrow\\rangle",
             "+", "\\cos(22.5^\\circ)", "|\\!\\uparrow\\rangle",
         )
         state.set_color_by_tex_to_color_map({
@@ -3529,7 +3529,7 @@ class PhotonAtSlightAngle(ThreeFilters):
         cos_brace.label = cos_brace.get_tex("%.2f"%np.cos(np.pi/8), buff = SMALL_BUFF)
 
         group = VGroup(
-            d_brace, d_brace.label, 
+            d_brace, d_brace.label,
             h_arrow, h_label,
             v_arrow, v_label,
             state,
@@ -3551,11 +3551,11 @@ class PhotonAtSlightAngle(ThreeFilters):
         self.play(
             Write(VGroup(*state[:2])),
             ReplacementTransform(
-                h_label.copy(), 
+                h_label.copy(),
                 state.get_part_by_tex("sin")
             ),
             ReplacementTransform(
-                h_arrow.copy(), 
+                h_arrow.copy(),
                 state.get_part_by_tex("rightarrow")
             ),
             Write(state.get_part_by_tex("+"))
@@ -3571,11 +3571,11 @@ class PhotonAtSlightAngle(ThreeFilters):
         )
         self.play(
             ReplacementTransform(
-                v_label.copy(), 
+                v_label.copy(),
                 state.get_part_by_tex("cos")
             ),
             ReplacementTransform(
-                v_arrow.copy(), 
+                v_arrow.copy(),
                 state.get_part_by_tex("uparrow")
             ),
         )
@@ -3708,7 +3708,7 @@ class PhotonAtSlightAngle(ThreeFilters):
                 Rotate(self.classically, np.pi/2, IN),
             ] + [
                 Rotate(
-                    v, np.pi/2, 
+                    v, np.pi/2,
                     axis = v.get_vector(),
                     in_place = True,
                 )
@@ -3764,7 +3764,7 @@ class PhotonAtSlightAngle(ThreeFilters):
         #     if photon.get_filtered:
         #         added_anims.append(
         #             self.get_filter_absorption_animation(
-        #                 self.pol_filter, photon, 
+        #                 self.pol_filter, photon,
         #             )
         #         )
         #     self.play(photon, *added_anims)
@@ -3777,7 +3777,7 @@ class PhotonAtSlightAngle(ThreeFilters):
                 line.set_stroke(width = 3)
 
         arrow = Arrow(
-            2*LEFT, 2*RIGHT, 
+            2*LEFT, 2*RIGHT,
             path_arc = 0.8*np.pi,
             use_rectangular_stem = False,
         )
@@ -3824,7 +3824,7 @@ class PhotonAtSlightAngle(ThreeFilters):
 
     def get_blocked_photon(self, **kwargs):
         return self.get_photon(
-            filter_distance = FRAME_X_RADIUS + 3, 
+            filter_distance = FRAME_X_RADIUS + 3,
             get_filtered = True,
             **kwargs
         )
@@ -3883,7 +3883,7 @@ class CompareWaveEquations(TeacherStudentsScene):
     def show_complex_plane(self):
         new_alpha, new_beta = terms = [
             self.equation.get_part_by_tex(tex).copy()
-            for tex in "alpha", "beta"
+            for tex in ("alpha", "beta")
         ]
         for term in terms:
             term.save_state()
@@ -3901,11 +3901,11 @@ class CompareWaveEquations(TeacherStudentsScene):
 
         alpha_dot, beta_dot = [
             Dot(
-                plane.coords_to_point(x, 0.5), 
+                plane.coords_to_point(x, 0.5),
                 radius = 0.05,
                 color = color
             )
-            for x, color in (-0.5, RED), (0.5, GREEN)
+            for x, color in ((-0.5, RED), (0.5, GREEN))
         ]
         new_alpha.target.next_to(alpha_dot, UP+LEFT, 0.5*SMALL_BUFF)
         new_alpha.target.set_color(RED)
@@ -3913,7 +3913,7 @@ class CompareWaveEquations(TeacherStudentsScene):
         new_beta.target.set_color(GREEN)
 
         rhs = TexMobject(
-            "=", "A_y", "e", "^{i(", 
+            "=", "A_y", "e", "^{i(",
             "2\\pi", "f", "t", "+", "\\phi_y", ")}"
         )
         rhs.scale(0.7)
@@ -3952,7 +3952,7 @@ class CompareWaveEquations(TeacherStudentsScene):
             phi_copy.shift, 0.5*SMALL_BUFF*UP
         )
         self.play(
-            A_copy.next_to, A_line.get_center(), 
+            A_copy.next_to, A_line.get_center(),
                 UP, SMALL_BUFF,
             A_copy.shift, 0.5*SMALL_BUFF*(UP+LEFT),
         )
@@ -3963,14 +3963,14 @@ class CompareWaveEquations(TeacherStudentsScene):
             "\\text{Classically: }", "&|\\beta|^2",
             "\\rightarrow",
             "\\text{Component of} \\\\",
-            "&\\text{energy in }", "|\\!\\uparrow\\rangle", 
+            "&\\text{energy in }", "|\\!\\uparrow\\rangle",
             "\\text{ direction}",
         )
         qm_words = TexMobject(
             "\\text{Quantum: }", "&|\\beta|^2",
             "\\rightarrow",
             "\\text{Probability that}", "\\text{ \\emph{all}} \\\\",
-            "&\\text{energy is measured in }", "|\\!\\uparrow\\rangle", 
+            "&\\text{energy is measured in }", "|\\!\\uparrow\\rangle",
             "\\text{ direction}",
         )
         for words in c_words, qm_words:
@@ -4045,7 +4045,7 @@ class CircularPhotons(ShootPhotonThroughFilter):
 
     def show_phase_difference(self):
         equation = TexMobject(
-            "|\\!\\circlearrowright\\rangle", 
+            "|\\!\\circlearrowright\\rangle",
             "=", "\\frac{1}{\\sqrt{2}}", "|\\!\\rightarrow\\rangle",
             "+", "\\frac{i}{\\sqrt{2}}", "|\\!\\uparrow\\rangle",
         )
@@ -4093,7 +4093,7 @@ class CircularPhotons(ShootPhotonThroughFilter):
 
     def show_vertically_polarized_light(self):
         equation = TexMobject(
-            "|\\!\\uparrow \\rangle", 
+            "|\\!\\uparrow \\rangle",
             "=", "\\frac{i}{\\sqrt{2}}", "|\\!\\circlearrowleft \\rangle",
             "+", "\\frac{-i}{\\sqrt{2}}", "|\\!\\circlearrowright \\rangle",
         )
@@ -4125,7 +4125,7 @@ class CircularPhotons(ShootPhotonThroughFilter):
             length = 20,
         )
         v_photon = WavePacket(
-            em_wave = em_wave, 
+            em_wave = em_wave,
             include_M_vects = False,
             run_time = 2
         )
@@ -4262,11 +4262,11 @@ class Footnote(Scene):
             \\begin{flushleft}
             \\Large
             By the way, in the quantum mechanical description
-            of polarization, states are written like 
+            of polarization, states are written like
             $|\\! \\leftrightarrow \\rangle$ with a double-headed
             arrow, rather than $|\\! \\rightarrow \\rangle$ with
             a single-headed arrow.  This conveys how there's no distinction
-            between left and right; they each have the same measurable 
+            between left and right; they each have the same measurable
             state: horizontal. \\\\
             \\quad \\\\
             Because of how I chose to motivate things with classical waves,
@@ -4277,14 +4277,3 @@ class Footnote(Scene):
         """)
         words.scale_to_fit_width(FRAME_WIDTH - 2)
         self.add(words)
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/wcat.py
+++ b/old_projects/wcat.py
@@ -78,7 +78,7 @@ class ClosedLoopScene(Scene):
     def add_dots_at_alphas(self, *alphas):
         self.add_dots(*[
             Dot(
-                self.loop.point_from_proportion(alpha), 
+                self.loop.point_from_proportion(alpha),
                 color = self.dot_color
             )
             for alpha in alphas
@@ -92,7 +92,7 @@ class ClosedLoopScene(Scene):
             pairs = zip(self.dots[:n_pairs], self.dots[n_pairs:])
         for d1, d2 in pairs:
             line = Line(d1.get_center(), d2.get_center())
-            line.start_dot = d1 
+            line.start_dot = d1
             line.end_dot = d2
             line.update_anim = UpdateFromFunc(
                 line,
@@ -226,7 +226,7 @@ class Introduction(TeacherStudentsScene):
         self.teacher_says("")
         for pi in self.get_students():
             pi.generate_target()
-            pi.target.change_mode("happy")            
+            pi.target.change_mode("happy")
             pi.target.look_at(self.get_teacher().bubble)
         self.play(*map(MoveToTarget, self.get_students()))
         self.random_blink(3)
@@ -254,7 +254,7 @@ class WhenIWasAKid(TeacherStudentsScene):
     def state_excitement(self, children, speaker):
         self.teacher_says(
             """
-            Here's why 
+            Here's why
             I'm excited!
             """,
             target_mode = "hooray"
@@ -310,7 +310,7 @@ class WhenIWasAKid(TeacherStudentsScene):
         )
         self.play(Write(title))
         self.random_blink()
-        
+
         self.play(pi1.change_mode, "raise_right_hand")
         self.random_blink()
         self.play(
@@ -331,7 +331,7 @@ class WhenIWasAKid(TeacherStudentsScene):
             "How is this math?",
             student_index = -1,
             target_mode = "pleading",
-            width = 5, 
+            width = 5,
             height = 3,
             direction = RIGHT
         )
@@ -423,8 +423,8 @@ class DefineInscribedSquareProblem(ClosedLoopScene):
         self.play(Write(self.title))
         self.wait()
         self.play(ShowCreation(
-            self.loop, 
-            run_time = 5, 
+            self.loop,
+            run_time = 5,
             rate_func = None
         ))
         self.wait()
@@ -485,9 +485,9 @@ class DefineInscribedSquareProblem(ClosedLoopScene):
         self.let_dots_wonder()
         randy_anims = [
             FadeIn(randy),
-            Animation(randy),            
+            Animation(randy),
             Blink(randy),
-            Animation(randy),         
+            Animation(randy),
             Blink(randy),
             Animation(randy),
             Blink(randy, rate_func = smooth)
@@ -526,7 +526,7 @@ class DefineInscribedSquareProblem(ClosedLoopScene):
 
         dot_pairs = [
             VGroup(self.dots[i], self.dots[j])
-            for i, j in (0, 2), (1, 3)
+            for i, j in ((0, 2), (1, 3))
         ]
         pair_colors = MAROON_B, PURPLE_B
         diag_lines = [
@@ -549,7 +549,7 @@ class RectangleProperties(Scene):
         ])
         dot_pairs = [
             VGroup(vertex_dots[i], vertex_dots[j])
-            for i, j in (0, 2), (1, 3)
+            for i, j in ((0, 2), (1, 3))
         ]
         colors = [MAROON_B, PURPLE_B]
         diag_lines = [
@@ -611,11 +611,11 @@ class PairOfPairBecomeRectangle(Scene):
             labels.add(label)
         lines = [
             Line(
-                dots[i].get_center(), 
-                dots[j].get_center(), 
+                dots[i].get_center(),
+                dots[j].get_center(),
                 color = dots[i].get_color()
             )
-            for i, j in (0, 1), (2, 3)
+            for i, j in ((0, 1), (2, 3))
         ]
         groups = [
             VGroup(dots[0], dots[1], labels[0], labels[1], lines[0]),
@@ -641,7 +641,7 @@ class PairOfPairBecomeRectangle(Scene):
         self.wait()
         self.play(*[
             ApplyMethod(
-                group.shift, 
+                group.shift,
                 -group[-1].get_center()+midpoint.get_center()
             )
             for group in groups
@@ -650,7 +650,7 @@ class PairOfPairBecomeRectangle(Scene):
             ShowCreation(midpoint),
             Write(words[0])
         )
-        factor = lines[0].get_length()/lines[1].get_length()        
+        factor = lines[0].get_length()/lines[1].get_length()
         grower = groups[1].copy()
         new_line = grower[-1]
         new_line.scale_in_place(factor)
@@ -665,7 +665,7 @@ class PairOfPairBecomeRectangle(Scene):
 
         rectangle = Polygon(*[
             dots[i].get_center()
-            for i in 0, 2, 1, 3
+            for i in (0, 2, 1, 3)
         ])
         rectangle.set_color(BLUE)
         self.play(
@@ -707,7 +707,7 @@ class SearchForRectangleOnLoop(ClosedLoopScene):
         self.wait()
         self.add_connecting_lines(cyclic = True)
         self.play(
-            ShowCreation(self.connecting_lines), 
+            ShowCreation(self.connecting_lines),
             Animation(self.dots)
         )
         self.wait()
@@ -715,7 +715,7 @@ class SearchForRectangleOnLoop(ClosedLoopScene):
 class DeclareFunction(ClosedLoopScene):
     def construct(self):
         self.add_dots_at_alphas(0.2, 0.8)
-        self.set_color_dots_by_pair()        
+        self.set_color_dots_by_pair()
         self.add_connecting_lines()
         VGroup(
             self.loop, self.dots, self.connecting_lines
@@ -788,7 +788,7 @@ class InputPairToFunction(Scene):
 
 class WigglePairUnderSurface(Scene):
     def construct(self):
-        pass        
+        pass
 
 class WriteContinuous(Scene):
     def construct(self):
@@ -845,7 +845,7 @@ class PairOfRealsToPlane(Scene):
         self.play(ShowCreation(two_d_point))
         everything = VGroup(*self.get_mobjects())
         self.play(
-            FadeIn(plane), 
+            FadeIn(plane),
             Animation(everything),
             Animation(dot2)
         )
@@ -855,7 +855,7 @@ class SeekSurfaceForPairs(ClosedLoopScene):
     def construct(self):
         self.loop.to_edge(LEFT)
         self.add_dots_at_alphas(0.2, 0.3)
-        self.set_color_dots_by_pair()        
+        self.set_color_dots_by_pair()
         self.add_connecting_lines()
 
         arrow = Arrow(LEFT, RIGHT).next_to(self.loop)
@@ -882,7 +882,7 @@ class AskAbouPairType(TeacherStudentsScene):
         """)
         self.play(*[
             ApplyMethod(self.get_students()[i].change_mode, "confused")
-            for i in 0, 2
+            for i in (0, 2)
         ])
         self.random_blink(3)
 
@@ -891,8 +891,8 @@ class DefineOrderedPair(ClosedLoopScene):
         title = TextMobject("Ordered pairs")
         title.to_edge(UP)
         subtitle = TexMobject(
-            "(", "a", ",", "b", ")", 
-            "\\ne", 
+            "(", "a", ",", "b", ")",
+            "\\ne",
             "(", "b", ",", "a", ")"
         )
         labels_start = VGroup(subtitle[1], subtitle[3])
@@ -950,7 +950,7 @@ class DefineUnorderedPair(ClosedLoopScene):
         dots = self.dots
         dots.set_color(PURPLE_B)
 
-        labels = VGroup(*[subtitle[i].copy() for i in 0, 2])
+        labels = VGroup(*[subtitle[i].copy() for i in (0, 2)])
         for label, vect in zip(labels, [LEFT, RIGHT]):
             label.next_to(dots, vect, LARGE_BUFF)
         arrows = [
@@ -1028,7 +1028,7 @@ class DeformToInterval(ClosedLoopScene):
         self.add(dots_copy)
         self.wait()
         self.transform_loop(
-            line, 
+            line,
             added_anims = [MoveToTarget(dot_at_1)],
             run_time = 3
         )
@@ -1046,7 +1046,7 @@ class DeformToInterval(ClosedLoopScene):
         fading_dots.target.set_fill(opacity = 0.3)
         self.play(MoveToTarget(fading_dots))
         self.play(
-            end_dots.shift, 0.2*UP, 
+            end_dots.shift, 0.2*UP,
             rate_func = wiggle
         )
         self.wait()
@@ -1098,7 +1098,7 @@ class RepresentPairInUnitSquare(ClosedLoopScene):
         self.wait()
         self.play(*[
             Rotate(mob, np.pi/2, about_point = interval.get_left())
-            for mob in vert_interval, self.dots[1]
+            for mob in (vert_interval, self.dots[1])
         ])
 
         #Find interior point
@@ -1124,8 +1124,8 @@ class RepresentPairInUnitSquare(ClosedLoopScene):
         for mob in movers:
             mob.generate_target()
         shift_vals = [
-            RIGHT+DOWN, 
-            LEFT+DOWN, 
+            RIGHT+DOWN,
+            LEFT+DOWN,
             LEFT+2*UP,
             3*DOWN,
             2*RIGHT+UP,
@@ -1138,7 +1138,7 @@ class RepresentPairInUnitSquare(ClosedLoopScene):
             self.dots[1].target.shift(shift_val[1]*UP)
             for line, dot in zip(dashed_lines, self.dots):
                 line.target.put_start_and_end_on(
-                    dot.target.get_center(), 
+                    dot.target.get_center(),
                     inner_dot.target.get_center()
                 )
             self.play(*map(MoveToTarget, movers))
@@ -1205,7 +1205,7 @@ class EdgesOfSquare(Scene):
                 square.get_corner(vect+LEFT),
                 square.get_corner(vect+RIGHT),
             )
-            for vect in DOWN, UP
+            for vect in (DOWN, UP)
         ])
         y_edges.set_color(BLUE)
         x_edges = VGroup(*[
@@ -1213,7 +1213,7 @@ class EdgesOfSquare(Scene):
                 square.get_corner(vect+DOWN),
                 square.get_corner(vect+UP),
             )
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         x_edges.set_color(MAROON_B)
         return x_edges, y_edges
@@ -1229,7 +1229,7 @@ class EdgesOfSquare(Scene):
                 ))
                 for alpha in alpha_range
             ])
-            for vect in LEFT, RIGHT            
+            for vect in (LEFT, RIGHT)
         ]
         for group in dot_groups:
             group.set_color_by_gradient(YELLOW, PURPLE_B)
@@ -1238,7 +1238,7 @@ class EdgesOfSquare(Scene):
                 TexMobject("(%s, %s)"%(a, b)).scale(0.7)
                 for b in alpha_range
             ])
-            for a in 0, 1
+            for a in (0, 1)
         ]
         for dot_group, label_group in zip(dot_groups, label_groups):
             for dot, label in zip(dot_group, label_group):
@@ -1261,7 +1261,7 @@ class EdgesOfSquare(Scene):
                 ])
                 for edge in edges
             ]).set_color(edges.get_color())
-            for edges in x_edges, y_edges
+            for edges in (x_edges, y_edges)
         ]
 
 class EndpointsGluedTogether(ClosedLoopScene):
@@ -1281,7 +1281,7 @@ class EndpointsGluedTogether(ClosedLoopScene):
         self.loop = line
         dots = VGroup(*[
             Dot(line.get_critical_point(vect))
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         dots.set_color(BLUE)
 
@@ -1307,7 +1307,7 @@ class TorusPlaneAnalogy(ClosedLoopScene):
         top_arrow = DoubleArrow(LEFT, RIGHT)
         top_arrow.to_edge(UP, buff = 2*LARGE_BUFF)
         single_pointed_top_arrow = Arrow(LEFT, RIGHT)
-        single_pointed_top_arrow.to_edge(UP, buff = 2*LARGE_BUFF)        
+        single_pointed_top_arrow.to_edge(UP, buff = 2*LARGE_BUFF)
         low_arrow = DoubleArrow(LEFT, RIGHT).shift(2*DOWN)
         self.loop.scale(0.5)
         self.loop.next_to(top_arrow, RIGHT)
@@ -1351,7 +1351,7 @@ class WigglingPairOfPoints(ClosedLoopScene):
 
 class WigglingTorusPoint(Scene):
         def construct(self):
-            pass    
+            pass
 
 class WhatAboutUnordered(TeacherStudentsScene):
     def construct(self):
@@ -1429,7 +1429,7 @@ class NotHelpful(Scene):
         self.wait()
 
 class FoldUnitSquare(EdgesOfSquare):
-    def construct(self):    
+    def construct(self):
         self.add_triangles()
         self.add_arrows()
         self.show_points_to_glue()
@@ -1443,13 +1443,13 @@ class FoldUnitSquare(EdgesOfSquare):
         triangles = VGroup(*[
             Polygon(*[square.get_corner(vect) for vect in vects])
             for vects in [
-                (DOWN+LEFT, UP+RIGHT, UP+LEFT),            
+                (DOWN+LEFT, UP+RIGHT, UP+LEFT),
                 (DOWN+LEFT, UP+RIGHT, DOWN+RIGHT),
             ]
         ])
         triangles.set_stroke(width = 0)
         triangles.set_fill(
-            color = square.get_color(), 
+            color = square.get_color(),
             opacity = square.get_fill_opacity()
         )
         self.remove(square)
@@ -1461,7 +1461,7 @@ class FoldUnitSquare(EdgesOfSquare):
         start_arrows = VGroup()
         end_arrows = VGroup()
         colors = MAROON_B, BLUE
-        for a in 0, 1:        
+        for a in 0, 1:
             for color in colors:
                 b_range = np.linspace(0, 1, 4)
                 for b1, b2 in zip(b_range, b_range[1:]):
@@ -1473,7 +1473,7 @@ class FoldUnitSquare(EdgesOfSquare):
                     )
                     if color is BLUE:
                         arrow.rotate(
-                            -np.pi/2, 
+                            -np.pi/2,
                             about_point = self.square.get_center()
                         )
                     if (a is 0):
@@ -1640,7 +1640,7 @@ class FoldUnitSquare(EdgesOfSquare):
     def get_point_from_coords(self, x, y):
         left, right, bottom, top = [
             self.triangles.get_edge_center(vect)
-            for vect in LEFT, RIGHT, DOWN, UP
+            for vect in (LEFT, RIGHT, DOWN, UP)
         ]
         x_point = interpolate(left, right, x)
         y_point = interpolate(bottom, top, y)
@@ -1661,7 +1661,7 @@ class PrepareForMobiusStrip(Scene):
             ),
             Polygon(
                 DOWN+RIGHT,
-                UP+RIGHT,          
+                UP+RIGHT,
                 ORIGIN,
             ),
         )
@@ -1686,7 +1686,7 @@ class PrepareForMobiusStrip(Scene):
             tri.add(arrows)
             i, j, k = (0, 2, 1) if tri is triangles[0] else (1, 2, 0)
             dashed_line = DashedLine(
-                anchors[i], anchors[j], 
+                anchors[i], anchors[j],
                 color = RED
             )
             tri.add(dashed_line)
@@ -1844,7 +1844,7 @@ class StripMustIntersectItself(TeacherStudentsScene):
     def construct(self):
         self.teacher_says(
             """
-            The strip must 
+            The strip must
             intersect itself
             during this process
             """,
@@ -1880,10 +1880,10 @@ class ThatsTheProof(TeacherStudentsScene):
         self.teacher_says(
             """
             If you trust
-            the mobius strip 
+            the mobius strip
             fact...
             """,
-            target_mode = "guilty",            
+            target_mode = "guilty",
             width = 4,
         )
         self.random_blink()
@@ -1900,7 +1900,7 @@ class TryItYourself(TeacherStudentsScene):
 
         pi = self.get_students()[1]
         bubble = pi.get_bubble(
-            "thought", 
+            "thought",
             width = 4, height = 4,
             direction = RIGHT
         )
@@ -1947,10 +1947,10 @@ class PatreonThanks(Scene):
         special_thanks.set_color(YELLOW)
         special_thanks.shift(2*UP)
 
-        left_patrons = VGroup(*map(TextMobject, 
+        left_patrons = VGroup(*map(TextMobject,
             self.specific_patrons[:n_patrons/2]
         ))
-        right_patrons = VGroup(*map(TextMobject, 
+        right_patrons = VGroup(*map(TextMobject,
             self.specific_patrons[n_patrons/2:]
         ))
         for patrons, vect in (left_patrons, LEFT), (right_patrons, RIGHT):
@@ -1983,7 +1983,7 @@ class CreditTWo(Scene):
         brother = PiCreature(color = GOLD_E)
         brother.next_to(morty, LEFT)
         brother.look_at(morty.eyes)
-        
+
         headphones = Headphones(height = 1)
         headphones.move_to(morty.eyes, aligned_edge = DOWN)
         headphones.shift(0.1*DOWN)
@@ -1994,7 +1994,7 @@ class CreditTWo(Scene):
         self.add(morty)
         self.play(Blink(morty))
         self.play(
-            FadeIn(headphones), 
+            FadeIn(headphones),
             Write(url),
             Animation(morty)
         )
@@ -2107,12 +2107,3 @@ class ThumbnailImage(ClosedLoopScene):
         self.add(title)
         self.loop.next_to(title, DOWN, buff = MED_SMALL_BUFF)
         self.loop.shift(2*LEFT)
-
-
-
-
-
-
-
-
-

--- a/old_projects/zeta.py
+++ b/old_projects/zeta.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 import mpmath
@@ -1800,7 +1801,7 @@ class ShowZetaOnHalfPlane(ZetaTransformationScene):
 
         line = Line(*map(self.z_to_point, [
             complex(np.euler_gamma, u*FRAME_Y_RADIUS)
-            for u in 1, -1
+            for u in (1, -1)
         ]))
         line.set_color(YELLOW)
         arrows = [
@@ -1826,9 +1827,9 @@ class ShowZetaOnHalfPlane(ZetaTransformationScene):
                     vert_vect+RIGHT,
                     vert_vect+(FRAME_X_RADIUS+1)*horiz_vect
                 )
-                for vert_vect in UP, DOWN
+                for vert_vect in (UP, DOWN)
             ])
-            for horiz_vect in RIGHT, LEFT
+            for horiz_vect in (RIGHT, LEFT)
         ]
         right_i_lines.set_color(YELLOW)
         left_i_lines.set_color(BLUE)
@@ -1913,7 +1914,7 @@ class ShowConditionalDefinition(Scene):
         something_else = TextMobject("Something else...")
         conditions = VGroup(*[
             TextMobject("if Re$(s) %s 1$"%s)
-            for s in ">", "\\le"
+            for s in (">", "\\le")
         ])
         definitions = VGroup(sigma, something_else)
         definitions.arrange_submobjects(DOWN, buff = MED_LARGE_BUFF, aligned_edge = LEFT)

--- a/scene/scene.py
+++ b/scene/scene.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 from PIL import Image
 from colour import Color
 import numpy as np
@@ -15,7 +17,7 @@ import random
 from constants import *
 
 from camera.camera import Camera
-from tk_scene import TkSceneRoot
+from .tk_scene import TkSceneRoot
 from mobject.mobject import Mobject
 from mobject.vectorized_mobject import VMobject
 from animation.animation import Animation
@@ -390,8 +392,8 @@ class Scene(Container):
         def compile_method(state):
             if state["curr_method"] is None:
                 return
-            mobject = state["curr_method"].im_self
-            if state["last_method"] and state["last_method"].im_self is mobject:
+            mobject = state["curr_method"].__self__
+            if state["last_method"] and state["last_method"].__self__ is mobject:
                 animations.pop()
                 #method should already have target then.
             else:
@@ -401,7 +403,7 @@ class Scene(Container):
                 method_kwargs = state["method_args"].pop()
             else:
                 method_kwargs = {}
-            state["curr_method"].im_func(
+            state["curr_method"].__func__(
                 mobject.target, 
                 *state["method_args"],
                 **method_kwargs

--- a/scene/scene_from_video.py
+++ b/scene/scene_from_video.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import cv2
 import itertools as it

--- a/stage_scenes.py
+++ b/stage_scenes.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 import sys
 import inspect
 import os
 import shutil
 import itertools as it
-from extract_scene import is_scene, get_module
-from constants import ANIMATIONS_DIR, STAGED_SCENES_DIR
+from .extract_scene import is_scene, get_module
+from .constants import ANIMATIONS_DIR, STAGED_SCENES_DIR
 
 
 def get_sorted_scene_names(module_name):

--- a/topics/characters.py
+++ b/topics/characters.py
@@ -214,7 +214,7 @@ class PiCreature(SVGMobject):
         body = self.body
         return VGroup(*[
             body.copy().pointwise_become_partial(body, *alpha_range)
-            for alpha_range in self.right_arm_range, self.left_arm_range
+            for alpha_range in (self.right_arm_range, self.left_arm_range)
         ])
             
 def get_all_pi_creature_modes():

--- a/topics/complex_numbers.py
+++ b/topics/complex_numbers.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 from constants import *
 
 
 from mobject.vectorized_mobject import VGroup
 from mobject.tex_mobject import TexMobject, TextMobject
-from number_line import NumberPlane
+from .number_line import NumberPlane
 from animation.animation import Animation
 from animation.transform import ApplyPointwiseFunction, MoveToTarget
 from animation.simple_animations import Homotopy, ShowCreation, \
@@ -251,7 +252,7 @@ class ComplexFunction(ApplyPointwiseFunction):
             )
         ApplyPointwiseFunction.__init__(
             self,
-            lambda (x, y, z) : complex_to_R3(function(complex(x, y))),
+            lambda x_y_z : complex_to_R3(function(complex(x_y_z[0], x_y_z[1]))),
             instantiate(mobject),
             **kwargs
         )

--- a/topics/counting.py
+++ b/topics/counting.py
@@ -102,7 +102,7 @@ class CountingScene(Scene):
                 added_anims += self.get_digit_increment_animations()
                 first_move = False
             moving_dot.target.replace(
-                self.dot_template_iterators[place].next()
+                next(self.dot_template_iterators[place])
             )
             self.play(MoveToTarget(moving_dot), *added_anims, **kwargs)
             self.curr_configurations[place].add(moving_dot)

--- a/topics/fractals.py
+++ b/topics/fractals.py
@@ -1,16 +1,18 @@
+from __future__ import absolute_import
 # from mobject.mobject import Mobject, Point, Mobject1D
 from mobject.vectorized_mobject import VMobject, VGroup, VectorizedPoint
 from scene.scene import Scene
 from animation.transform import Transform
 from animation.simple_animations import ShowCreation
 from topics.geometry import Line, Polygon, RegularPolygon, Square, Circle
-from characters import PiCreature, Randolph, get_all_pi_creature_modes
+from .characters import PiCreature, Randolph, get_all_pi_creature_modes
 from utils.bezier import interpolate
 from utils.color import color_gradient
 from utils.config_ops import digest_config
 from utils.space_ops import rotation_matrix, rotate_vector, compass_directions, center_of_mass
 
 from constants import *
+from functools import reduce
 
 
 def rotate(points, angle = np.pi, axis = OUT):

--- a/topics/geometry.py
+++ b/topics/geometry.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from constants import *
 
 import itertools as it

--- a/topics/graph_scene.py
+++ b/topics/graph_scene.py
@@ -138,7 +138,7 @@ class GraphScene(Scene):
         x_max = None,
         ):
         if color is None:
-            color = self.default_graph_colors_cycle.next()
+            color = next(self.default_graph_colors_cycle)
         if x_min is None:
             x_min = self.x_min
         if x_max is None:

--- a/topics/graph_theory.py
+++ b/topics/graph_theory.py
@@ -8,6 +8,7 @@ from constants import *
 from scene.scene import Scene
 from utils.rate_functions import there_and_back
 from utils.space_ops import center_of_mass
+from functools import reduce
 
 
 class Graph():
@@ -276,7 +277,7 @@ class GraphScene(Scene):
             cycle = self.graph.region_cycles[0]
         time_per_edge = run_time / len(cycle)
         next_in_cycle = it.cycle(cycle)
-        next_in_cycle.next()#jump one ahead
+        next(next_in_cycle)#jump one ahead
         self.traced_cycle = Mobject(*[
             Line(self.points[i], self.points[j]).set_color(color)
             for i, j in zip(cycle, next_in_cycle)

--- a/topics/matrix.py
+++ b/topics/matrix.py
@@ -138,7 +138,7 @@ class NumericalMatrixMultiplication(Scene):
     def construct(self):
         left_string_matrix, right_string_matrix = [
             np.array(matrix).astype("string")
-            for matrix in self.left_matrix, self.right_matrix
+            for matrix in (self.left_matrix, self.right_matrix)
         ]
         if right_string_matrix.shape[0] != left_string_matrix.shape[1]:
             raise Exception("Incompatible shapes for matrix multiplication")
@@ -213,7 +213,7 @@ class NumericalMatrixMultiplication(Scene):
         )
         circles = VMobject(*[
             entry.get_point_mobject()
-            for entry in l_matrix[0][0], r_matrix[0][0]
+            for entry in (l_matrix[0][0], r_matrix[0][0])
         ])
         (m, k), n = l_matrix.shape, r_matrix.shape[1]
         for mob in result_matrix.flatten():

--- a/topics/vector_space_scene.py
+++ b/topics/vector_space_scene.py
@@ -4,7 +4,7 @@ from scene.scene import Scene
 from mobject.mobject import Mobject
 from mobject.vectorized_mobject import VMobject, VGroup
 from mobject.tex_mobject import TexMobject, TextMobject
-from animation.animation import Animation    
+from animation.animation import Animation
 from animation.transform import ApplyPointwiseFunction, Transform, \
     ApplyMethod, FadeOut, ApplyFunction
 from animation.simple_animations import ShowCreation, Write
@@ -66,11 +66,11 @@ class VectorScene(Scene):
     def get_basis_vectors(self):
         return [
             Vector(
-                vect, color = color, 
+                vect, color = color,
                 stroke_width = self.basis_vector_stroke_width
             )
             for vect, color in [
-                ([1, 0], X_COLOR), 
+                ([1, 0], X_COLOR),
                 ([0, 1], Y_COLOR)
             ]
         ]
@@ -79,7 +79,7 @@ class VectorScene(Scene):
         i_hat, j_hat = self.get_basis_vectors()
         return VGroup(*[
             self.get_vector_label(
-                vect, label, color = color, 
+                vect, label, color = color,
                 label_scale_factor = 1,
                 **kwargs
             )
@@ -89,10 +89,10 @@ class VectorScene(Scene):
             ]
         ])
 
-    def get_vector_label(self, vector, label, 
-                         direction = "left", 
+    def get_vector_label(self, vector, label,
+                         direction = "left",
                          rotate = False,
-                         color = None, 
+                         color = None,
                          label_scale_factor = VECTOR_LABEL_SCALE_FACTOR):
         if not isinstance(label, TexMobject):
             if len(label) == 1:
@@ -267,9 +267,9 @@ class LinearTransformationScene(VectorScene):
         self.has_already_setup = True
         ##^This is to not break all the old Scenes
         self.background_mobjects = []
-        self.foreground_mobjects = []        
+        self.foreground_mobjects = []
         self.transformable_mobjects = []
-        self.moving_vectors = []        
+        self.moving_vectors = []
         self.transformable_labels = []
         self.moving_mobjects = []
 
@@ -280,7 +280,7 @@ class LinearTransformationScene(VectorScene):
 
         if self.show_coordinates:
             self.background_plane.add_coordinates()
-        if self.include_background_plane:                
+        if self.include_background_plane:
             self.add_background_mobject(self.background_plane)
         if self.include_foreground_plane:
             self.plane = NumberPlane(**self.foreground_plane_kwargs)
@@ -307,7 +307,7 @@ class LinearTransformationScene(VectorScene):
 
     def add_foreground_mobject(self, *mobjects):
         self.add_special_mobjects(self.foreground_mobjects, *mobjects)
-            
+
     def add_transformable_mobject(self, *mobjects):
         self.add_special_mobjects(self.transformable_mobjects, *mobjects)
 
@@ -325,7 +325,7 @@ class LinearTransformationScene(VectorScene):
         else:
             square.set_fill(color, opacity)
         self.add_transformable_mobject(square)
-        self.bring_to_front(*self.moving_vectors)        
+        self.bring_to_front(*self.moving_vectors)
         self.square = square
         return self
 
@@ -372,11 +372,11 @@ class LinearTransformationScene(VectorScene):
             new_matrix[:2, :2] = transposed_matrix
             transposed_matrix = new_matrix
         elif transposed_matrix.shape != (3, 3):
-            raise "Matrix has bad dimensions"
+            raise Exception("Matrix has bad dimensions")
         return lambda point: np.dot(point, transposed_matrix)
 
     def get_piece_movement(self, pieces):
-        start = VMobject(*pieces)       
+        start = VMobject(*pieces)
         target = VMobject(*[mob.target for mob in pieces])
         if self.leave_ghost_vectors:
             self.add(start.copy().fade(0.7))
@@ -438,14 +438,3 @@ class LinearTransformationScene(VectorScene):
             for f_mob in self.foreground_mobjects
         ] + added_anims
         self.play(*anims, **kwargs)
-
-
-
-
-
-
-
-
-
-
-

--- a/utils/color.py
+++ b/utils/color.py
@@ -1,6 +1,7 @@
 from colour import Color
 import numpy as np
 import random
+from ..constants import PALETTE, WHITE
 
 from utils.bezier import interpolate
 

--- a/utils/config_ops.py
+++ b/utils/config_ops.py
@@ -1,5 +1,6 @@
 import inspect
 import operator as op
+from functools import reduce
 
 def instantiate(obj):
     """

--- a/utils/iterables.py
+++ b/utils/iterables.py
@@ -1,5 +1,12 @@
 import numpy as np
 import itertools as it
+from functools import reduce
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 def remove_list_redundancies(l):
     """
@@ -86,8 +93,8 @@ def make_even_by_cycling(iterable_1, iterable_2):
     cycle1 = it.cycle(iterable_1)
     cycle2 = it.cycle(iterable_2)
     return (
-        [cycle1.next() for x in range(length)],
-        [cycle2.next() for x in range(length)]
+        [next(cycle1) for x in range(length)],
+        [next(cycle2) for x in range(length)]
     )
 
 def composition(func_list):
@@ -95,9 +102,9 @@ def composition(func_list):
     func_list should contain elements of the form (f, args)
     """
     return reduce(
-        lambda (f1, args1), (f2, args2) : (lambda x : f1(f2(x, *args2), *args1)), 
+        lambda func_args0, func_args1: (lambda x: func_args0[0](func_args1[0](x, *func_args1[1]), *func_args0[1])),
         func_list,
-        lambda x : x
+        lambda x: x
     )
 
 def remove_nones(sequence):
@@ -106,8 +113,3 @@ def remove_nones(sequence):
 ## Note this is redundant with it.chain
 def concatenate_lists(*list_of_lists):
     return [item for l in list_of_lists for item in l]
-
-
-
-
-

--- a/utils/simple_functions.py
+++ b/utils/simple_functions.py
@@ -1,5 +1,12 @@
 import operator as op
 import numpy as np
+from functools import reduce
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 def sigmoid(x):
     return 1.0/(1 + np.exp(-x))

--- a/utils/space_ops.py
+++ b/utils/space_ops.py
@@ -1,5 +1,6 @@
 import numpy as np
 from constants import RIGHT, OUT
+from functools import reduce
 
 #Matrix operations
 


### PR DESCRIPTION
Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.
* Run __futurize --stage1__ http://python-future.org/futurize_cheatsheet.html
* Adjust adjust some __lambda__ and __tuple__ expressions to be compatible with Python 3.

Fixes #182 and helps with  #128

__Ready for review.__  Python 3 syntax compatibility does _not_ mean that the port is complete.  