### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/active_projects/eop/bayes.py
+++ b/active_projects/eop/bayes.py
@@ -1634,7 +1634,7 @@ class MusicExample(SampleSpaceScene, PiCreatureScene):
         randy = self.pi_creature
         friends = VGroup(*[
             PiCreature(mode = "happy", color = color).flip()
-            for color in BLUE_B, GREY_BROWN, MAROON_E
+            for color in (BLUE_B, GREY_BROWN, MAROON_E)
         ])
         friends.scale(0.6)
         friends.arrange_submobjects(RIGHT)

--- a/active_projects/eop/bayes_footnote.py
+++ b/active_projects/eop/bayes_footnote.py
@@ -672,7 +672,7 @@ class ShowRestrictedSpace(Scene):
         words.to_edge(UP)
         arrows = [
             Arrow(words.get_bottom(), movers.target[i].get_top())
-            for i in 0, -1
+            for i in (0, -1)
         ]
 
         self.play(FadeOut(to_fade))
@@ -1354,7 +1354,7 @@ class CompareNumbersInBothExamples(Scene):
             TexMobject(
                 "P(", "\\text{%s}"%s, ")", "= 1/1{,}000}"
             )
-            for s in "Sick", "Powers"
+            for s in ("Sick", "Powers")
         ])
         likelihoods = VGroup(*[
             TexMobject(

--- a/active_projects/eop/combinations.py
+++ b/active_projects/eop/combinations.py
@@ -175,7 +175,7 @@ class ExperienceProblemSolver(PiCreatureScene):
                     last_row.copy(), VGroup(*mobs),
                     remover = True
                 )
-                for mobs in curr_row[1:], curr_row[:-1]
+                for mobs in (curr_row[1:], curr_row[:-1])
             ])
             self.add(curr_row)
         self.wait(3)
@@ -1776,7 +1776,7 @@ class IntroducePascalsTriangle(Scene):
                     last_row.copy(), VGroup(*mobs),
                     remover = True
                 )
-                for mobs in curr_row[1:], curr_row[:-1]
+                for mobs in (curr_row[1:], curr_row[:-1])
             ])
             self.add(curr_row)
         self.wait()
@@ -2115,7 +2115,7 @@ class StacksApproachBellCurve(Scene):
 
             self.play(*[
                 MoveToTarget(mob, submobject_mode = "lagged_start")
-                for mob in bars_copy, numbers, numbers_copy
+                for mob in (bars_copy, numbers, numbers_copy)
             ])
             self.remove(numbers, numbers_copy)
             numbers = VGroup(numbers[0])
@@ -2407,7 +2407,7 @@ class ChooseThreeFromFive(InitialFiveChooseThreeExample, PiCreatureScene):
             self.wait()
             word_arrow_groups.submobjects = [
                 word_arrow_groups[j]
-                for j in 1, 2, 0
+                for j in (1, 2, 0)
             ]
         self.play(*map(FadeOut, [line, odm_words]))
 
@@ -2457,7 +2457,7 @@ class ChooseThreeFromFive(InitialFiveChooseThreeExample, PiCreatureScene):
     def get_names(self, people):
         names = VGroup(*[
             TextMobject(name + ",")
-            for name in "Ali", "Ben", "Cam", "Denis", "Evan"
+            for name in ("Ali", "Ben", "Cam", "Denis", "Evan")
         ])
         for name, pi in zip(names, people):
             name[-1].set_fill(opacity = 0)
@@ -2668,7 +2668,7 @@ class StudentsGetConfused(PiCreatureScene):
     def create_pi_creatures(self):
         pis = VGroup(*[
             Randolph(color = color)
-            for color in BLUE_D, BLUE_B
+            for color in (BLUE_D, BLUE_B)
         ])
         pis[1].flip()
         pis.arrange_submobjects(RIGHT, buff = 5)

--- a/active_projects/eop/independence.py
+++ b/active_projects/eop/independence.py
@@ -205,7 +205,7 @@ class MeaningOfIndependence(SampleSpaceScene):
                 self.sample_space.get_corner(vect+RIGHT),
                 0.7
             )
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ])
         line.set_stroke(RED, 8)
         word = TextMobject("Independence")
@@ -925,7 +925,7 @@ class ThousandPossibleQuizzes(Scene):
                 include_qs = False,
                 buff = SMALL_BUFF
             )
-            for b in True, False
+            for b in (True, False)
         ])
         question = VGroup(
             TextMobject("Where are"), sg1,
@@ -1485,7 +1485,7 @@ class ShowAllEightConditionals(Scene):
                 "P(", filler_tex, "|", filler_tex, ")",
             )
             sub_bool_lists = [
-                bool_list[:n] for n in 3, 1, 2, 1, 3, 2
+                bool_list[:n] for n in (3, 1, 2, 1, 3, 2)
             ]
             parts = equation.get_parts_by_tex(filler_tex)
             for part, sub_list in zip(parts, sub_bool_lists):
@@ -2305,7 +2305,7 @@ class NameBinomial(Scene):
         flip_indices = self.flip_indices
         flipped_arrows, faded_crosses, full_checks = [
             VGroup(*[group[i] for i in flip_indices])
-            for group in arrows, crosses, checkmarks
+            for group in (arrows, crosses, checkmarks)
         ]
         faded_checkmarks = VGroup(*filter(
             lambda m : m not in full_checks,
@@ -2529,7 +2529,7 @@ class CycleThroughPatterns(NameBinomial):
                     getattr(new_pattern, attr),
                     path_arc = np.pi
                 )
-                for attr in "boys", "girls"
+                for attr in ("boys", "girls")
             ])
 
     ####
@@ -3065,7 +3065,7 @@ class CorrectForDependence(NameBinomial):
                 for i in range(len(group))
                 if i in indices
             ])
-            for group in self.checkmarks, self.arrows, self.crosses
+            for group in (self.checkmarks, self.arrows, self.crosses)
         ]
         for arrow in arrows:
             arrow.target = arrow.deepcopy()
@@ -3262,7 +3262,7 @@ class CompareTwoSituations(PiCreatureScene):
         randy = self.randy
         top_left, top_right = screens = [
             ScreenRectangle(height = 3).to_corner(vect)
-            for vect in UP+LEFT, UP+RIGHT
+            for vect in (UP+LEFT, UP+RIGHT)
         ]
         arrow = DoubleArrow(*screens, buff = SMALL_BUFF)
         arrow.set_color(BLUE)
@@ -3390,7 +3390,7 @@ class SkepticalOfDistributions(TeacherStudentsScene):
         k_range = range(11)
         dists = [
             get_binomial_distribution(10, p)
-            for p in 0.2, 0.8, 0.5
+            for p in (0.2, 0.8, 0.5)
         ]
         values_list = [
             map(dist, k_range)

--- a/animation/composition.py
+++ b/animation/composition.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import itertools as it
 import numpy as np
@@ -151,7 +152,7 @@ class Succession(Animation):
                     "Rounding error not near alpha=1 in Succession.update_mobject," + \
                     "instead alpha = %f"%alpha
                 )
-                print self.critical_alphas, alpha
+                print(self.critical_alphas, alpha)
             i = self.num_anims - 1
 
         # At this point, we should have self.critical_alphas[i] <= alpha <= self.critical_alphas[i +1]

--- a/animation/indication.py
+++ b/animation/indication.py
@@ -16,6 +16,7 @@ from mobject.geometry import Dot
 from utils.config_ops import digest_config
 from utils.rate_functions import squish_rate_func
 from utils.rate_functions import there_and_back
+from functools import reduce
 
 
 class FocusOn(Transform):
@@ -170,7 +171,7 @@ class Vibrate(Animation):
         )
         for mob, start in zip(*families):
             mob.points = np.apply_along_axis(
-                lambda (x, y, z) : (x, y + self.wave_function(x, time), z),
+                lambda x_y_z : (x_y_z[0], x_y_z[1] + self.wave_function(x_y_z[0], time), x_y_z[2]),
                 1, start.points
             )
 

--- a/animation/transform.py
+++ b/animation/transform.py
@@ -107,7 +107,7 @@ class ApplyMethod(Transform):
             "Whoops, looks like you accidentally invoked " + \
             "the method you want to animate"
         )
-        assert(isinstance(method.im_self, Mobject))
+        assert(isinstance(method.__self__, Mobject))
         args = list(args) #So that args.pop() works
         if "method_kwargs" in kwargs:
             method_kwargs = kwargs["method_kwargs"]
@@ -115,9 +115,9 @@ class ApplyMethod(Transform):
             method_kwargs = args.pop()
         else:
             method_kwargs = {}
-        target = method.im_self.copy()
-        method.im_func(target, *args, **method_kwargs)
-        Transform.__init__(self, method.im_self, target, **kwargs)
+        target = method.__self__.copy()
+        method.__func__(target, *args, **method_kwargs)
+        Transform.__init__(self, method.__self__, target, **kwargs)
 
 class ApplyPointwiseFunction(ApplyMethod):
     CONFIG = {
@@ -158,7 +158,7 @@ class ApplyMatrix(ApplyPointwiseFunction):
             new_matrix[:2, :2] = matrix
             matrix = new_matrix
         elif matrix.shape != (3, 3):
-            raise "Matrix has bad dimensions"
+            raise Exception("Matrix has bad dimensions")
         transpose = np.transpose(matrix)
         def func(p):
             return np.dot(p, transpose)
@@ -172,7 +172,7 @@ class ComplexFunction(ApplyPointwiseFunction):
             )
         ApplyPointwiseFunction.__init__(
             self,
-            lambda (x, y, z) : complex_to_R3(function(complex(x, y))),
+            lambda x_y_z : complex_to_R3(function(complex(x_y_z[0], x_y_z[1]))),
             instantiate(mobject),
             **kwargs
         )

--- a/big_ol_pile_of_manim_imports.py
+++ b/big_ol_pile_of_manim_imports.py
@@ -12,82 +12,83 @@ addressible by changing this file.
 Note: One should NOT import from this file for main library code, it is meant only
 as a convenience for scripts createing scenes for videos
 """
+from __future__ import absolute_import
 
-from constants import *
+from .constants import *
 
-from animation.animation import *
-from animation.composition import *
-from animation.creation import *
-from animation.indication import *
-from animation.movement import *
-from animation.numbers import *
-from animation.rotation import *
-from animation.specialized import *
-from animation.transform import *
-from animation.update import *
+from .animation.animation import *
+from .animation.composition import *
+from .animation.creation import *
+from .animation.indication import *
+from .animation.movement import *
+from .animation.numbers import *
+from .animation.rotation import *
+from .animation.specialized import *
+from .animation.transform import *
+from .animation.update import *
 
-from camera.camera import *
-from camera.mapping_camera import *
-from camera.moving_camera import *
-from camera.three_d_camera import *
+from .camera.camera import *
+from .camera.mapping_camera import *
+from .camera.moving_camera import *
+from .camera.three_d_camera import *
 
-from continual_animation.continual_animation import *
-from continual_animation.from_animation import *
-from continual_animation.numbers import *
-from continual_animation.update import *
+from .continual_animation.continual_animation import *
+from .continual_animation.from_animation import *
+from .continual_animation.numbers import *
+from .continual_animation.update import *
 
-from mobject.frame import *
-from mobject.functions import *
-from mobject.geometry import *
-from mobject.matrix import *
-from mobject.mobject import *
-from mobject.number_line import *
-from mobject.numbers import *
-from mobject.probability import *
-from mobject.shape_matchers import *
-from mobject.svg.brace import *
-from mobject.svg.svg_mobject import *
-from mobject.svg.tex_mobject import *
-from mobject.three_dimensions import *
-from mobject.types.image_mobject import *
-from mobject.types.point_cloud_mobject import *
-from mobject.types.vectorized_mobject import *
-from mobject.value_tracker import *
+from .mobject.frame import *
+from .mobject.functions import *
+from .mobject.geometry import *
+from .mobject.matrix import *
+from .mobject.mobject import *
+from .mobject.number_line import *
+from .mobject.numbers import *
+from .mobject.probability import *
+from .mobject.shape_matchers import *
+from .mobject.svg.brace import *
+from .mobject.svg.svg_mobject import *
+from .mobject.svg.tex_mobject import *
+from .mobject.three_dimensions import *
+from .mobject.types.image_mobject import *
+from .mobject.types.point_cloud_mobject import *
+from .mobject.types.vectorized_mobject import *
+from .mobject.value_tracker import *
 
-from for_3b1b_videos.common_scenes import *
-from for_3b1b_videos.pi_creature import *
-from for_3b1b_videos.pi_creature_animations import *
-from for_3b1b_videos.pi_creature_scene import *
+from .for_3b1b_videos.common_scenes import *
+from .for_3b1b_videos.pi_creature import *
+from .for_3b1b_videos.pi_creature_animations import *
+from .for_3b1b_videos.pi_creature_scene import *
 
-from scene.graph_scene import *
-from scene.moving_camera_scene import *
-from scene.reconfigurable_scene import *
-from scene.scene import *
-from scene.scene_from_video import *
-from scene.three_d_scene import *
-from scene.vector_space_scene import *
-from scene.zoomed_scene import *
+from .scene.graph_scene import *
+from .scene.moving_camera_scene import *
+from .scene.reconfigurable_scene import *
+from .scene.scene import *
+from .scene.scene_from_video import *
+from .scene.three_d_scene import *
+from .scene.vector_space_scene import *
+from .scene.zoomed_scene import *
 
-from once_useful_constructs.arithmetic import *
-from once_useful_constructs.combinatorics import *
-from once_useful_constructs.complex_transformation_scene import *
-from once_useful_constructs.counting import *
-from once_useful_constructs.fractals import *
-from once_useful_constructs.graph_theory import *
-from once_useful_constructs.light import *
+from .once_useful_constructs.arithmetic import *
+from .once_useful_constructs.combinatorics import *
+from .once_useful_constructs.complex_transformation_scene import *
+from .once_useful_constructs.counting import *
+from .once_useful_constructs.fractals import *
+from .once_useful_constructs.graph_theory import *
+from .once_useful_constructs.light import *
 
 
-from utils.bezier import *
-from utils.color import *
-from utils.config_ops import *
-from utils.images import *
-from utils.iterables import *
-from utils.paths import *
-from utils.rate_functions import *
-from utils.simple_functions import *
-from utils.sounds import *
-from utils.space_ops import *
-from utils.strings import *
+from .utils.bezier import *
+from .utils.color import *
+from .utils.config_ops import *
+from .utils.images import *
+from .utils.iterables import *
+from .utils.paths import *
+from .utils.rate_functions import *
+from .utils.simple_functions import *
+from .utils.sounds import *
+from .utils.space_ops import *
+from .utils.strings import *
 
 # Non manim libraries that are also nice to have without thinking
 

--- a/camera/camera.py
+++ b/camera/camera.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import itertools as it
 import numpy as np
 import os
@@ -22,6 +23,7 @@ from utils.iterables import batch_by_property
 from utils.iterables import list_difference_update
 from utils.iterables import remove_list_redundancies
 from utils.simple_functions import fdiv
+from functools import reduce
 
 class Camera(object):
     CONFIG = {
@@ -128,14 +130,14 @@ class Camera(object):
         pixel coordinates), and each output is expected to be an RGBA array of 4 floats.
         """
 
-        print "Starting set_background; for reference, the current time is ", time.strftime("%H:%M:%S")
+        print("Starting set_background; for reference, the current time is ", time.strftime("%H:%M:%S"))
         coords = self.get_coords_of_all_pixels()
         new_background = np.apply_along_axis(
             coords_to_colors_func,
             2,
             coords
         )
-        print "Ending set_background; for reference, the current time is ", time.strftime("%H:%M:%S")
+        print("Ending set_background; for reference, the current time is ", time.strftime("%H:%M:%S"))
 
         return self.convert_pixel_array(new_background, convert_from_floats = True)
 
@@ -440,7 +442,7 @@ class Camera(object):
         # rgba_max_val = self.rgb_max_val
         src_rgb, src_a, dst_rgb, dst_a = [
             a.astype(np.float32)/self.rgb_max_val
-            for a in fg[...,:3], fg[...,3], bg[...,:3], bg[...,3]
+            for a in (fg[...,:3], fg[...,3], bg[...,:3], bg[...,3])
         ]
 
         out_a = src_a + dst_a*(1.0-src_a)

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from big_ol_pile_of_manim_imports import *
+from __future__ import absolute_import
+from .big_ol_pile_of_manim_imports import *
 
 # To watch one of these scenes, run the following:
 # python extract_scene.py file_name <SceneName> -p
@@ -26,7 +27,7 @@ class WarpSquare(Scene):
     def construct(self):
         square = Square()
         self.play(ApplyPointwiseFunction(
-            lambda (x, y, z) : complex_to_R3(np.exp(complex(x, y))),
+            lambda x_y_z : complex_to_R3(np.exp(complex(x_y_z[0], x_y_z[1]))),
             square
         ))
         self.wait()

--- a/extract_scene.py
+++ b/extract_scene.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
 # import getopt
 import argparse
@@ -11,11 +13,11 @@ import os
 import subprocess as sp
 import traceback
 
-from camera.camera import Camera
-from constants import *
-from scene.scene import Scene
-from utils.sounds import play_error_sound
-from utils.sounds import play_finish_sound
+from .camera.camera import Camera
+from .constants import *
+from .scene.scene import Scene
+from .utils.sounds import play_error_sound
+from .utils.sounds import play_finish_sound
 
 HELP_MESSAGE = """
    Usage:
@@ -74,7 +76,7 @@ def get_configuration():
          output_name_root, output_name_ext = os.path.splitext(args.output_name)
          expected_ext = '.png' if args.show_last_frame else '.mp4'
          if not output_name_ext in ['', expected_ext]:
-            print "WARNING: The output will be to (doubly-dotted) %s%s"%output_name_root%expected_ext
+            print("WARNING: The output will be to (doubly-dotted) %s%s"%output_name_root%expected_ext)
             output_name = args.output_name
          else:
             # If anyone wants .mp4.mp4 and is surprised to only get .mp4, or such... Well, too bad.
@@ -245,7 +247,7 @@ def main():
    
    scene_kwargs["name"] = config["output_name"]
    if config["save_pngs"]:
-      print "We are going to save a PNG sequence as well..."
+      print("We are going to save a PNG sequence as well...")
       scene_kwargs["save_pngs"] = True
       scene_kwargs["pngs_mode"] = config["saved_image_mode"]
       

--- a/for_3b1b_videos/pi_creature.py
+++ b/for_3b1b_videos/pi_creature.py
@@ -206,7 +206,7 @@ class PiCreature(SVGMobject):
         body = self.body
         return VGroup(*[
             body.copy().pointwise_become_partial(body, *alpha_range)
-            for alpha_range in self.right_arm_range, self.left_arm_range
+            for alpha_range in (self.right_arm_range, self.left_arm_range)
         ])
 
 def get_all_pi_creature_modes():

--- a/mobject/mobject.py
+++ b/mobject/mobject.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import itertools as it
 import numpy as np
@@ -20,6 +21,7 @@ from utils.space_ops import R3_to_complex
 from utils.space_ops import angle_of_vector
 from utils.space_ops import complex_to_R3
 from utils.space_ops import rotation_matrix
+from functools import reduce
 
 
 #TODO: Explain array_attrs
@@ -214,7 +216,7 @@ class Mobject(Container):
 
     def apply_complex_function(self, function, **kwargs):
         return self.apply_function(
-            lambda (x, y, z) : complex_to_R3(function(complex(x, y))),
+            lambda x_y_z : complex_to_R3(function(complex(x_y_z[0], x_y_z[1]))),
             **kwargs
         )
 
@@ -765,7 +767,7 @@ class Mobject(Container):
 
     def print_submobject_family(self, n_tabs = 0):
         """For debugging purposes"""
-        print "\t"*n_tabs, self, id(self)
+        print("\t"*n_tabs, self, id(self))
         for submob in self.submobjects:
             submob.print_mobject_family(n_tabs + 1)
 
@@ -801,7 +803,7 @@ class Mobject(Container):
         #push it into its submobject list
         self_has_points, mob_has_points = [
             mob.get_num_points() > 0
-            for mob in self, mobject
+            for mob in (self, mobject)
         ]
         if self_has_points and not mob_has_points:
             mobject.null_point_align(self)

--- a/mobject/svg/svg_mobject.py
+++ b/mobject/svg/svg_mobject.py
@@ -135,7 +135,7 @@ class SVGMobject(VMobject):
             float(circle_element.getAttribute(key))
             if circle_element.hasAttribute(key)
             else 0.0
-            for key in "cx", "cy", "r"
+            for key in ("cx", "cy", "r")
         ]
         return Circle(radius = r).shift(x*RIGHT+y*DOWN)
 
@@ -144,7 +144,7 @@ class SVGMobject(VMobject):
             float(circle_element.getAttribute(key))
             if circle_element.hasAttribute(key)
             else 0.0
-            for key in "cx", "cy", "rx", "ry"
+            for key in ("cx", "cy", "rx", "ry")
         ]
         return Circle().scale(rx*RIGHT + ry*UP).shift(x*RIGHT+y*DOWN)
 

--- a/mobject/svg/tex_mobject.py
+++ b/mobject/svg/tex_mobject.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
+from __future__ import absolute_import
 from constants import *
 
-from svg_mobject import SVGMobject
-from svg_mobject import VMobjectFromSVGPathstring
+from .svg_mobject import SVGMobject
+from .svg_mobject import VMobjectFromSVGPathstring
 from mobject.shape_matchers import BackgroundRectangle
 from utils.config_ops import digest_config
 from mobject.types.vectorized_mobject import VGroup
@@ -11,6 +13,7 @@ from mobject.types.vectorized_mobject import VectorizedPoint
 import collections
 import operator as op
 import sys
+from functools import reduce
 
 TEX_MOB_SCALE_FACTOR = 0.05
 
@@ -209,7 +212,7 @@ class TexMobject(SVGMobject):
 
     def sort_submobjects_alphabetically(self):
         def alphabetical_cmp(m1, m2):
-            if not all([isinstance(m, TexMobject) for m in m1, m2]):
+            if not all([isinstance(m, TexMobject) for m in (m1, m2)]):
                 return 0
             return cmp(m1.get_tex_string(), m2.get_tex_string())
         self.submobjects.sort(alphabetical_cmp)

--- a/mobject/types/point_cloud_mobject.py
+++ b/mobject/types/point_cloud_mobject.py
@@ -160,7 +160,7 @@ class PMobject(Mobject):
     def pointwise_become_partial(self, mobject, a, b):
         lower_index, upper_index = [
             int(x * mobject.get_num_points())
-            for x in a, b
+            for x in (a, b)
         ]
         for attr in self.get_array_attrs():
             full_array = getattr(mobject, attr)

--- a/mobject/types/vectorized_mobject.py
+++ b/mobject/types/vectorized_mobject.py
@@ -212,7 +212,7 @@ class VMobject(Mobject):
         points = np.array(points)
         self.set_anchors_and_handles(points, *[
             interpolate(points[:-1], points[1:], alpha)
-            for alpha in 1./3, 2./3
+            for alpha in (1./3, 2./3)
         ])
         return self
 

--- a/old_projects/WindingNumber.py
+++ b/old_projects/WindingNumber.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 import time
@@ -60,16 +61,18 @@ def rev_to_rgba(alpha):
 def rev_to_color(alpha):
     return rgba_to_color(rev_to_rgba(alpha))
 
-def point_to_rev((x, y), allow_origin = False):
+def point_to_rev(xxx_todo_changeme6, allow_origin = False):
     # Warning: np.arctan2 would happily discontinuously returns the value 0 for (0, 0), due to 
     # design choices in the underlying atan2 library call, but for our purposes, this is 
     # illegitimate, and all winding number calculations must be set up to avoid this
+    (x, y) = xxx_todo_changeme6
     if not(allow_origin) and (x, y) == (0, 0):
-        print "Error! Angle of (0, 0) computed!"
+        print("Error! Angle of (0, 0) computed!")
         return
     return fdiv(np.arctan2(y, x), TAU)
 
-def point_to_size((x, y)):
+def point_to_size(xxx_todo_changeme7):
+    (x, y) = xxx_todo_changeme7
     return np.sqrt(x**2 + y**2)
 
 # rescaled_size goes from 0 to 1 as size goes from 0 to infinity
@@ -137,8 +140,8 @@ class EquationSolver1d(GraphScene, ZoomedScene):
         if self.show_target_line:
             self.play(FadeOut(target_line_label)) # Reduce clutter
 
-        print "For reference, graphOrigin: ", self.coords_to_point(0, 0)
-        print "targetYPoint: ", self.coords_to_point(0, self.targetY)
+        print("For reference, graphOrigin: ", self.coords_to_point(0, 0))
+        print("targetYPoint: ", self.coords_to_point(0, self.targetY))
 
     # This is a mess right now (first major animation coded), 
     # but it works; can be refactored later or never
@@ -439,10 +442,11 @@ def complex_to_pair(c):
     return np.array((c.real, c.imag))
 
 def plane_func_from_complex_func(f):
-    return lambda (x, y) : complex_to_pair(f(complex(x,y)))
+    return lambda x_y4 : complex_to_pair(f(complex(x_y4[0],x_y4[1])))
 
 def point3d_func_from_plane_func(f):
-    def g((x, y, z)):
+    def g(xxx_todo_changeme):
+        (x, y, z) = xxx_todo_changeme
         f_val = f((x, y))
         return np.array((f_val[0], f_val[1], 0))
     return g
@@ -450,7 +454,8 @@ def point3d_func_from_plane_func(f):
 def point3d_func_from_complex_func(f):
     return point3d_func_from_plane_func(plane_func_from_complex_func(f))
 
-def plane_zeta((x, y)):
+def plane_zeta(xxx_todo_changeme8):
+    (x, y) = xxx_todo_changeme8
     CLAMP_SIZE = 1000
     z = complex(x, y)
     try:
@@ -461,7 +466,8 @@ def plane_zeta((x, y)):
         answer = answer/abs(answer) * CLAMP_SIZE
     return (float(answer.real), float(answer.imag))
 
-def rescaled_plane_zeta((x, y)):
+def rescaled_plane_zeta(xxx_todo_changeme9):
+    (x, y) = xxx_todo_changeme9
     return plane_zeta((x/FRAME_X_RADIUS, 8*y))
 
 # Returns a function from 2-ples to 2-ples
@@ -476,13 +482,13 @@ def plane_func_by_wind_spec(*specs):
         elif len(p) == 2:
             return (p[0], p[1], 1)
         else:
-            print "Error in plane_func_by_wind_spec embiggen!"
+            print("Error in plane_func_by_wind_spec embiggen!")
     specs = map(embiggen, specs)
 
-    pos_specs = filter(lambda (x, y, z) : z > 0, specs)
-    neg_specs = filter(lambda (x, y, z) : z < 0, specs)
+    pos_specs = filter(lambda x_y_z : x_y_z[2] > 0, specs)
+    neg_specs = filter(lambda x_y_z1 : x_y_z1[2] < 0, specs)
 
-    neg_specs_made_pos = map (lambda (x, y, z) : (x, y, -z), neg_specs)
+    neg_specs_made_pos = map (lambda x_y_z2 : (x_y_z2[0], x_y_z2[1], -x_y_z2[2]), neg_specs)
 
     def poly(c, root_specs):
         return np.prod([(c - complex(x, y))**z for (x, y, z) in root_specs])
@@ -651,8 +657,8 @@ class ColorMappedByFuncScene(Scene):
             self.input_to_pos_func = lambda p : p
             self.pos_to_color_func = self.func
 
-        self.pixel_pos_to_color_func = lambda (x, y) : self.pos_to_color_func(
-            self.num_plane.point_to_coords_cheap(np.array([x, y, 0]))
+        self.pixel_pos_to_color_func = lambda x_y3 : self.pos_to_color_func(
+            self.num_plane.point_to_coords_cheap(np.array([x_y3[0], x_y3[1], 0]))
         )
 
         jitter_val = 0.1
@@ -661,7 +667,7 @@ class ColorMappedByFuncScene(Scene):
         def mini_hasher(p):
             rgba = point_to_rgba(self.pixel_pos_to_color_func(p))
             if rgba[3] != 1.0:
-                print "Warning! point_to_rgba assigns fractional alpha", rgba[3]
+                print("Warning! point_to_rgba assigns fractional alpha", rgba[3])
             return tuple(rgba)
         to_hash = tuple(mini_hasher(p) for p in func_hash_points)
         func_hash = hash(to_hash)
@@ -674,18 +680,18 @@ class ColorMappedByFuncScene(Scene):
         )
         self.in_background_pass = not os.path.exists(self.background_image_file)
 
-        print "Background file: " + self.background_image_file
+        print("Background file: " + self.background_image_file)
         if self.in_background_pass:
-            print "The background file does not exist yet; this will be a background creation + video pass"
+            print("The background file does not exist yet; this will be a background creation + video pass")
         else:
-            print "The background file already exists; this will only be a video pass"
+            print("The background file already exists; this will only be a video pass")
 
     def construct(self):
         if self.in_background_pass:
             self.camera.set_background_from_func(
-                lambda (x, y): point_to_rgba(
+                lambda x_y: point_to_rgba(
                     self.pixel_pos_to_color_func(
-                        (x, y)
+                        (x_y[0], x_y[1])
                     )
                 )
             )
@@ -863,7 +869,8 @@ class PiWalkerCircle(PiWalker):
         self.walk_coords = [r * np.array((np.cos(i * TAU/N), np.sin(i * TAU/N))) for i in range(N)]
         PiWalker.setup(self)
 
-def split_interval((a, b)):
+def split_interval(xxx_todo_changeme10):
+    (a, b) = xxx_todo_changeme10
     mid = (a + b)/2.0
     return ((a, mid), (mid, b))
 
@@ -915,7 +922,7 @@ class RectangleData():
         elif dim == 1:
             return_data = [RectangleData(x_interval, new_interval) for new_interval in split_interval(y_interval)[::-1]]        
         else: 
-            print "RectangleData.splits_on_dim passed illegitimate dimension!"
+            print("RectangleData.splits_on_dim passed illegitimate dimension!")
 
         return tuple(return_data)
 
@@ -928,7 +935,7 @@ class RectangleData():
         elif dim == 1:
             sides = (self.get_left(), self.get_right())
         else:
-            print "RectangleData.split_line_on_dim passed illegitimate dimension!"
+            print("RectangleData.split_line_on_dim passed illegitimate dimension!")
 
         return tuple([mid(x, y) for (x, y) in sides])
 
@@ -973,10 +980,10 @@ class EquationSolver2dNode(object):
 
     def play_in_bfs(self, scene, border_anim):
         bfs_nodes = self.hacky_bfs()
-        print "Number of nodes: ", len(bfs_nodes)
+        print("Number of nodes: ", len(bfs_nodes))
 
         if len(bfs_nodes) < 1:
-            print "Less than 1 node! Aborting!"
+            print("Less than 1 node! Aborting!")
             return
 
         scene.play(bfs_nodes[0].first_anim, border_anim)
@@ -1029,7 +1036,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
 
     def construct(self):
         if self.num_iterations == 0:
-            print "You forgot to set num_iterations (maybe you meant to subclass something other than EquationSolver2d directly?)"
+            print("You forgot to set num_iterations (maybe you meant to subclass something other than EquationSolver2d directly?)")
             return
 
         ColorMappedObjectsScene.construct(self)
@@ -1071,7 +1078,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
         def Animate2dSolver(cur_depth, rect, dim_to_split, 
             sides_to_draw = [0, 1, 2, 3], 
             manual_wind_override = None):
-            print "Solver at depth: " + str(cur_depth)
+            print("Solver at depth: " + str(cur_depth))
 
             if cur_depth >= self.num_iterations:
                 return EquationSolver2dNode(empty_animation)
@@ -1195,7 +1202,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
 
         rect = RectangleData(x_interval, y_interval)
 
-        print "Starting to compute anim"
+        print("Starting to compute anim")
 
         node = Animate2dSolver(
             cur_depth = 0, 
@@ -1205,7 +1212,7 @@ class EquationSolver2d(ColorMappedObjectsScene):
             manual_wind_override = self.manual_wind_override
         )
 
-        print "Done computing anim"
+        print("Done computing anim")
 
         if self.display_in_parallel:
             anim = node.display_in_parallel()
@@ -1241,14 +1248,14 @@ class EquationSolver2d(ColorMappedObjectsScene):
             rate_func = rect_rate
         )
 
-        print "About to do the big Play; for reference, the current time is ", time.strftime("%H:%M:%S")
+        print("About to do the big Play; for reference, the current time is ", time.strftime("%H:%M:%S"))
 
         if self.use_separate_plays:
             node.play_in_bfs(self, border_anim)
         else:
             self.play(anim, border_anim)
 
-        print "All done; for reference, the current time is ", time.strftime("%H:%M:%S")
+        print("All done; for reference, the current time is ", time.strftime("%H:%M:%S"))
 
         self.wait()
 
@@ -1712,7 +1719,7 @@ class Initial2dFuncSceneBase(Scene):
     }
 
     def show_planes(self):
-        print "Error! Unimplemented (pure virtual) show_planes"
+        print("Error! Unimplemented (pure virtual) show_planes")
 
     def shared_construct(self):
         points = [LEFT + DOWN, RIGHT + DOWN, LEFT + UP, RIGHT + UP]
@@ -2414,7 +2421,7 @@ class BorderOf2dRegionScene(Scene):
         border = Polygon(*points, color = negative_color, stroke_width = border_stroke_width)
         self.play(ShowCreation(border))
 
-big_loop_no_zeros_func = lambda (x, y) : complex_to_pair(np.exp(complex(10, y * np.pi)))
+big_loop_no_zeros_func = lambda x_y5 : complex_to_pair(np.exp(complex(10, x_y5[1] * np.pi)))
 
 class BigLoopNoZeros(ColorMappedObjectsScene):
     CONFIG = {
@@ -2539,7 +2546,8 @@ class TinyLoopOfBasicallySameColor(PureColorMap):
         self.play(ShowCreation(circle))
         self.wait()
 
-def uhOhFunc((x, y)):
+def uhOhFunc(xxx_todo_changeme11):
+    (x, y) = xxx_todo_changeme11
     x = -np.clip(x, -5, 5)/5
     y = -np.clip(y, -3, 3)/3
 
@@ -2648,7 +2656,8 @@ class UhOhSalientStill(ColorMappedObjectsScene):
 
 # Random test scenes and test functions go here:
 
-def rect_to_circle((x, y, z)):
+def rect_to_circle(xxx_todo_changeme12):
+    (x, y, z) = xxx_todo_changeme12
     size = np.sqrt(x**2 + y**2)
     max_abs_size = max(abs(x), abs(y))
     return fdiv(np.array((x, y, z)) * max_abs_size, size)
@@ -2725,7 +2734,7 @@ class SpecifiedWinder(PiWalker):
             cur_pos += (self.step_size, 0)
             mid_rev = rev_func(cur_pos)
 
-        print "Reached ", cur_pos, ", with rev ", mid_rev - start_rev
+        print("Reached ", cur_pos, ", with rev ", mid_rev - start_rev)
         mid_pos = cur_pos.copy()
 
         end_rev = mid_rev
@@ -2735,10 +2744,10 @@ class SpecifiedWinder(PiWalker):
 
         end_pos = cur_pos.copy()
 
-        print "Reached ", cur_pos, ", with rev ", end_rev - mid_rev
+        print("Reached ", cur_pos, ", with rev ", end_rev - mid_rev)
 
         self.walk_coords = [start_pos, mid_pos, end_pos]
-        print "Walk coords: ", self.walk_coords
+        print("Walk coords: ", self.walk_coords)
         PiWalker.setup(self)
 
 class OneFifthTwoFifthWinder(SpecifiedWinder):

--- a/old_projects/WindingNumber_G.py
+++ b/old_projects/WindingNumber_G.py
@@ -236,7 +236,7 @@ class Introduce1DFunctionCase(Scene):
                 axes.coords_to_point(x, 0),
                 axes.coords_to_point(x, f_graph.underlying_function(solution)),
             )
-            for x in axes.x_min, axes.x_max, solution
+            for x in (axes.x_min, axes.x_max, solution)
         ]
 
         equation = TexMobject("f(x)", "=", "g(x)")
@@ -1408,7 +1408,7 @@ class Rearrange2DEquation(AltTeacherStudentsScene):
     def construct(self):
         f_tex, g_tex, h_tex = [
             "%s(\\text{2d point})"%char
-            for char in "f", "g", "h" 
+            for char in ("f", "g", "h") 
         ]
         zero_tex = "\\vec{\\textbf{0}}"
         equations = VGroup(
@@ -2100,7 +2100,7 @@ class PathContainingZero(InputOutputScene, PiCreatureScene):
             morty.change, "pondering",
             *[
                 ShowCreation(mob, rate_func = bezier([0, 0, 1, 1]))
-                for mob in path, out_path
+                for mob in (path, out_path)
             ],
             run_time = 5
         )
@@ -2272,7 +2272,7 @@ class TransitionFromPathsToBoundaries(ColorMappedObjectsScene):
     def get_squares_and_joint_rect(self):
         squares = VGroup(*[
             Square(side_length = 4).next_to(ORIGIN, vect, buff = 0)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         joint_rect = SurroundingRectangle(squares, buff = 0)
         for mob in it.chain(squares, [joint_rect]):
@@ -2293,7 +2293,7 @@ class TransitionFromPathsToBoundaries(ColorMappedObjectsScene):
             rev = (get_output_rev() - self.start_rev)%1
             possible_windings = [
                 np.floor(self.curr_winding)+k+rev
-                for k in -1, 0, 1
+                for k in (-1, 0, 1)
             ]
             i = np.argmin([abs(pw - self.curr_winding) for pw in possible_windings])
             self.curr_winding = possible_windings[i]
@@ -2369,7 +2369,7 @@ class BreakDownLoopWithNonzeroWinding(TransitionFromPathsToBoundaries):
         both_cannot_be_zero.to_edge(UP)
         arrows = VGroup(*[
             Arrow(both_cannot_be_zero.get_bottom(), var.get_top(), buff = SMALL_BUFF)
-            for var in x, y
+            for var in (x, y)
         ])
 
         self.position_dot(joint_rect.points[0])
@@ -2579,7 +2579,7 @@ class PolynomialTerms(MonomialTerm):
                 background_image_file = self.input_coloring.background_image_file ,
                 stroke_width = 4,
             )
-            for u in -1, 1
+            for u in (-1, 1)
         ]
         out_line = line.copy()
         update_out_line = UpdateFromFunc(

--- a/old_projects/basel/basel.py
+++ b/old_projects/basel/basel.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 from once_useful_constructs.light import *
@@ -147,7 +148,7 @@ class LightIndicator(VMobject):
 
     def continual_update(self):
         if self.light_source == None:
-            print "Indicator cannot update, reason: no light source found"
+            print("Indicator cannot update, reason: no light source found")
         self.set_intensity(self.measured_intensity())
 
         
@@ -176,9 +177,9 @@ class ContinualLightIndicatorUpdate(ContinualAnimation):
 
 def copy_func(f):
     """Based on http://stackoverflow.com/a/6528148/190597 (Glenn Maynard)"""
-    g = types.FunctionType(f.func_code, f.func_globals, name=f.func_name,
-                           argdefs=f.func_defaults,
-                           closure=f.func_closure)
+    g = types.FunctionType(f.__code__, f.__globals__, name=f.__name__,
+                           argdefs=f.__defaults__,
+                           closure=f.__closure__)
     g = functools.update_wrapper(g, f)
     return g
 
@@ -2552,7 +2553,7 @@ class InscribedAngleScene(ThreeDScene):
             show_animation = (onscreen_old or onscreen_1 or onscreen_2)
 
             if show_animation:
-                print "animating (", i, ",", step, ")"
+                print("animating (", i, ",", step, ")")
                 self.play(
                     ApplyMethod(ls1.move_source_to,ls_new_loc1, run_time = run_time),
                     ApplyMethod(ls2.move_source_to,ls_new_loc2, run_time = run_time),
@@ -3333,7 +3334,7 @@ class PondScene(ThreeDScene):
             show_animation = (onscreen_old or onscreen_1 or onscreen_2)
 
             if show_animation or animate:
-                print "animating (", i, ",", step, ")"
+                print("animating (", i, ",", step, ")")
                 self.play(
                     ApplyMethod(ls1.move_source_to,ls_new_loc1, run_time = run_time),
                     ApplyMethod(ls2.move_source_to,ls_new_loc2, run_time = run_time),
@@ -3671,7 +3672,7 @@ class PondScene(ThreeDScene):
         self.play(FadeOut(self.inner_lake))
 
         for n in range(3,max_it + 1):
-            print "working on n = ", n, "..."
+            print("working on n = ", n, "...")
             new_lake = self.outer_lake.copy().scale(2,about_point = self.obs_dot.get_center())
             for (i,ls) in enumerate(self.light_sources_array[:2**n]):
                 #print i
@@ -3702,14 +3703,14 @@ class PondScene(ThreeDScene):
                 onscreen_2 = np.all(np.abs(pos2[:2]) < 10 * 2**2)
                 
                 if onscreen_old or onscreen_1:
-                    print "anim1 for step", n, "part", i
-                    print "------------------ moving from", ls_old_loc[:2], "to", pos1[:2]
+                    print("anim1 for step", n, "part", i)
+                    print("------------------ moving from", ls_old_loc[:2], "to", pos1[:2])
                     shift_list.append(ApplyMethod(ls1.move_source_to, pos1, run_time = STEP_RUN_TIME))
                 else:
                     ls1.move_source_to(pos1)
                 if onscreen_old or onscreen_2:
-                    print "anim2 for step", n, "part", i
-                    print "------------------ moving from", ls_old_loc[:2], "to", pos2[:2]
+                    print("anim2 for step", n, "part", i)
+                    print("------------------ moving from", ls_old_loc[:2], "to", pos2[:2])
                     shift_list.append(ApplyMethod(ls2.move_source_to, pos2, run_time = STEP_RUN_TIME))
                 else:
                     ls2.move_source_to(pos2)
@@ -3718,7 +3719,7 @@ class PondScene(ThreeDScene):
                 #print shift_list
 
             self.play(*shift_list)
-            print "...done"
+            print("...done")
 
 
         #self.revert_to_original_skipping_status()
@@ -3745,9 +3746,9 @@ class PondScene(ThreeDScene):
             label_direction = UP,
         ).shift(origin_point - self.number_line.number_to_point(0)) # .shift(scale * 2.5 * DOWN)
 
-        print "scale ", scale
-        print "number line at", self.number_line.get_center()
-        print "should be at", origin_point, "or", OBSERVER_POINT
+        print("scale ", scale)
+        print("number line at", self.number_line.get_center())
+        print("should be at", origin_point, "or", OBSERVER_POINT)
 
         self.number_line.tick_marks.fade(1)
         self.number_line_labels = self.number_line.get_number_mobjects()

--- a/old_projects/basel/basel2.py
+++ b/old_projects/basel/basel2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 from once_useful_constructs.light import *
 
@@ -128,7 +129,7 @@ class LightIndicator(Mobject):
 
     def continual_update(self):
         if self.light_source == None:
-            print "Indicator cannot update, reason: no light source found"
+            print("Indicator cannot update, reason: no light source found")
         self.set_intensity(self.measured_intensity())
 
 class UpdateLightIndicator(AnimationGroup):
@@ -152,9 +153,9 @@ class ContinualLightIndicatorUpdate(ContinualAnimation):
 
 def copy_func(f):
     """Based on http://stackoverflow.com/a/6528148/190597 (Glenn Maynard)"""
-    g = types.FunctionType(f.func_code, f.func_globals, name=f.func_name,
-                           argdefs=f.func_defaults,
-                           closure=f.func_closure)
+    g = types.FunctionType(f.__code__, f.__globals__, name=f.__name__,
+                           argdefs=f.__defaults__,
+                           closure=f.__closure__)
     g = functools.update_wrapper(g, f)
     return g
 
@@ -348,7 +349,7 @@ class IntroScene(PiCreatureScene):
         rect_label_anims = []
 
         for i, t1, t2 in zip(it.count(1), [0]+series_terms, series_terms):
-            color = slab_colors.next()
+            color = next(slab_colors)
             line = Line(*map(number_line.number_to_point, [t1, t2]))
             rect = Rectangle(
                 stroke_width = 0,
@@ -2115,7 +2116,7 @@ class TwoLightSourcesScene(ManipulateLightsourceSetups):
                 buff = SMALL_BUFF,
                 color = WHITE,
             )
-            for ls in lsA, lsB, lsC
+            for ls in (lsA, lsB, lsC)
         ])
 
         #Lines
@@ -3813,7 +3814,7 @@ class ThinkBackToHowAmazingThisIs(ThreeDScene):
                 Dot(number_line.number_to_point(u*x))
                 for x in range(1, int(self.x_radius), 2)
             ])
-            for u in 1, -1
+            for u in (1, -1)
         ]
         dot_pairs = it.starmap(VGroup, zip(positive_dots, negative_dots))
 
@@ -3843,7 +3844,7 @@ class ThinkBackToHowAmazingThisIs(ThreeDScene):
                 TexMobject("+").next_to(
                     number_line.number_to_point(u*n), UP, buff = 1.25,
                 )
-                for u in -1, 1
+                for u in (-1, 1)
             ])
             for n in range(0, self.max_shown_n, 2)
         ])
@@ -3890,7 +3891,7 @@ class ThinkBackToHowAmazingThisIs(ThreeDScene):
         circle = everything.copy()
         circle.move_to(ORIGIN)
         circle.apply_function(
-            lambda (x, y, z) : complex_to_R3(7*np.exp(complex(0, 0.0315*x)))
+            lambda x_y_z : complex_to_R3(7*np.exp(complex(0, 0.0315*x_y_z[0])))
         )
         circle.rotate(-TAU/4, about_point = ORIGIN)
         circle.center()

--- a/old_projects/bell.py
+++ b/old_projects/bell.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
 from big_ol_pile_of_manim_imports import *
 
 from tqdm import tqdm as ProgressDisplay
 
-from waves import *
+from .waves import *
+from functools import reduce
 
 #force_skipping
 #revert_to_original_skipping_status
@@ -193,7 +195,7 @@ class PhotonsThroughPerpendicularFilters(PhotonPassesCompletelyOrNotAtAll):
                 em_wave = self.em_wave.copy(),
                 run_time = 1,
             )
-            for x in -2, 2, 10
+            for x in (-2, 2, 10)
         ]
 
     def get_probability_text(self, prob = 0):
@@ -590,7 +592,7 @@ class ShowVariousFilterPairsWithPhotonsOverTime(PhotonsThroughPerpendicularFilte
         "filter_x_coordinates" : [-2, 2, 2, 2, 2],
         "pol_filter_configs" : [
             {"filter_angle" : angle}
-            for angle in 0, 0, np.pi/2, np.pi/4, np.pi/8
+            for angle in (0, 0, np.pi/2, np.pi/4, np.pi/8)
         ],
         "apply_filter" : False,
     }
@@ -838,7 +840,7 @@ class ShowVariousFilterPairs(ShowVariousFilterPairsWithPhotonsOverTime):
         n = self.n_lines
         start, end = [
             (f.point_from_proportion(0.75) if f is not None else None)
-            for f in filter1, filter2
+            for f in (filter1, filter2)
         ]
         if start is None:
             start = end + self.line_start_length*LEFT
@@ -878,7 +880,7 @@ class ShowVariousFilterPairsFrom0To45(ShowVariousFilterPairs):
 
         cosines = VGroup(*[
             TexMobject("\\cos^2(%s^\\circ)"%str(x))
-            for x in 45, 22.5
+            for x in (45, 22.5)
         ])
         cosines.scale(0.8)
         # cosines.set_color(BLUE)
@@ -896,7 +898,7 @@ class ForgetPreviousActions(ShowVariousFilterPairs):
         "filter_x_coordinates" : [-6, -2, 2, 2, 2],
         "pol_filter_configs" : [
             {"filter_angle" : angle}
-            for angle in np.pi/4, 0, np.pi/4, np.pi/3, np.pi/6
+            for angle in (np.pi/4, 0, np.pi/4, np.pi/3, np.pi/6)
         ],
         "start_theta" : -0.6*np.pi,
         "EMWave_config" : {
@@ -1393,7 +1395,7 @@ class VennDiagramProofByContradiction(Scene):
                     "%s \\\\"%start,
                     "through", char + "$\\! \\uparrow$"
                 ).set_color_by_tex(char, circle.get_color())
-                for start in "Would pass", "Pass"
+                for start in ("Would pass", "Pass")
             ]
             for mob in label, alt_label:
                 mob[-1][-1].rotate_in_place(-angle)
@@ -1976,7 +1978,7 @@ class VennDiagramProofByContradiction(Scene):
                 fill_opacity = 0.5,
                 fill_color = YELLOW,
             )
-            for s in "in_A_out_B", "in_A_in_B_out_C", "in_A_out_C", "in_A_in_B"
+            for s in ("in_A_out_B", "in_A_in_B_out_C", "in_A_out_C", "in_A_in_B")
         ])
 
         in_A_out_B.scale(2.59)
@@ -2383,7 +2385,7 @@ class NoFirstMeasurementPreferenceBasedOnDirection(ShowVariousFilterPairs):
         "filter_x_coordinates" : [0, 0, 0],
         "pol_filter_configs" : [
             {"filter_angle" : angle}
-            for angle in 0, np.pi/8, np.pi/4
+            for angle in (0, np.pi/8, np.pi/4)
         ],
         "lines_depth" : 1.2,
         "lines_shift_vect" : SMALL_BUFF*OUT,

--- a/old_projects/borsuk.py
+++ b/old_projects/borsuk.py
@@ -1,4 +1,5 @@
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 class Jewel(VMobject):
     CONFIG = {
@@ -943,7 +944,7 @@ class WalkEquatorPostTransform(GraphScene):
                 curve.x_collision_points[i]
                 for curve in gerat_arc_images
             ]
-            for i in 0, 1
+            for i in (0, 1)
         ]))
         full_curve = VMobject(close_new_points = True)
         full_curve.set_points_smoothly(points + [points[0]])
@@ -1818,7 +1819,7 @@ class ChoicesInNecklaceCutting(ReconfigurableScene):
         for group in groups:
             group.target_points = [
                 group.get_center() + self.thief_box_offset*vect
-                for vect in UP, DOWN
+                for vect in (UP, DOWN)
             ]
 
         return groups
@@ -1835,7 +1836,7 @@ class ChoicesInNecklaceCutting(ReconfigurableScene):
 
         boxes = VGroup(*[
             box.copy().shift(self.thief_box_offset*vect)
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ])
         labels = VGroup(*[
             TextMobject(
@@ -2083,7 +2084,7 @@ class NecklaceDivisionSphereAssociation(ChoicesInNecklaceCutting):
                 TexMobject(
                     char, "=", sign, "\\sqrt{\\frac{1}{%d}}"%denom
                 )
-                for sign in "+", "-"
+                for sign in ("+", "-")
             ]
             for choice, color in zip(choices, [GREEN, RED]):
                 # choice[0].set_color(brace.label.get_color())
@@ -2216,7 +2217,7 @@ class TotalLengthOfEachJewelEquals(NecklaceDivisionSphereAssociation, ThreeDScen
                     lambda segment: segment.get_color() == color,
                     segment_group
                 ))
-                for segment_group in top_segments, bottom_segments
+                for segment_group in (top_segments, bottom_segments)
             ]
             labels = VGroup()
             for i, group in enumerate(monochrome_groups):
@@ -2304,7 +2305,7 @@ class ShowFunctionDiagram(TotalLengthOfEachJewelEquals, ReconfigurableScene):
                 skip_animations = True, 
                 thief_number = x
             )
-            for x in 1, 2
+            for x in (1, 2)
         ]
         t1_plane, t2_plane = planes = VGroup(*[
             VGroup(*plane_class.get_top_level_mobjects())

--- a/old_projects/brachistochrone/curves.py
+++ b/old_projects/brachistochrone/curves.py
@@ -353,7 +353,7 @@ class TransitionAwayFromSlide(PathSlidingScene):
         arrow = Arrow(ORIGIN, 2*RIGHT)
         arrows = Mobject(*[
             arrow.copy().shift(vect)
-            for vect in 3*LEFT, ORIGIN, 3*RIGHT
+            for vect in (3*LEFT, ORIGIN, 3*RIGHT)
         ])
         arrows.shift(FRAME_WIDTH*RIGHT)
         self.add(arrows)

--- a/old_projects/brachistochrone/cycloid.py
+++ b/old_projects/brachistochrone/cycloid.py
@@ -36,7 +36,7 @@ class CycloidScene(Scene):
     def grow_parts(self):
         self.play(*[
             ShowCreation(mob)
-            for mob in self.circle, self.ceiling
+            for mob in (self.circle, self.ceiling)
         ])
 
     def generate_cycloid(self):
@@ -295,7 +295,7 @@ class LeviSolution(CycloidScene):
         self.wait()
         self.play(*[
             Transform(mob, d_mob)
-            for mob in brace, diameter_word
+            for mob in (brace, diameter_word)
         ])
         self.remove(brace, diameter_word)
         self.add(d_mob)

--- a/old_projects/brachistochrone/drawing_images.py
+++ b/old_projects/brachistochrone/drawing_images.py
@@ -255,7 +255,7 @@ class NewtonVsJohann(Scene):
     def construct(self):
         newton, johann = [
             ImageMobject(name, invert = False).scale(0.5)
-            for name in "Newton", "Johann_Bernoulli2"
+            for name in ("Newton", "Johann_Bernoulli2")
         ]
         greater_than = TexMobject(">")
         newton.next_to(greater_than, RIGHT)
@@ -277,7 +277,7 @@ class JohannThinksOfFermat(Scene):
     def construct(self):
         johann, fermat = [
             ImageMobject(name, invert = False)
-            for name in "Johann_Bernoulli2", "Pierre_de_Fermat"
+            for name in ("Johann_Bernoulli2", "Pierre_de_Fermat")
         ]
         johann.scale(0.2)
         johann.to_corner(DOWN+LEFT)

--- a/old_projects/brachistochrone/graveyard.py
+++ b/old_projects/brachistochrone/graveyard.py
@@ -69,7 +69,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
         )
         top_rgb, bottom_rgb = [
             np.array(Color(color).get_rgb())
-            for color in self.top_color, self.bottom_color
+            for color in (self.top_color, self.bottom_color)
         ]
         epsilon = 1./(self.num_discrete_layers-1)
         self.layer_colors = [
@@ -239,7 +239,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
     def show_snells(self, index, frame):
         left_text, right_text = [
             "\\dfrac{\\sin(\\theta_%d)}{\\phantom{\\sqrt{y_1}}}"%x
-            for x in index, index+1
+            for x in (index, index+1)
         ]
         left, equals, right = TexMobject(
             [left_text, "=", right_text]
@@ -251,7 +251,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
                 TexMobject(
                     text, size = "\\Large"
                 ).next_to(numerator, DOWN)
-                for text in "v_%d"%x, "\\sqrt{y_%d}"%x
+                for text in ("v_%d"%x, "\\sqrt{y_%d}"%x)
             ]
             vs.append(v)
             sqrt_ys.append(sqrt_y)
@@ -259,7 +259,7 @@ class MultilayeredGlass(PhotonScene, ZoomedScene):
             Mobject(
                 left.copy(), mobs[0], equals.copy(), right.copy(), mobs[1]
             ).replace(frame)
-            for mobs in vs, sqrt_ys
+            for mobs in (vs, sqrt_ys)
         ]
 
         self.add(start)

--- a/old_projects/brachistochrone/light.py
+++ b/old_projects/brachistochrone/light.py
@@ -499,7 +499,7 @@ class GeometryOfGlassSituation(ShowMultiplePathsInWater):
         new_graph.reverse_points()
         pairs_for_end_transform = [
             (mob, mob.copy())
-            for mob in top_line, bottom_line, left_brace, x_mob
+            for mob in (top_line, bottom_line, left_brace, x_mob)
         ]
 
         self.add(glass, point_a, point_b, A, B)
@@ -636,7 +636,7 @@ class SpringSetup(ShowMultiplePathsInWater):
                 Spring(self.start_point, r.get_top()),
                 Spring(self.end_point, r.get_bottom())
             )
-            for r in ring, ring.copy().shift(self.ring_shift_val)
+            for r in (ring, ring.copy().shift(self.ring_shift_val))
         ]
         
     def add_rod_and_ring(self, rod, ring):
@@ -663,7 +663,7 @@ class SpringSetup(ShowMultiplePathsInWater):
     def add_springs(self):
         colors = iter([BLACK, BLUE_E])
         for spring in self.start_springs.split():
-            circle = Circle(color = colors.next())
+            circle = Circle(color = next(colors))
             circle.reverse_points()
             circle.scale(spring.loop_radius)
             circle.shift(spring.points[0])
@@ -725,7 +725,7 @@ class SpringSetup(ShowMultiplePathsInWater):
             arc = Arc(angle, radius = 0.5).rotate(np.pi/2)
             if point is self.end_point:
                 arc.rotate(np.pi)
-            theta = TexMobject("\\theta_%d"%counter.next())
+            theta = TexMobject("\\theta_%d"%next(counter))
             theta.scale(0.5)
             theta.shift(2*arc.get_center())
             arc.shift(ring_center)
@@ -765,7 +765,7 @@ class SpringSetup(ShowMultiplePathsInWater):
         frac1, sin1, equals, frac2, sin2 = equation.split()
         v_air, v_water = [
             TexMobject("v_{\\text{%s}}"%s, size = "\\Large")
-            for s in "air", "water"
+            for s in ("air", "water")
         ]
         v_air.next_to(Point(frac1.get_center()), DOWN)
         v_water.next_to(Point(frac2.get_center()), DOWN)
@@ -773,7 +773,7 @@ class SpringSetup(ShowMultiplePathsInWater):
         frac2.add(v_water)
         f1, f2 = [
             TexMobject("F_%d"%d, size = "\\Large") 
-            for d in 1, 2
+            for d in (1, 2)
         ]
         f1.next_to(sin1, LEFT)
         f2.next_to(equals, RIGHT)
@@ -875,7 +875,7 @@ class StateSnellsLaw(PhotonScene):
             if point is point_b:
                 arc.rotate(np.pi)
                 line.reverse_points()
-            theta = TexMobject("\\theta_%d"%counter.next())
+            theta = TexMobject("\\theta_%d"%next(counter))
             theta.scale(0.5)
             theta.shift(2*arc.get_center())
             arc.shift(midpoint)

--- a/old_projects/brachistochrone/misc.py
+++ b/old_projects/brachistochrone/misc.py
@@ -7,7 +7,8 @@ from brachistochrone.curves import Cycloid
 class PhysicalIntuition(Scene):
     def construct(self):
         n_terms = 4
-        def func((x, y, ignore)):
+        def func(xxx_todo_changeme):
+            (x, y, ignore) = xxx_todo_changeme
             z = complex(x, y)                                    
             if (np.abs(x%1 - 0.5)<0.01 and y < 0.01) or np.abs(z)<0.01:
                 return ORIGIN
@@ -87,7 +88,7 @@ class TimeLine(Scene):
         for point, event in zip(centers[1:], dated_events):
             self.play(ApplyMethod(
                 timeline.shift, -point.get_center(), 
-                run_time = run_times.next()
+                run_time = next(run_times)
             ))
             picture = ImageMobject(event["picture"], invert = False)
             picture.scale_to_fit_width(2)

--- a/old_projects/brachistochrone/multilayered.py
+++ b/old_projects/brachistochrone/multilayered.py
@@ -23,7 +23,7 @@ class MultilayeredScene(Scene):
         height = float(self.total_glass_height)/n_layers
         rgb_pair = [
             np.array(Color(color).get_rgb())
-            for color in self.top_color, self.bottom_color
+            for color in (self.top_color, self.bottom_color)
         ]
         rgb_range = [
             interpolate(*rgb_pair+[x])
@@ -253,7 +253,7 @@ class ShowLayerVariables(MultilayeredScene, PhotonScene):
                 )
                 for mob, start in zip(mobs, starts)
             ]
-            for mobs in start_ys, braces
+            for mobs in (start_ys, braces)
         ]))
         self.wait()
 

--- a/old_projects/complex_multiplication_article.py
+++ b/old_projects/complex_multiplication_article.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import sys
 
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 DEFAULT_PLANE_CONFIG = {
     "stroke_width" : 2*DEFAULT_POINT_THICKNESS

--- a/old_projects/counting_in_binary.py
+++ b/old_projects/counting_in_binary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import numpy as np
 import itertools as it
 from copy import deepcopy

--- a/old_projects/crypto.py
+++ b/old_projects/crypto.py
@@ -140,7 +140,7 @@ class ListOfAttributes(Scene):
                 fill_opacity = 1,
                 stroke_width = 0,
             )
-            for word in "government", "bank"
+            for word in ("government", "bank")
         ]
         attributes = VGroup(digital, *buildings)
         attributes.arrange_submobjects(RIGHT, buff = LARGE_BUFF)
@@ -809,7 +809,7 @@ class IntroduceLedgerSystem(LedgerScene):
         self.wait()
         debtor_cash, creditor_cash = [
             VGroup(*it.chain(*[pi.cash for pi in group]))
-            for group in debtors, creditors
+            for group in (debtors, creditors)
         ]
         self.play(FadeIn(debtor_cash))
         self.play(
@@ -1691,7 +1691,7 @@ class LedgerWithInitialBuyIn(SignedLedgerScene):
     def point_out_charlie_is_broke(self):
         charlie_lines = VGroup(*[
             VGroup(*self.ledger.content[i][1:5])
-            for i in 3, 5, 6, 7
+            for i in (3, 5, 6, 7)
         ])
         rects = VGroup(*[
             SurroundingRectangle(line)
@@ -1722,11 +1722,11 @@ class LedgerWithInitialBuyIn(SignedLedgerScene):
     def running_balance(self):
         charlie_lines = VGroup(*[
             VGroup(*self.ledger.content[i][1:5])
-            for i in 3, 5, 6, 7
+            for i in (3, 5, 6, 7)
         ])
         signatures = VGroup(*[
             self.ledger.content[i][5]
-            for i in 5, 6, 7
+            for i in (5, 6, 7)
         ])
         rect = Rectangle(color = WHITE)
         rect.set_fill(BLACK, 0.8)
@@ -2770,7 +2770,7 @@ class IntroduceNonceOnTrasactions(LedgerScene):
         self.play(LaggedStart(
             ReplacementTransform, 
             VGroup(*[point.copy() for x in range(256)]),
-            lambda m : (m, bit_iter.next()),
+            lambda m : (m, next(bit_iter)),
         ))
         self.remove(*self.get_mobjects_from_last_animation())
         self.add(digest)
@@ -3181,7 +3181,7 @@ class IntroduceBlockChain(Scene):
             Line(
                 rect.get_left(), rect.get_right()
             ).shift(0.3*rect.get_height()*vect)
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ]
 
         payments = VGroup()
@@ -4674,7 +4674,7 @@ class CompareBlockTimes(Scene):
         self.wait()
         self.play(*[
             LaggedStart(FadeIn, VGroup(*group[1:]))
-            for group in examples, logos
+            for group in (examples, logos)
         ])
         self.wait(2)
 

--- a/old_projects/domino_play.py
+++ b/old_projects/domino_play.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 
@@ -804,7 +805,7 @@ class ShowAllSteadyStateVelocities(SimpleVelocityGraph):
             )
             self.add(dot)
             self.add(label)
-            print index_str, self.velocities[-1], self.friction
+            print(index_str, self.velocities[-1], self.friction)
 
 class Test(Scene):
     def construct(self):
@@ -871,7 +872,7 @@ class Test(Scene):
             run_time = 3,
         ))
 
-        print arc1.angle, arc2.angle
+        print(arc1.angle, arc2.angle)
 
 
 

--- a/old_projects/efvgt.py
+++ b/old_projects/efvgt.py
@@ -932,7 +932,7 @@ class AddCircleSymmetries(CircleSymmetries):
         for term, arc in zip(equation[::2], arcs):
             self.play(*[
                 ApplyMethod(mob.scale_in_place, 1.2, rate_func = there_and_back)
-                for mob in term, arc
+                for mob in (term, arc)
             ])
             self.wait()
 
@@ -1001,7 +1001,7 @@ class AddCubeSymmetries(GroupOfCubeSymmetries):
                     start_angle = np.pi/12+a, angle = 5*np.pi/6,
                     color = YELLOW
                 ).add_tip()
-                for a in 0, np.pi
+                for a in (0, np.pi)
             ])
             arrows.scale_to_fit_height(1.5*cube.get_height())
             z_to_axis = z_to_vector(axis)
@@ -1843,7 +1843,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
                 self.number_line.number_to_point(num),
                 self.shadow_line.number_to_point(num)
             )
-            for num in 3, 0.5
+            for num in (3, 0.5)
         ]
         three_mob = filter(
             lambda m : m.get_tex_string() == "3",
@@ -1927,7 +1927,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
                 self.number_line.number_to_point(num),
                 self.shadow_line.number_to_point(num)
             )
-            for num in 0.33, 1
+            for num in (0.33, 1)
         ]
 
         self.play(
@@ -1965,7 +1965,7 @@ class MultiplicativeGroupOfReals(AdditiveGroupOfReals):
     def compose_actions(self, num1, num2):
         words = VGroup(*[
             TextMobject("(%s by %s)"%(word, str(num)))
-            for num in num1, num2, num1*num2
+            for num in (num1, num2, num1*num2)
             for word in ["Stretch" if num > 1 else "Squish"]
         ])
         words.submobjects.insert(2, TexMobject("="))
@@ -2727,7 +2727,7 @@ class ExponentsAsHomomorphism(Scene):
             self.wait()
         self.play(*[
             line.restore 
-            for line in self.top_line, self.bottom_line
+            for line in (self.top_line, self.bottom_line)
         ])
 
     def get_stretch_anim(self, bottom_line, x):
@@ -3334,7 +3334,7 @@ class ExpTransformation(ComplexTransformationScene):
         self.prepare_for_transformation(self.plane)
         final_plane = self.plane.copy().apply_complex_function(np.exp)
         cylinder = self.plane.copy().apply_function(
-            lambda (x, y, z) : np.array([x, np.sin(y), -np.cos(y)])
+            lambda x_y_z : np.array([x_y_z[0], np.sin(x_y_z[1]), -np.cos(x_y_z[1])])
         )
         title = TexMobject("x \\to e^x")
         title.add_background_rectangle()

--- a/old_projects/eoc/chapter1.py
+++ b/old_projects/eoc/chapter1.py
@@ -385,7 +385,7 @@ class PreviewFrame(Scene):
 
         colors = iter(color_gradient([BLUE, YELLOW], 3))
         titles = [
-            TextMobject("Chapter %d:"%d, s).to_edge(UP).set_color(colors.next())
+            TextMobject("Chapter %d:"%d, s).to_edge(UP).set_color(next(colors))
             for d, s in [
                 (3, "Derivative formulas through geometry"),
                 (4, "Chain rule, product rule, etc."),
@@ -483,7 +483,7 @@ class ProductRuleDiagram(Scene):
         self.play(MoveToTarget(fg_group))
         self.play(*[
             mob.restore
-            for mob in df_brace, df_label, dg_brace, dg_label
+            for mob in (df_brace, df_label, dg_brace, dg_label)
         ] + [
             ReplacementTransform(d_rect.line, d_rect)
             for d_rect in d_rects
@@ -521,11 +521,11 @@ class ProductRuleDiagram(Scene):
                 (g_label, "g"),
                 (df_label, "df"),
             ]
-            for alpha in [alpha_iter.next()]
+            for alpha in [next(alpha_iter)]
         ]+[
             Write(VGroup(*it.chain(*[
                 deriv.get_parts_by_tex(tex, substring = False)
-                for tex in "d(", ")", "=", "\\cdot", "+"
+                for tex in ("d(", ")", "=", "\\cdot", "+")
             ])))
         ], run_time = 3)
         self.wait()
@@ -820,7 +820,7 @@ class ApproximateOneRing(CircleScene, ReconfigurableScene):
                 self.unwrapped_ring, vect, buff = SMALL_BUFF,
                 min_num_quads = 2,
             )
-            for vect in UP, LEFT
+            for vect in (UP, LEFT)
         ]
         top_brace.scale_in_place(self.ring.R/(self.ring.R+self.dR))
         side_brace.set_stroke(WHITE, 0.5)
@@ -1041,7 +1041,7 @@ class GraphRectangles(CircleScene, GraphScene):
                 color = YELLOW,
                 tip_length = 0.15
             )
-            for tick in r_ticks[0], r_ticks[-1]
+            for tick in (r_ticks[0], r_ticks[-1])
         ])
         first_tick = r_ticks[0].copy()
         moving_arrow = arrows[0].copy()
@@ -1094,7 +1094,7 @@ class GraphRectangles(CircleScene, GraphScene):
                 start_color = self.rings[0].get_fill_color(),
                 end_color = self.rings[-1].get_fill_color(),
             )
-            for g in graph, flat_graph
+            for g in (graph, flat_graph)
         ]
         self.graph, self.flat_rects = graph, flat_rects
 
@@ -1303,7 +1303,7 @@ class GraphRectangles(CircleScene, GraphScene):
     def compute_area_under_graph(self):
         formula, formula_with_R = formulas = [
             self.get_area_formula(R)
-            for R in "3", "R"
+            for R in ("3", "R")
         ]
         for mob in formulas:
             mob.to_corner(UP+RIGHT, buff = MED_SMALL_BUFF)
@@ -2038,7 +2038,7 @@ class AreaUnderParabola(GraphScene):
                 FRAME_HEIGHT*UP, ORIGIN,
                 color = RED
             ).move_to(self.coords_to_point(x, 0), DOWN)
-            for x in 0, self.default_right_x
+            for x in (0, self.default_right_x)
         ])
 
         self.play(
@@ -2345,7 +2345,7 @@ class PlayingTowardsDADX(AreaUnderParabola, ReconfigurableScene):
                 deriv_equation.get_part_by_tex(tex),
                 run_time = 2,
             )
-            for tex in "dA", "approx", f_tex, "dx"
+            for tex in ("dA", "approx", f_tex, "dx")
         ] + [
             Write(deriv_equation.get_part_by_tex("over"))
         ])

--- a/old_projects/eoc/chapter10.py
+++ b/old_projects/eoc/chapter10.py
@@ -254,11 +254,11 @@ class Pendulum(ReconfigurableScene):
         self.height_tex_R = height_tex_R
         self.cosine = VGroup(*[
             height_tex.get_part_by_tex(tex)
-            for tex in "cos", "theta", ")"
+            for tex in ("cos", "theta", ")")
         ])
         self.one_minus = VGroup(*[
             height_tex.get_part_by_tex(tex)
-            for tex in "\\big(1-", "\\big)"
+            for tex in ("\\big(1-", "\\big)")
         ])
 
     def get_angry_at_cosine(self):
@@ -500,9 +500,9 @@ class ExampleApproximationWithCos(ExampleApproximationWithSine):
                     line_class = DashedLine,
                     color = YELLOW
                 )
-                for u in -1, 1
+                for u in (-1, 1)
             ])
-            for dx in 0.01, 0.7
+            for dx in (0.01, 0.7)
         ]
 
         self.play(*map(ShowCreation, v_lines), run_time = 2)
@@ -1101,7 +1101,7 @@ class ReflectOnQuadraticApproximation(TeacherStudentsScene):
                 "\\cos(", s, ")", "\\approx",
                 "1 - \\frac{1}{2}", "(", s, ")", "^2"
             ).next_to(self.get_students(), UP, 2)
-            for s in "x", "0.1",
+            for s in ("x", "0.1",)
         ]
         approx_rhs = TexMobject("=", "0.995")
         approx_rhs.next_to(approx_at_point, RIGHT)
@@ -1612,7 +1612,7 @@ class CubicAndQuarticApproximations(ConstructQuadraticApproximation):
 
             possibly_added_anims = []
             try:
-                possibly_added_anims.append(added_anims_iter.next())
+                possibly_added_anims.append(next(added_anims_iter))
             except:
                 pass
 
@@ -1779,7 +1779,7 @@ class HigherTermsDontMessUpLowerTerms(Scene):
         polynomial.shift(2*LEFT + UP)
         c0, c2, c4 = [
             polynomial.get_part_by_tex(tex)
-            for tex in c0_tex, c2_tex, c4_tex
+            for tex in (c0_tex, c2_tex, c4_tex)
         ]
         for term, color in zip([c0, c2, c4], self.colors):
             term.set_color(color)
@@ -2046,7 +2046,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
         )
         outer_v_lines = VGroup(*[
             center_v_line.copy().shift(vect)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         outer_v_lines.set_color(GREEN)
         dot = Dot(color = YELLOW)
@@ -2101,7 +2101,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
                     "-\\cos", "\\sin", "\\cos"
                 ]
             ])
-            for arg in "x", "0"
+            for arg in ("x", "0")
         ]
         arrows = VGroup(*[
             Arrow(
@@ -2268,7 +2268,7 @@ class TranslationOfInformation(CubicAndQuarticApproximations):
                     ("\\frac{d^4 f}{dx^4}", "(", arg, ")"),
                 ]
             ])
-            for arg in "x", "0", "a"
+            for arg in ("x", "0", "a")
         ]
         derivs_at_x.arrange_submobjects(DOWN, buff = MED_LARGE_BUFF)
         derivs_at_x.scale_to_fit_height(FRAME_HEIGHT - MED_LARGE_BUFF)
@@ -2513,7 +2513,7 @@ class ExpPolynomial(TranslationOfInformation, ExampleApproximationWithExp):
                 TexMobject("e^%s"%s).set_color(c)
                 for c in self.colors
             ])
-            for s in "x", "0"
+            for s in ("x", "0")
         ]
         derivs_at_x.submobjects[0] = self.e_to_x.target
         arrows = VGroup(*[
@@ -2698,7 +2698,7 @@ class SecondTermIntuition(AreaIsDerivative):
                     new_t_max = target,
                     run_time = 3,
                 )
-        self.func_name = func_name
+        self.__name__ = func_name
 
     def write_derivative(self):
         deriv = TexMobject("\\frac{df_{\\text{area}}}{dx}(x)")
@@ -2826,7 +2826,7 @@ class SecondTermIntuition(AreaIsDerivative):
         tex_scale_factor = 0.7
         base_line = Line(*[
             triangle.get_corner(DOWN+vect)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         base_line.set_color(RED)
         base_label = TextMobject("Base = ", "$(x-a)$")
@@ -2905,7 +2905,7 @@ class SecondTermIntuition(AreaIsDerivative):
     def walk_through_taylor_terms(self):
         mini_area, mini_rect, mini_triangle = [
             mob.copy()
-            for mob in self.dark_area, self.rect, self.triangle
+            for mob in (self.dark_area, self.rect, self.triangle)
         ]
         mini_area.set_fill(BLUE_E, opacity = 1)
         mini_area.scale_to_fit_height(1)
@@ -2939,7 +2939,7 @@ class SecondTermIntuition(AreaIsDerivative):
             part.add_to_back(BackgroundRectangle(part))
 
         new_func_name = TexMobject("f_{\\text{area}}(a)")
-        new_func_name.replace(self.func_name)
+        new_func_name.replace(self.__name__)
 
         self.play(FadeIn(
             geometric_taylor,
@@ -2950,7 +2950,7 @@ class SecondTermIntuition(AreaIsDerivative):
         self.play(
             FadeIn(VGroup(*analytic_taylor[:3])),
             self.dark_area.set_fill, BLUE_E, 1,
-            Transform(self.func_name, new_func_name)
+            Transform(self.__name__, new_func_name)
         )
         self.wait()
         self.play(
@@ -3302,7 +3302,7 @@ class BoundedRadiusOfConvergence(CubicAndQuarticApproximations):
                 self.coords_to_point(x, 2),
                 color = WHITE
             )
-            for x in -1, 1
+            for x in (-1, 1)
         ])
 
         colors = list(self.colors) + [GREEN, MAROON_B, PINK]
@@ -3400,15 +3400,15 @@ class RadiusOfConvergenceForLnX(ExpGraphConvergence):
         v_lines = [
             DashedLine(*[
                 self.coords_to_point(x, y)
-                for y in -2, 2
+                for y in (-2, 2)
             ])
-            for x in 0, 1, 2
+            for x in (0, 1, 2)
         ]
         outer_v_lines = VGroup(*v_lines[::2])
         center_v_line = VGroup(v_lines[1])
         input_v_line = Line(*[
             self.coords_to_point(self.convergent_example, y)
-            for y in -4, 3
+            for y in (-4, 3)
         ])
         input_v_line.set_stroke(WHITE, width = 2)
 
@@ -3535,7 +3535,7 @@ class RadiusOfConvergenceForLnX(ExpGraphConvergence):
     def write_radius_of_convergence(self):
         line = Line(*[
             self.coords_to_point(x, 0)
-            for x in 1, 2
+            for x in (1, 2)
         ])
         line.set_color(YELLOW)
         brace = Brace(line, DOWN)

--- a/old_projects/eoc/chapter2.py
+++ b/old_projects/eoc/chapter2.py
@@ -331,7 +331,7 @@ class GraphCarTrajectory(GraphScene):
     def introduce_graph(self, graph, origin):
         h_line, v_line = [
             Line(origin, origin, color = color, stroke_width = 2)
-            for color in TIME_COLOR, DISTANCE_COLOR
+            for color in (TIME_COLOR, DISTANCE_COLOR)
         ]
         def h_update(h_line, proportion = 1):
             end = graph.point_from_proportion(proportion)
@@ -931,7 +931,7 @@ class CompareTwoVerySimilarTimes(CompareTwoTimes):
                 for mob in formula
                 if mob.get_color() == Color(color)
             ])
-            for color in DISTANCE_COLOR, TIME_COLOR
+            for color in (DISTANCE_COLOR, TIME_COLOR)
         ]
         ds_brace = Brace(ds_symbols, UP)
         ds_text = ds_brace.get_text("$ds$", buff = SMALL_BUFF)
@@ -1086,7 +1086,7 @@ class DsOverDtGraphically(GraphCarTrajectory, ZoomedScene):
                 line_class = Line,
                 line_kwargs = {"color" : MAROON_B}
             )
-            for time in self.end_time, self.end_time + self.dt
+            for time in (self.end_time, self.end_time + self.dt)
         ]
 
 
@@ -1285,7 +1285,7 @@ class SecantLineToTangentLine(GraphCarTrajectory, DefineTrueDerivative):
     def get_ds_dt_group(self, dt, animate = False):
         points = [
             self.input_to_graph_point(time, self.graph)
-            for time in self.curr_time, self.curr_time+dt
+            for time in (self.curr_time, self.curr_time+dt)
         ]
         dots = map(Dot, points)
         for dot in dots:
@@ -1453,7 +1453,7 @@ class SecantLineToTangentLine(GraphCarTrajectory, DefineTrueDerivative):
             TextMobject(
                 "$dt$", "is", "not", s
             )
-            for s in "``infinitely small''", "0"
+            for s in ("``infinitely small''", "0")
         ]
         for phrase in phrases:
             phrase[0].set_color(TIME_COLOR)
@@ -1646,7 +1646,7 @@ class TCubedExample(SecantLineToTangentLine):
         self.play(Write(ds_dt_group, run_time = 2))
         self.play(
             FadeIn(lhs),
-            *[mob.restore for mob in ds, dt]
+            *[mob.restore for mob in (ds, dt)]
         )
         self.play(ShowCreation(v_lines[0]))
         self.wait()
@@ -1690,7 +1690,7 @@ class TCubedExample(SecantLineToTangentLine):
                     "dashed_segment_length" : 0.05,
                 }
             )
-            for time in self.start_time, self.start_time+self.start_dt
+            for time in (self.start_time, self.start_time+self.start_dt)
         ])
 
     def brace_for_details(self):
@@ -2315,7 +2315,7 @@ class TinyMovement(ZoomedScene):
 
         dots = VGroup(*[
             Dot(point, radius = self.distance/10)
-            for point in wheel_point, target_wheel_point
+            for point in (wheel_point, target_wheel_point)
         ])
         brace = Brace(Line(ORIGIN, RIGHT))
         distance_label = TexMobject(self.distance_label)

--- a/old_projects/eoc/chapter3.py
+++ b/old_projects/eoc/chapter3.py
@@ -99,7 +99,7 @@ class ContrastAbstractAndConcrete(Scene):
                 t_max = 12*np.pi,
                 num_anchor_points = 100,
             )
-            for denom in 12.0, 4.0
+            for denom in (12.0, 4.0)
         ]
         for spring in compact_spring, extended_spring:
             spring.scale(0.5)
@@ -253,7 +253,7 @@ class DerivativeOfXSquaredAsGraph(GraphScene, ZoomedScene, PiCreatureScene):
                 color = RED,
                 dashed_segment_length = 0.025
             )
-            for x in self.start_x, self.start_x+self.dx
+            for x in (self.start_x, self.start_x+self.dx)
         ]
 
         df_dx = TexMobject("\\frac{df}{dx} ?")
@@ -534,10 +534,10 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         self.play(
             *[
                 mob.restore
-                for mob in r1, r2, s
+                for mob in (r1, r2, s)
             ]+[
                 Write(symbol)
-                for symbol in equals, plus1, plus2
+                for symbol in (equals, plus1, plus2)
             ], 
             run_time = 2
         )
@@ -612,7 +612,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
             FadeOut(example_value),
             *[
                 mob.restore
-                for mob in xs, dxs, text
+                for mob in (xs, dxs, text)
             ]
         )
         self.remove(text)
@@ -652,7 +652,7 @@ class NudgeSideLengthOfSquare(PiCreatureScene):
         self.wait(2)
         self.play(*[
             mob.restore
-            for mob in self.dxs, text
+            for mob in (self.dxs, text)
         ] + [
             self.pi_creature.change_mode, "erm"
         ])
@@ -889,7 +889,7 @@ class NudgeSideLengthOfCube(Scene):
                 for piece in dv_pieces
                 if piece.type == target_type
             ])
-            for target_type in "face", "bar", "corner_cube"
+            for target_type in ("face", "bar", "corner_cube")
         ]
 
     def write_df_equation(self):
@@ -1023,7 +1023,7 @@ class NudgeSideLengthOfCube(Scene):
         self.shrink_dx("Derivative is written", restore = False)
         self.play(*[
             ApplyMethod(mob.fade, 0.7)
-            for mob in extra_stuff, inner_dx
+            for mob in (extra_stuff, inner_dx)
         ])
         self.wait(2)
 
@@ -1471,7 +1471,7 @@ class PowerRuleAlgebra(Scene):
                 for submob, tex in product_part_tex_pairs
                 if tex == target_tex
             ])
-            for target_tex in "x", "dx"
+            for target_tex in ("x", "dx")
         ]
 
         x_to_n = TexMobject("x^n")
@@ -1760,7 +1760,7 @@ class OneOverX(PiCreatureScene, GraphScene):
                 color = self.df_color,
                 stroke_width = 2
             ).move_to(rect.get_corner(UP+LEFT), LEFT)
-            for rect in rect_group.rectangle, new_rect
+            for rect in (rect_group.rectangle, new_rect)
         ])
 
         v_lines = VGroup(*[
@@ -1769,7 +1769,7 @@ class OneOverX(PiCreatureScene, GraphScene):
                 color = self.dx_color,
                 stroke_width = 2
             ).move_to(rect.get_corner(DOWN+RIGHT), DOWN)
-            for rect in rect_group.rectangle, new_rect
+            for rect in (rect_group.rectangle, new_rect)
         ])
 
         dx_brace = Brace(v_lines, UP, buff = 0)
@@ -1922,7 +1922,7 @@ class OneOverX(PiCreatureScene, GraphScene):
 
         result.x_brace, result.recip_brace = braces = [
             Brace(result.rectangle, vect)
-            for vect in UP, RIGHT
+            for vect in (UP, RIGHT)
         ]
         result.labels = VGroup()
         for brace, label in zip(braces, [x_label, one_over_x_label]):
@@ -2048,7 +2048,7 @@ class SquareRootOfX(Scene):
 
         bottom_brace, right_brace = braces = VGroup(*[
             Brace(square, vect)
-            for vect in DOWN, RIGHT
+            for vect in (DOWN, RIGHT)
         ])
         for brace in braces:
             brace.add(brace.get_text("$\\sqrt{x}$"))

--- a/old_projects/eoc/chapter4.py
+++ b/old_projects/eoc/chapter4.py
@@ -211,7 +211,7 @@ class DampenedSpring(Scene):
                 num_anchor_points = 100,
                 color = GREY,
             ).shift(3*LEFT)
-            for denom in 12.0, 2.0
+            for denom in (12.0, 2.0)
         ]
         for spring in compact_spring, extended_spring:
             spring.scale(0.5)
@@ -441,7 +441,7 @@ class SumRule(GraphScene):
             line.save_state()
         sine_lines, parabola_lines = [
             VGroup(example_v_lines[i], nudged_v_lines[i])
-            for i in 0, 1
+            for i in (0, 1)
         ]
         faders = VGroup(*filter(
             lambda line : line not in example_v_lines,
@@ -944,7 +944,7 @@ class IntroduceProductAsArea(ReconfigurableScene):
         line, triangle, x_mob = self.x_slider
         dx_line = Line(*[
             line.number_to_point(self.x_slider.x_val + num)
-            for num in 0, self.dx,
+            for num in (0, self.dx,)
         ])
         dx_line.set_stroke(
             self.df_box_kwargs["fill_color"], 
@@ -1943,7 +1943,7 @@ class GeneralizeChainRule(Scene):
         self.wait()
         self.play(*it.chain(*[
             [mob.scale_in_place, 1.2, mob.set_color, YELLOW]
-            for mob in example_inner, d_example_inner
+            for mob in (example_inner, d_example_inner)
         ]), rate_func = there_and_back)
         self.play(Transform(
             example_inner.copy(), d_example_inner,

--- a/old_projects/eoc/chapter5.py
+++ b/old_projects/eoc/chapter5.py
@@ -100,7 +100,7 @@ class DoublingPopulation(PiCreatureScene):
 
         pop_brace, mass_brace = [
             Brace(function[0], DOWN)
-            for function in P_t, M_t
+            for function in (P_t, M_t)
         ]
         for brace, word in (pop_brace, "size"), (mass_brace, "mass"):
             text = brace.get_text("Population %s"%word)
@@ -601,7 +601,7 @@ class FakeDiagram(TeacherStudentsScene):
                 x_min = -8,
                 x_max = 2 + dx
             )
-            for dx in 0.25, 0
+            for dx in (0.25, 0)
         ])
         for graph in graphs:
             end_point = graph.points[-1]
@@ -775,7 +775,7 @@ class AnalyzeExponentRatio(PiCreatureScene):
         ]
         words = VGroup(*[
             TextMobject(s, " ideas")
-            for s in "Additive", "Multiplicative"
+            for s in ("Additive", "Multiplicative")
         ])
         words[0].move_to(words[1], LEFT)
         words.set_color(BLUE)
@@ -812,14 +812,14 @@ class AnalyzeExponentRatio(PiCreatureScene):
                 run_time = 2,
                 rate_func = squish_rate_func(smooth, 0.5, 1)
             )
-            for mob in one, lp, rp
+            for mob in (one, lp, rp)
         ] + [
             ReplacementTransform(
                 mob, extracted_two_to_t,
                 path_arc = np.pi/2,
                 run_time = 2,
             )
-            for mob in two_to_t, VGroup(*two_to_t_two_to_dt[:2])
+            for mob in (two_to_t, VGroup(*two_to_t_two_to_dt[:2]))
         ] + [
             lhs.next_to, extracted_two_to_t, LEFT
         ])
@@ -1006,7 +1006,7 @@ class CompareTwoConstantToEightConstant(PiCreatureScene):
     def construct(self):
         two_deriv, eight_deriv = derivs = VGroup(*[
             self.get_derivative_expression(base)
-            for base in 2, 8
+            for base in (2, 8)
         ])
 
         derivs.arrange_submobjects(
@@ -1268,7 +1268,7 @@ class ApplyChainRule(TeacherStudentsScene):
                 path_arc = -np.pi,
                 run_time = 2
             )
-            for tex in "e^", "{3", "t}"
+            for tex in ("e^", "{3", "t}")
         ] + [
             Write(deriv_equation.get_part_by_tex("="))
         ])
@@ -1663,7 +1663,7 @@ class TemperatureOverTimeOfWarmWater(GraphScene):
         )
         h_line = DashedLine(*[
             self.coords_to_point(x, self.T_room)
-            for x in self.x_min, self.x_max
+            for x in (self.x_min, self.x_max)
         ])
         T_room_label = TexMobject("T_{\\text{room}}")
         T_room_label.next_to(h_line, LEFT)

--- a/old_projects/eoc/chapter6.py
+++ b/old_projects/eoc/chapter6.py
@@ -563,7 +563,7 @@ class Ladder(VMobject):
     def generate_points(self):
         left_line, right_line = [
             Line(ORIGIN, self.height*UP).shift(self.width*vect/2.0)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ]
         rungs = [
             Line(
@@ -677,7 +677,7 @@ class RelatedRatesExample(ThreeDScene):
 
         down_arrow, left_arrow = [
             Arrow(ORIGIN, vect, color = YELLOW, buff = 0)
-            for vect in DOWN, LEFT
+            for vect in (DOWN, LEFT)
         ]
         down_arrow.shift(y_line.get_start()+MED_SMALL_BUFF*RIGHT)
         left_arrow.shift(x_line.get_start()+SMALL_BUFF*DOWN)
@@ -1302,7 +1302,7 @@ class CompareLadderAndCircle(PiCreatureScene, ThreeDScene):
             for i, j in enumerate([1, 0, 3, 5, 4, 7])
         ]+[
             Write(derivative[j])
-            for j in 2, 6
+            for j in (2, 6)
         ])
         self.play(
             self.pi_creature.change_mode, "pondering",
@@ -1508,7 +1508,7 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
             )
         ]+[
             Write(derivative[1][j])
-            for j in 3, 7
+            for j in (3, 7)
         ])
         self.play(*[
             ReplacementTransform(
@@ -1729,7 +1729,7 @@ class TwoVariableFunctionAndDerivative(SlopeOfCircleExample):
                 buff = SMALL_BUFF/self.zoom_factor,
                 tip_length = 0.15/self.zoom_factor
             )
-            for mob in dot, new_dot
+            for mob in (dot, new_dot)
         ]
 
         for line, tex, vect in (dy_line, "dy", RIGHT), (dx_line, "dx", UP):
@@ -2025,7 +2025,7 @@ class AlternateExample(ZoomedScene):
 
         arrows = VGroup(*[
             Arrow(word, part)
-            for part in lhs, rhs
+            for part in (lhs, rhs)
         ])
 
         self.play(FocusOn(formula))
@@ -2072,7 +2072,7 @@ class AlternateExample(ZoomedScene):
         )
         derivative_rects = [
             BackgroundRectangle(VGroup(*subset))
-            for subset in derivative[:2], derivative[2:]
+            for subset in (derivative[:2], derivative[2:])
         ]
         derivative_rects[1].stretch(1.05, dim = 0)
 

--- a/old_projects/eoc/chapter7.py
+++ b/old_projects/eoc/chapter7.py
@@ -191,7 +191,7 @@ class RefreshOnDerivativeDefinition(GraphScene):
                 line_class = DashedLine,
                 color = RED
             )
-            for nudge in 0, self.start_dx
+            for nudge in (0, self.start_dx)
         ]
         nudged_x_v_line.save_state()
         ss_group = self.get_secant_slope_group(
@@ -343,7 +343,7 @@ class RantOpenAndClose(Scene):
                 start, "Rant on infinitesimals", "$>$",
                 arg_separator = ""
             )
-            for start in "$<$", "$<$/"
+            for start in ("$<$", "$<$/")
         ]
         self.play(FadeIn(opening))
         self.wait(2)
@@ -439,7 +439,7 @@ class DiscussLowercaseDs(RefreshOnDerivativeDefinition, PiCreatureScene, ZoomedS
                 lhs.get_part_by_tex(tex)[0],
                 stretch = True,
             ).scale_in_place(1.5).rotate_in_place(-np.pi/12)
-            for tex in "df", "dx"
+            for tex in ("df", "dx")
         ])
         d_words = TextMobject("""
             Limit idea is
@@ -452,7 +452,7 @@ class DiscussLowercaseDs(RefreshOnDerivativeDefinition, PiCreatureScene, ZoomedS
             Rectangle(color = GREEN_B).replace(
                 mob, stretch = True
             )
-            for mob in lhs, rhs.target
+            for mob in (lhs, rhs.target)
         ]
         for rect in rects:
             rect.stretch_to_fit_width(rect.get_width()+2*MED_SMALL_BUFF)
@@ -654,7 +654,7 @@ class OtherViewsOfDx(TeacherStudentsScene):
                 VGroup(*statement.get_parts_by_tex(
                     tex, substring = False
                 )).set_color(GREEN)
-                for tex in "$h$", "$dx$"
+                for tex in ("$h$", "$dx$")
             ]
 
         #Question
@@ -1165,14 +1165,14 @@ class GraphLimitExpression(GraphScene):
                     (limit_x+basically_zero, limit_x+delta),
                 ]
             ]).set_stroke(width = input_range_stroke_width)
-            for func in (lambda h : 0), self.func
+            for func in ((lambda h : 0), self.func)
         ]
         result.epsilon_lines = VGroup(*[
             dashed_line.copy().move_to(
                 self.coords_to_point(limit_x, 0)[0]*RIGHT+\
                 result.output_range.get_edge_center(vect)[1]*UP
             )
-            for vect in DOWN, UP
+            for vect in (DOWN, UP)
         ])
 
         result.digest_mobject_attrs()
@@ -1588,7 +1588,7 @@ class EpsilonDeltaExample(GraphLimitExpression, ZoomedScene):
             Line(
                 ORIGIN, line_length*RIGHT,
             ).move_to(self.coords_to_point(0, limit_value+nudge))
-            for nudge in 0, -epsilon, epsilon
+            for nudge in (0, -epsilon, epsilon)
         ]
         result.limit_line = lines[0]
         result.limit_line.set_stroke(RED, width = 3)
@@ -1599,7 +1599,7 @@ class EpsilonDeltaExample(GraphLimitExpression, ZoomedScene):
             brace.copy().scale_to_fit_height(
                 group.get_height()
             ).next_to(group, RIGHT, SMALL_BUFF)
-            for i in 1, 2
+            for i in (1, 2)
             for group in [VGroup(lines[0], lines[i])]
         ])
         result.labels = VGroup(*[
@@ -1623,7 +1623,7 @@ class EpsilonDeltaExample(GraphLimitExpression, ZoomedScene):
         )
         result.braces = VGroup(*[
             brace.copy().move_to(self.coords_to_point(x, 0))
-            for x in -delta/2, delta/2
+            for x in (-delta/2, delta/2)
         ])
         result.braces.shift(self.holes[0].get_height()*DOWN)
         result.labels = VGroup(*[
@@ -1897,11 +1897,11 @@ class LHopitalExample(LimitCounterExample, PiCreatureScene, ZoomedScene, Reconfi
                 line_class = DashedLine,
                 color = self.x_color
             )
-            for x in 1, -1
+            for x in (1, -1)
         ]
         hole, alt_hole = [
             self.get_hole(x, self.func(x))
-            for x in 1, -1
+            for x in (1, -1)
         ]
         ed_group = self.get_epsilon_delta_group(
             self.big_delta, limit_x = 1,
@@ -2090,7 +2090,7 @@ class LHopitalExample(LimitCounterExample, PiCreatureScene, ZoomedScene, Reconfi
                 fill_opacity = 0.75,
                 fill_color = BLACK,
             ).next_to(self.coords_to_point(1, 0), vect, MED_LARGE_BUFF)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
 
         self.play(
@@ -2149,7 +2149,7 @@ class LHopitalExample(LimitCounterExample, PiCreatureScene, ZoomedScene, Reconfi
                 tip_length = arrow_tip_length,
                 color = graph.get_color()
             )
-            for graph in self.sine_graph, self.parabola
+            for graph in (self.sine_graph, self.parabola)
         ]
         tex_arrow_pairs = [
             [("d\\big(", "\\sin(", "\\pi", "x", ")", "\\big)"), d_sine_arrow],
@@ -2606,7 +2606,7 @@ class GeneralLHoptial(LHopitalExample):
                 tip_length = arrow_tip_length,
                 color = graph.get_color()
             )
-            for graph in self.f_graph, self.g_graph
+            for graph in (self.f_graph, self.g_graph)
         ]
         v_labels = []
         for char, arrow in ("f", df_arrow), ("g", dg_arrow):
@@ -2881,7 +2881,7 @@ class NextVideo(TeacherStudentsScene):
             ])
         ]+[
             Write(VGroup(*ftc.get_parts_by_tex(part)))
-            for part in "-", "=", "over", "(x)"
+            for part in ("-", "=", "over", "(x)")
         ])
         self.change_student_modes(*["pondering"]*3)
         self.wait(3)

--- a/old_projects/eoc/chapter8.py
+++ b/old_projects/eoc/chapter8.py
@@ -653,7 +653,7 @@ class ConstantVelocityPlot(PlotVelocity):
     def note_units(self):
         x_line, y_line  = lines = VGroup(*[
             axis.main_line.copy()
-            for axis in self.x_axis, self.y_axis
+            for axis in (self.x_axis, self.y_axis)
         ])
         lines.set_color(TIME_COLOR)
         square = Square(
@@ -665,7 +665,7 @@ class ConstantVelocityPlot(PlotVelocity):
         square.replace(
             VGroup(*[
                 VectorizedPoint(self.coords_to_point(i, i))
-                for i in 0, 1
+                for i in (0, 1)
             ]),
             stretch = True
         )
@@ -876,7 +876,7 @@ class PiecewiseConstantPlot(PlotVelocity):
             FadeOut(self.pw_constant_graph),
             *[
                 m.restore 
-                for m in self.v_graph, self.v_graph_label
+                for m in (self.v_graph, self.v_graph_label)
             ]+[Animation(self.rects)]
         )
         for new_rects in self.rect_list[1:]:
@@ -1022,7 +1022,7 @@ class PiecewiseConstantPlot(PlotVelocity):
 
         self.play(*map(FadeOut, [
             group[1]
-            for group in v_lines, h_lines, height_labels
+            for group in (v_lines, h_lines, height_labels)
         ]))
         self.play(
             v_lines[0].set_color, RED,
@@ -1368,7 +1368,7 @@ class CarJourneyApproximation(Scene):
         "bottom_words" : "Approximated motion (5 jumps)",
     }
     def construct(self):
-        points = [5*LEFT + v for v in UP, 2*DOWN]
+        points = [5*LEFT + v for v in (UP, 2*DOWN)]
         cars = [Car().move_to(point) for point in points]
         h_line = Line(LEFT, RIGHT).scale(FRAME_X_RADIUS)
         words = [
@@ -1539,7 +1539,7 @@ class AreaIsDerivative(PlotVelocity, ReconfigurableScene):
                 mob.get_left(), self.area.get_center(),
                 color = WHITE
             )
-            for mob in integral, s_T
+            for mob in (integral, s_T)
         ]
 
         distance_word = TextMobject("Distance")
@@ -1678,7 +1678,7 @@ class AreaIsDerivative(PlotVelocity, ReconfigurableScene):
                 formula1.get_part_by_tex(tex),
                 formula2.get_part_by_tex(tex),
             )
-            for tex in "ds", "=", "v(T)", "dT"
+            for tex in ("ds", "=", "v(T)", "dT")
         ] + [
             Write(formula2.get_part_by_tex("over"))
         ])
@@ -1865,7 +1865,7 @@ class FindAntiderivative(Antiderivative):
                 run_time = 2,
                 path_arc = -np.pi/6.
             )
-            for i in 0, 1
+            for i in (0, 1)
         ])
         self.change_mode("thinking")
         self.wait()
@@ -2172,7 +2172,7 @@ class LowerBound(AreaIsDerivative):
                 self.coords_to_point(d, 0), 
                 DOWN, MED_LARGE_BUFF
             )
-            for d in 1, 7
+            for d in (1, 7)
         ]
         tex_mobs = [new_integral]+new_antideriv_diff[1::2]+numbers
         for tex_mob in tex_mobs:
@@ -2353,7 +2353,7 @@ class FundamentalTheorem(GraphScene):
                 dx_brace.next_to, rects[i], DOWN, 0,
                 *[
                     MaintainPositionRelativeTo(brace.label, brace)
-                    for brace in f_brace, dx_brace
+                    for brace in (f_brace, dx_brace)
                 ]
             )
         self.wait()
@@ -2419,7 +2419,7 @@ class FundamentalTheorem(GraphScene):
     def show_integral_considering_continuum(self):
         self.play(*[
             ApplyMethod(mob.set_fill, None, 0.2)
-            for mob in self.deriv, self.rhs
+            for mob in (self.deriv, self.rhs)
         ])
         self.play(
             self.rects.restore,
@@ -2600,7 +2600,7 @@ class NegativeArea(GraphScene):
                 equation.get_part_by_tex(tex).get_top(),
                 color = RED,
             )
-            for tex in "ds", "v(t)"
+            for tex in ("ds", "v(t)")
         ])
 
         self.play(

--- a/old_projects/eoc/chapter9.py
+++ b/old_projects/eoc/chapter9.py
@@ -1149,9 +1149,9 @@ class Antiderivative(AverageOfSineStart):
         (start_pi, end_pi), (start_zero, end_zero) = start_end_pairs = [
             [
                 m.get_part_by_tex(tex) 
-                for m in integral, rhs
+                for m in (integral, rhs)
             ]
-            for tex in "\\pi", "0"
+            for tex in ("\\pi", "0")
         ]
 
         for tex_mob in integral, rhs:
@@ -1271,7 +1271,7 @@ class Antiderivative(AverageOfSineStart):
             TexMobject("\\over\\,").stretch_to_fit_width(
                 mob.get_width()
             ).move_to(mob)
-            for mob in integral, rhs_without_eq
+            for mob in (integral, rhs_without_eq)
         ])
         frac_lines.shift(
             (integral.get_height()/2 + SMALL_BUFF)*DOWN
@@ -1301,7 +1301,7 @@ class Antiderivative(AverageOfSineStart):
                 integral.get_part_by_tex(tex).copy(),
                 pi_minus_zeros[0].get_part_by_tex(tex)
             )
-            for tex in "\\pi","0"
+            for tex in ("\\pi","0")
         ] + [
             Write(pi_minus_zeros[0].get_part_by_tex("-"))
         ])
@@ -1312,7 +1312,7 @@ class Antiderivative(AverageOfSineStart):
                 ).copy(),
                 pi_minus_zeros[1].get_part_by_tex(tex)
             )
-            for tex in "\\pi", "-", "0"
+            for tex in ("\\pi", "-", "0")
         ])
         self.wait(2)
 
@@ -1514,7 +1514,7 @@ class GeneralAverage(AverageOfContinuousVariable):
             Write(
                 VGroup(*[
                     fraction.get_part_by_tex(tex)
-                    for tex in "int", "f(x)", "dx", "over"
+                    for tex in ("int", "f(x)", "dx", "over")
                 ]),
                 rate_func = squish_rate_func(smooth, 0.25, 0.75),
                 run_time = 4

--- a/old_projects/eoc/footnote.py
+++ b/old_projects/eoc/footnote.py
@@ -135,7 +135,7 @@ class SecondDerivativeGraphically(GraphScene):
         second_deriv.set_color(self.second_deriv_color)
         points = [
             self.input_to_graph_point(x, self.graph)
-            for x in self.x2, self.x3
+            for x in (self.x2, self.x3)
         ]
         words = TextMobject("Change to \\\\ slope")
         words.next_to(
@@ -243,7 +243,7 @@ class SecondDerivativeGraphically(GraphScene):
         ]
         arg_rhs_list = [
             TexMobject("(", str(x0), ")", "=", str(rhs))
-            for rhs in 10, 0.4, 0
+            for rhs in (10, 0.4, 0)
         ]
         for graph, arg_rhs in zip(graphs, arg_rhs_list):
             graph.ss_group = self.get_secant_slope_group(
@@ -736,7 +736,7 @@ class SecondDerivativeAsAcceleration(Scene):
         )
         s_graph, v_graph, a_graph, j_graph = graphs = [
             VGroup(*scene.get_top_level_mobjects())
-            for scene in s_scene, v_scene, a_scene, j_scene
+            for scene in (s_scene, v_scene, a_scene, j_scene)
         ]
         for i, graph in enumerate(graphs):
             graph.scale_to_fit_height(FRAME_Y_RADIUS)

--- a/old_projects/eoc/old_chapter1.py
+++ b/old_projects/eoc/old_chapter1.py
@@ -723,12 +723,12 @@ class IntroduceTinyChangeInArea(CircleScene):
         self.wait(2)
         self.play(*[
             ApplyMethod(mob.set_color, RED)
-            for mob in pi_R_squared, pi_R_squared2
+            for mob in (pi_R_squared, pi_R_squared2)
         ])
         self.wait()
         self.play(*[
             ApplyMethod(mob.fade, 0.7)
-            for mob in plus, pi_R_squared, pi_R_squared2, minus2
+            for mob in (plus, pi_R_squared, pi_R_squared2, minus2)
         ]) 
         self.wait()
 
@@ -2056,7 +2056,7 @@ class GraphIntegral(GraphScene):
     def show_horizontal_axis(self):
         arrows = [
             Arrow(self.little_r, self.coords_to_point(*coords))
-            for coords in (0, 0), (self.x_max, 0)
+            for coords in ((0, 0), (self.x_max, 0))
         ]
         moving_arrow = arrows[0].copy()
         self.play(

--- a/old_projects/eola/chapter0.py
+++ b/old_projects/eola/chapter0.py
@@ -381,7 +381,7 @@ class LinAlgPyramid(Scene):
         self.wait()
         self.play(*[
             ApplyMethod(m.set_color, DARK_GREY)
-            for m in words[0], rects[0]
+            for m in (words[0], rects[0])
         ])
         self.wait()
         self.list_applications(rects[-1])
@@ -390,7 +390,7 @@ class LinAlgPyramid(Scene):
         height = 1
         rects = [
             Rectangle(height = height, width = width)
-            for width in 8, 5, 2
+            for width in (8, 5, 2)
         ]
         rects[0].shift(2*DOWN)
         for i in 1, 2:
@@ -907,7 +907,7 @@ class ResourceForTeachers(Scene):
         bubble.clear()
         randys = VMobject(*[
             Randolph(color = c)
-            for c in BLUE_D, BLUE_C, BLUE_E
+            for c in (BLUE_D, BLUE_C, BLUE_E)
         ])
         randys.arrange_submobjects(RIGHT)
         randys.scale(0.8)
@@ -937,7 +937,7 @@ class DifferingBackgrounds(Scene):
         ])
         students = VMobject(*[
             Randolph(color = c)
-            for c in BLUE_D, BLUE_C, BLUE_E
+            for c in (BLUE_D, BLUE_C, BLUE_E)
         ])
         modes = ["pondering", "speaking_looking_left", "sassy"]
         students.arrange_submobjects(RIGHT)

--- a/old_projects/eola/chapter1.py
+++ b/old_projects/eola/chapter1.py
@@ -403,7 +403,7 @@ class HelpsToHaveOneThought(Scene):
 
         randys = VMobject(*[
             Randolph(color = color).scale(0.8)
-            for color in BLUE_D, BLUE_C, BLUE_E
+            for color in (BLUE_D, BLUE_C, BLUE_E)
         ])
         randys.arrange_submobjects(RIGHT)
         randys.to_corner(DOWN+LEFT)
@@ -795,7 +795,7 @@ class VectorAdditionNumerically(VectorScene):
             Write(plus, run_time = 1), 
             *[
                 ApplyMethod(mob.shift, v1.get_end())
-                for mob in v2, x_line2, y_line2
+                for mob in (v2, x_line2, y_line2)
             ]
         )
         equals.next_to(coords2, RIGHT)

--- a/old_projects/eola/chapter10.py
+++ b/old_projects/eola/chapter10.py
@@ -241,7 +241,7 @@ class VectorRemainsOnSpan(ExampleTranformationScene):
         self.wait()
         target_vectors = [
             vector.copy().scale(scalar)
-            for scalar in 2, -2, 1
+            for scalar in (2, -2, 1)
         ]
         for target, time in zip(target_vectors, [1, 2, 2]):
             self.play(Transform(vector, target, run_time = time))
@@ -269,7 +269,7 @@ class IHatAsEigenVector(ExampleTranformationScene):
         x_axis = self.plane.axes[0]
         targets = [
             self.i_hat.copy().scale(val)
-            for val in -FRAME_X_RADIUS, FRAME_X_RADIUS, 1
+            for val in (-FRAME_X_RADIUS, FRAME_X_RADIUS, 1)
         ]
         lines = [
             Line(v1.get_end(), v2.get_end(), color = YELLOW)
@@ -1422,7 +1422,7 @@ class RevisitExampleTransformation(ExampleTranformationScene):
             two.move_to(lamb)
             self.play(Transform(lamb, two))
         self.play(*it.chain(
-            [mob.restore for mob in self.plane, self.i_hat, self.j_hat],
+            [mob.restore for mob in (self.plane, self.i_hat, self.j_hat)],
             map(Animation, self.foreground_mobjects),            
         ))
 
@@ -1460,7 +1460,7 @@ class RevisitExampleTransformation(ExampleTranformationScene):
         )
         self.wait()
         self.play(*it.chain(
-            [mob.restore for mob in self.plane, self.i_hat, self.j_hat, vectors],
+            [mob.restore for mob in (self.plane, self.i_hat, self.j_hat, vectors)],
             map(FadeOut, [xy_array, equals, zero_array]),
             map(Animation, self.foreground_mobjects)
         ))
@@ -2167,7 +2167,7 @@ class ChangeToEigenBasis(ExampleTranformationScene):
 
         cob_matrix = Matrix(np.array([
             list(vect.entries.target)
-            for vect in b1, b2
+            for vect in (b1, b2)
         ]).T)
         cob_matrix.rect = BackgroundRectangle(cob_matrix)
         cob_matrix.add_to_back(cob_matrix.rect)
@@ -2178,7 +2178,7 @@ class ChangeToEigenBasis(ExampleTranformationScene):
         brace_text.next_to(brace, DOWN, aligned_edge = LEFT)
         brace_text.add_background_rectangle()
 
-        copies = [vect.coords.copy() for vect in b1, b2]
+        copies = [vect.coords.copy() for vect in (b1, b2)]
         self.to_fade += copies
         self.add(*copies)
         self.play(

--- a/old_projects/eola/chapter11.py
+++ b/old_projects/eola/chapter11.py
@@ -181,7 +181,7 @@ class WhatIsA2DVector(LinearTransformationScene):
             ]),
             [ApplyMethod(s.change_mode, "plain") for s in students],
             map(Animation, [cs_student.bubble, cs_student.arrow]),
-            [mob.restore for mob in cs_student.v, cs_student.coords],
+            [mob.restore for mob in (cs_student.v, cs_student.coords)],
         ))
         bubble = cs_student.get_bubble(SpeechBubble, width = 4, height = 3)
         bubble.set_fill(BLACK, opacity = 1)
@@ -756,7 +756,7 @@ class AddTwoFunctions(FunctionGraphScene):
             }
         self.play(*[
             MoveToTarget(mob, **kwargs)
-            for mob in g_lines, dots
+            for mob in (g_lines, dots)
         ])
         # self.play(
         #     *[mob.fade for mob in g_lines, f_lines]+[
@@ -933,7 +933,7 @@ class FromVectorsToFunctions(VectorScene):
         self.wait()
         self.play(*[
             ApplyMethod(mob.shift, FRAME_WIDTH*RIGHT)
-            for mob in axes, everything
+            for mob in (axes, everything)
         ] + [Animation(words)]
         )
         self.play(ShowCreation(graph), Animation(words))
@@ -2036,7 +2036,7 @@ class ShowVectorSpaces(Scene):
             Line(
                 h_line.get_center(), FRAME_Y_RADIUS*DOWN
             ).shift(vect*FRAME_X_RADIUS/3.)
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ]
         vectors = self.get_vectors()
         vectors.shift(LEFT*FRAME_X_RADIUS*(2./3))
@@ -2121,7 +2121,7 @@ class MathematicianSpeakingToAll(Scene):
         mathy = Mathematician().to_corner(DOWN+LEFT)
         others = VGroup(*[
             Randolph().flip().set_color(color)
-            for color in BLUE_D, GREEN_E, GOLD_E, BLUE_C
+            for color in (BLUE_D, GREEN_E, GOLD_E, BLUE_C)
         ])
         others.arrange_submobjects()
         others.scale(0.8)
@@ -2246,7 +2246,7 @@ class AxiomsAreInterface(Scene):
         mathy.change_mode("pondering")
         others = [
             Randolph().flip().set_color(color)
-            for color in BLUE_D, GREEN_E, GOLD_E, BLUE_C
+            for color in (BLUE_D, GREEN_E, GOLD_E, BLUE_C)
         ]
         others = VGroup(
             VGroup(*others[:2]),
@@ -2336,7 +2336,7 @@ class VectorSpaceOfPiCreatures(Scene):
 
     def show_sum(self, creatures):
         def is_valid(pi1, pi2, pi3):
-            if len(set([pi.get_color() for pi in pi1, pi2, pi3])) < 3:
+            if len(set([pi.get_color() for pi in (pi1, pi2, pi3)])) < 3:
                 return False
             if pi1.is_flipped()^pi2.is_flipped():
                 return False
@@ -2475,7 +2475,7 @@ class WhatIsThree(Scene):
         triplets = [
             VGroup(*[
                 PiCreature(color = color).scale(0.4)
-                for color in BLUE_E, BLUE_C, BLUE_D
+                for color in (BLUE_E, BLUE_C, BLUE_D)
             ]),
             VGroup(*[HyperCube().scale(0.3) for x in range(3)]),
             VGroup(*[Vector(RIGHT) for x in range(3)]),

--- a/old_projects/eola/chapter2.py
+++ b/old_projects/eola/chapter2.py
@@ -291,7 +291,7 @@ class ShowVaryingLinearCombinations(VectorScene):
         ]
         anims += [
             ApplyMethod(v.copy().fade, 0.7)
-            for v in v1, v2
+            for v in (v1, v2)
         ]
         anims += label_anims + scalar_anims
         self.play(*anims, **{"run_time" : 2})
@@ -457,7 +457,7 @@ class NameLinearCombinations(Scene):
         scalars_word.next_to(equation, DOWN, buff = 2)
         arrows = [
             Arrow(scalars_word, letter)
-            for letter in a, b
+            for letter in (a, b)
         ]
 
         self.add(equation)
@@ -605,7 +605,7 @@ class DefineSpan(Scene):
         vary_words.next_to(equation, DOWN, buff = 2)
         arrows = [
             Arrow(vary_words, letter)
-            for letter in a, b
+            for letter in (a, b)
         ]
 
         self.play(Write(definition))
@@ -836,7 +836,7 @@ class LinearCombinationOfThreeVectorsText(Scene):
         VMobject(*span_comment.split()[3:7]).set_color(YELLOW)
         arrows = VMobject(*[
             Arrow(span_comment, var)
-            for var in a, b, c
+            for var in (a, b, c)
         ])
 
         self.play(Write(text))
@@ -967,7 +967,7 @@ class LinearDependentEquations(Scene):
         low_words2.to_edge(DOWN)
         arrows = VMobject(*[
             Arrow(low_words2, var)
-            for var in a, b
+            for var in (a, b)
         ])
 
         self.play(Write(equation1))
@@ -1064,7 +1064,7 @@ class AlternateDefOfLinearlyDependent(Scene):
         scalar_specification.shift(1.5*DOWN)
         scalar_specification.add(*[
             Arrow(scalar_specification, equations[0].split()[i])
-            for i in 2, 5
+            for i in (2, 5)
         ])
 
         brace = Brace(VMobject(*equations[2].split()[2:]))

--- a/old_projects/eola/chapter3.py
+++ b/old_projects/eola/chapter3.py
@@ -152,7 +152,7 @@ class WhyConfuseWithTerminology(TeacherStudentsScene):
     def construct(self):
         self.setup()
         self.student_says("Why confuse us with \\\\ redundant terminology?")
-        other_students = [self.get_students()[i] for i in 0, 2]
+        other_students = [self.get_students()[i] for i in (0, 2)]
         self.play(*[
             ApplyMethod(student.change_mode, "confused")
             for student in other_students
@@ -668,7 +668,7 @@ class TrackBasisVectorsExample(LinearTransformationScene):
         self.remove(coords)
 
     def show_linear_combination(self, clean_up = True):
-        i_hat_copy, j_hat_copy = [m.copy() for m in self.i_hat, self.j_hat]
+        i_hat_copy, j_hat_copy = [m.copy() for m in (self.i_hat, self.j_hat)]
         self.play(ApplyFunction(
             lambda m : m.scale(self.v_coords[0]).fade(0.3),
             i_hat_copy

--- a/old_projects/eola/chapter4.py
+++ b/old_projects/eola/chapter4.py
@@ -164,7 +164,7 @@ class FollowLinearCombination(LinearTransformationScene):
         scaled_j = self.get_mobjects_from_last_animation()[0]
         self.play(*[
             ApplyMethod(mob.shift, scaled_i.get_end())
-            for mob in scaled_j, scaled_j_label
+            for mob in (scaled_j, scaled_j_label)
         ])
         self.wait()
         self.play(*map(FadeOut, [
@@ -313,7 +313,7 @@ class IntroduceIdeaOfComposition(RotationThenShear):
         matrix.next_to(words, RIGHT, aligned_edge = UP)
         col1, col2 = [
             VMobject(*matrix.get_mob_matrix()[:,i])
-            for i in 0, 1
+            for i in (0, 1)
         ]
         matrix_background = BackgroundRectangle(matrix)
 
@@ -536,7 +536,7 @@ class MoreComplicatedExampleNumerically(MoreComplicatedExampleVisually):
 
         col1, col2 = [
             VMobject(*m1_mob.split()[1].get_mob_matrix()[:,i])
-            for i in 0, 1
+            for i in (0, 1)
         ]
         col1.target_color = X_COLOR
         col2.target_color = Y_COLOR
@@ -862,9 +862,9 @@ class AskAssociativityQuestion(Scene):
 
         lhs = TexMobject(list("(AB)C"))
         lp, a, b, rp, c = lhs.split()
-        rhs = VMobject(*[m.copy() for m in a, lp, b, c, rp])
+        rhs = VMobject(*[m.copy() for m in (a, lp, b, c, rp)])
         point = VectorizedPoint()
-        start = VMobject(*[m.copy() for m in point, a, b, point, c])
+        start = VMobject(*[m.copy() for m in (point, a, b, point, c)])
         for mob in lhs, rhs, start:
             mob.arrange_submobjects(buff = 0.1)
         a, lp, b, c, rp = rhs.split()
@@ -904,7 +904,7 @@ class AskAssociativityQuestion(Scene):
 
         matrices = map(matrix_to_mobject, [
             np.array(list(m)).reshape((2, 2))
-            for m in "abcd", "efgh", "ijkl"
+            for m in ("abcd", "efgh", "ijkl")
         ])
         VMobject(*matrices).arrange_submobjects()
 
@@ -931,10 +931,10 @@ class AskAssociativityQuestion(Scene):
             m3
         )
         state2 = VMobject(*[
-            m.copy() for m in lp, m1, m2, rp, m3
+            m.copy() for m in (lp, m1, m2, rp, m3)
         ])
         state3 = VMobject(*[
-            m.copy() for m in m1, lp, m2, m3, rp
+            m.copy() for m in (m1, lp, m2, m3, rp)
         ])
         for state in state2, state3:
             state.arrange_submobjects(RIGHT, buff = 0.1)

--- a/old_projects/eola/chapter5.py
+++ b/old_projects/eola/chapter5.py
@@ -893,7 +893,7 @@ class TwoDDeterminantFormula(Scene):
         self.wait()
         self.play(*[
             Transform(m, m.zero)
-            for m in mb, mc, b, c
+            for m in (mb, mc, b, c)
         ])
         self.wait()
         for pair in (mb, b), (mc, c):
@@ -932,7 +932,7 @@ class TwoDDeterminantFormulaIntuition(LinearTransformationScene):
             [[1, 0], [float(b)/d, 1]],
             added_anims = [
                 ApplyMethod(m.shift, b*RIGHT)
-                for m in side_brace, height
+                for m in (side_brace, height)
             ]
         )
         self.wait()

--- a/old_projects/eola/chapter6.py
+++ b/old_projects/eola/chapter6.py
@@ -362,7 +362,7 @@ class SystemOfEquations(Scene):
                 eq.split()[i]
                 for eq in equations.split()
             ])
-            for i in 1, 4, 7
+            for i in (1, 4, 7)
         ]
         ys.words = "Vertically align variables"
         colors = [PINK, YELLOW, BLUE_B, BLUE_C, BLUE_D]
@@ -432,7 +432,7 @@ class SystemOfEquations(Scene):
         ax_equals_v.to_edge(RIGHT)
         all_brackets = [
             mob.get_brackets()
-            for mob in matrix, x_array, v_array
+            for mob in (matrix, x_array, v_array)
         ]
 
         self.play(equations.to_edge, LEFT)
@@ -651,7 +651,7 @@ class ShowBijectivity(LinearTransformationScene):
             Vector([x, y])
             for x, y in it.product(*[
                 np.arange(-int(val)+0.5, int(val)+0.5)
-                for val in FRAME_X_RADIUS, FRAME_Y_RADIUS
+                for val in (FRAME_X_RADIUS, FRAME_Y_RADIUS)
             ])
         ])
         vectors.set_submobject_colors_by_gradient(BLUE_E, PINK)
@@ -970,7 +970,7 @@ class SymbolicInversion(Scene):
         self.wait()
         self.play(*[
             ApplyMethod(m.set_color, BLACK)
-            for m in product, product.brace, product.words
+            for m in (product, product.brace, product.words)
         ])
         self.wait()
         self.play(ApplyFunction(
@@ -1239,7 +1239,7 @@ class ColumnsRepresentBasisVectors(Scene):
         matrix.shift(UP)
         i_hat_words, j_hat_words = [
             TextMobject("Where $\\hat{\\%smath}$ lands"%char)
-            for char in "i", "j"
+            for char in ("i", "j")
         ]
         i_hat_words.set_color(X_COLOR)
         i_hat_words.next_to(ORIGIN, LEFT).to_edge(UP)
@@ -1462,7 +1462,7 @@ class NameColumnSpace(Scene):
         two_d_span.move_to(span_text, aligned_edge = RIGHT)
         mob_matrix = np.array([
             two_d_span[i].get_entries().split()
-            for i in 2, 4
+            for i in (2, 4)
         ])
 
         self.play(Transform(span_text, two_d_span))
@@ -1482,7 +1482,7 @@ class NameColumnSpace(Scene):
         self.add(span_text)
         mob_matrix = np.array([
             span_text[i].get_entries().split()
-            for i in 2, 4, 6
+            for i in (2, 4, 6)
         ])
         self.replace_number_matrix(mob_matrix, [[1, 1, 0], [0, 1, 1], [1, 0, 1]])
         self.wait()

--- a/old_projects/eola/chapter7.py
+++ b/old_projects/eola/chapter7.py
@@ -304,7 +304,7 @@ class GeometricInterpretation(VectorScene):
         dot_product = np.dot(self.v.get_end(), self.w.get_end())
         v_norm, w_norm = [
             np.linalg.norm(vect.get_end())
-            for vect in self.v, self.w
+            for vect in (self.v, self.w)
         ]
         projected = Vector(
             self.stable_vect.get_end()*dot_product/(
@@ -348,7 +348,7 @@ class GeometricInterpretation(VectorScene):
 
         proj_brace, stable_brace = braces = [
             Brace(Line(ORIGIN, vect.get_length()*RIGHT*sgn), UP)
-            for vect in self.proj_vect, self.stable_vect
+            for vect in (self.proj_vect, self.stable_vect)
             for sgn in [np.sign(np.dot(vect.get_end(), self.stable_vect.get_end()))]
         ]
         proj_brace.put_at_tip(proj_words.start)
@@ -581,7 +581,7 @@ class SymmetricVAndW(VectorScene):
             color = GREY
         )
 
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in ("v", "w")]
         equation = TexMobject(
             "(", "2", v_tex, ")", "\\cdot", w_tex,
             "=",
@@ -600,7 +600,7 @@ class SymmetricVAndW(VectorScene):
         v.proj_line.save_state()
         self.play(Transform(*[
             VGroup(mob, mob.label)
-            for mob in v, new_v
+            for mob in (v, new_v)
         ]), run_time = 2)
         last_mob = self.get_mobjects_from_last_animation()[0] 
         self.remove(last_mob)
@@ -700,7 +700,7 @@ class Introduce2Dto1DLinearTransformations(TwoDToOneDScene):
         self.apply_transposed_matrix(self.t_matrix)
         self.play(
             ShowCreation(number_line),
-            *[Animation(v) for v in self.i_hat, self.j_hat]
+            *[Animation(v) for v in (self.i_hat, self.j_hat)]
         )
         self.play(*map(Write, [numbers, number_line_words]))
         self.wait()
@@ -778,7 +778,7 @@ class OkayToIgnoreFormalProperties(Scene):
         title.to_edge(UP)
         h_line = Line(LEFT, RIGHT).scale(FRAME_X_RADIUS)
         h_line.next_to(title, DOWN)
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in ("v", "w")]
         additivity = TexMobject(
             "L(", v_tex, "+", w_tex, ") = ",
             "L(", v_tex, ") + L(", w_tex, ")",
@@ -829,7 +829,7 @@ class FormalVsVisual(Scene):
         formal.next_to(line, DOWN).shift(FRAME_X_RADIUS*LEFT/2)
         visual.next_to(line, DOWN).shift(FRAME_X_RADIUS*RIGHT/2)
 
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in ("v", "w")]
         additivity = TexMobject(
             "L(", v_tex, "+", w_tex, ") = ",
             "L(", v_tex, ")+", "L(", w_tex, ")"
@@ -900,13 +900,13 @@ class AdditivityProperty(TwoDToOneDScene):
         sum_vect.target = sum_vect
         self.play(*[
             Transform(mob, mob.target)
-            for mob in v, w, sum_vect
+            for mob in (v, w, sum_vect)
         ])
         self.add_vector(sum_vect, animate = False)
         return sum_vect
 
     def get_symbols(self):
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%c for c in ("v", "w")]
         if self.sum_before:
             tex_mob = TexMobject(
                 "L(", v_tex, "+", w_tex, ")"
@@ -1029,7 +1029,7 @@ class NonLinearFailsDotTest(TwoDTo1DTransformWithDots):
 
 class AlwaysfollowIHatJHat(TeacherStudentsScene):
     def construct(self):
-        i_tex, j_tex = ["$\\hat{\\%smath}$"%c for c in "i", "j"]
+        i_tex, j_tex = ["$\\hat{\\%smath}$"%c for c in ("i", "j")]
         words = TextMobject(
             "Always follow", i_tex, "and", j_tex
         )
@@ -1131,7 +1131,7 @@ class FollowVectorViaCoordinates(TwoDToOneDScene):
         self.play(
             *map(FadeOut, to_fade) + [
                 vect.restore
-                for vect in self.i_hat, self.j_hat
+                for vect in (self.i_hat, self.j_hat)
             ]
         )
 
@@ -1149,7 +1149,7 @@ class FollowVectorViaCoordinates(TwoDToOneDScene):
         else:
             new_labels = [
                 TexMobject("L(\\hat{\\%smath})"%char)
-                for char in "i", "j"
+                for char in ("i", "j")
             ]
             
         new_labels[0].set_color(X_COLOR)
@@ -1609,7 +1609,7 @@ class AskAboutProjectionMatrix(Scene):
         VMobject(words, matrix).arrange_submobjects(buff = MED_SMALL_BUFF).shift(UP)
         basis_words = [
             TextMobject("Where", "$\\hat{\\%smath}$"%char, "lands")
-            for char in "i", "j"
+            for char in ("i", "j")
         ]
         for b_words, q_mark, direction in zip(basis_words, matrix.get_entries(), [UP, DOWN]):
             b_words.next_to(q_mark, direction, buff = 1.5)
@@ -1650,7 +1650,7 @@ class ProjectBasisVectors(ProjectOntoUnitVectorNumberline):
             for vector in basis_vectors
         ])
 
-        i_tex, j_tex = ["$\\hat{\\%smath}$"%char for char in "i", "j"]
+        i_tex, j_tex = ["$\\hat{\\%smath}$"%char for char in ("i", "j")]
         question = TextMobject(
             "Where do", i_tex, "and", j_tex, "land?"
         )
@@ -1698,7 +1698,7 @@ class ProjectBasisVectors(ProjectOntoUnitVectorNumberline):
         # self.show_u_coords(u_label)
         u_x, u_y = [
             TexMobject("u_%s"%c).set_color(self.u_hat.get_color())
-            for c in "x", "y"
+            for c in ("x", "y")
         ]
         matrix_x, matrix_y = matrix.get_entries()
         self.remove(j_hat, j_label)
@@ -2160,7 +2160,7 @@ class TranslateToTheWorldOfTransformations(TwoDOneDMatrixMultiplication):
     def construct(self):
         v1, v2 = [
             Matrix(["x_%d"%n, "y_%d"%n])
-            for n in 1, 2
+            for n in (1, 2)
         ]
         v1.set_color_columns(V_COLOR)
         v2.set_color_columns(W_COLOR)

--- a/old_projects/eola/chapter8.py
+++ b/old_projects/eola/chapter8.py
@@ -183,7 +183,7 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
                     vect.label.target.restore, 
                     rate_func = lambda t : smooth(1-t)
                 )
-                for vect in self.v, self.w
+                for vect in (self.v, self.w)
             ]
         )
         self.wait()
@@ -250,7 +250,7 @@ class SimpleDefine2dCrossProduct(LinearTransformationScene):
         self.play(
             FadeOut(positive), 
             FadeOut(positive.arrow),
-            *[mob.restore for mob in square, self.v, self.w]
+            *[mob.restore for mob in (square, self.v, self.w)]
         )
         arc = self.get_arc(self.v, self.w, radius = 1.5)
         arc.set_color(RED)
@@ -770,7 +770,7 @@ class Define2dCrossProduct(LinearTransformationScene):
 
         col1, col2 = [
             VGroup(*matrix.get_mob_matrix()[i,:])
-            for i in 0, 1
+            for i in (0, 1)
         ]
 
         both_words = []
@@ -836,7 +836,7 @@ class Define2dCrossProduct(LinearTransformationScene):
 
         vect_stuffs = VGroup(*it.chain(*[
             [m, m.label, m.coord_array]
-            for m in self.v, self.w
+            for m in (self.v, self.w)
         ]))
         to_restore = [self.plane, self.i_hat, self.j_hat]
         for mob in to_restore:
@@ -917,10 +917,10 @@ class Define2dCrossProduct(LinearTransformationScene):
         self.play(Transform(movers, movers.target))
         self.wait()
 
-        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in "v", "w"]
+        v_tex, w_tex = ["\\vec{\\textbf{%s}}"%s for s in ("v", "w")]
         positive_words, negative_words = words_list = [
             TexMobject(v_tex, "\\times", w_tex, "\\text{ is }", word)
-            for word in "\\text{positive}", "\\text{negative}"
+            for word in ("\\text{positive}", "\\text{negative}")
         ]
         for words in words_list:
             words.set_color_by_tex(v_tex, V_COLOR)
@@ -1382,7 +1382,7 @@ class ShowCrossProductFormula(Scene):
 
         arrays = [
             ["%s_%d"%(s, i) for i in range(1, 4)]
-            for s in "v", "w"
+            for s in ("v", "w")
         ]
         matrices = map(Matrix, arrays)
         for matrix in matrices:
@@ -1466,7 +1466,7 @@ class DeterminantTrick(Scene):
     def construct(self):
         v_terms, w_terms = [
             ["%s_%d"%(s, d) for d in range(1, 4)]
-            for s in "v", "w"
+            for s in ("v", "w")
         ]
         v = Matrix(v_terms)
         w = Matrix(w_terms)
@@ -1475,7 +1475,7 @@ class DeterminantTrick(Scene):
         matrix = Matrix(np.array([
             [
                 TexMobject("\\hat{%s}"%s)
-                for s in "\\imath", "\\jmath", "k"
+                for s in ("\\imath", "\\jmath", "k")
             ],
             list(v.get_entries().copy()),
             list(w.get_entries().copy()),

--- a/old_projects/eola/chapter8p2.py
+++ b/old_projects/eola/chapter8p2.py
@@ -106,7 +106,7 @@ class BruteForceVerification(Scene):
                 "(", v_tex, "\\times", w_tex, ")",
                 "= 0"
             )
-            for tex in v_tex, w_tex
+            for tex in (v_tex, w_tex)
         ]
         theta_def = TexMobject(
             "\\theta", 
@@ -149,7 +149,7 @@ class Prerequisites(Scene):
         rect.scale_to_fit_width(FRAME_X_RADIUS - 1)
         left_rect, right_rect = [
             rect.copy().shift(DOWN/2).to_edge(edge)
-            for edge in LEFT, RIGHT
+            for edge in (LEFT, RIGHT)
         ]
         chapter5 = TextMobject("""
             \\centering 
@@ -293,7 +293,7 @@ class ThreeStepPlan(Scene):
         v_tex, w_tex = get_vect_tex(*"vw")
         v_text, w_text, cross_text = [
             "$%s$"%s 
-            for s in v_tex, w_tex, v_tex + "\\times" + w_tex
+            for s in (v_tex, w_tex, v_tex + "\\times" + w_tex)
         ]
         steps = [
             TextMobject(
@@ -413,7 +413,7 @@ class DefineDualTransform(Scene):
         det_text = get_det_text(matrix, background_rect = False)
         syms = times1, times2, equals = [
             TexMobject(sym) 
-            for sym in "\\times", "\\times", "=",
+            for sym in ("\\times", "\\times", "=",)
         ]
         triple_cross = VGroup(
             u_tex.target, times1, v_tex.target, times2, w_tex.target, equals
@@ -509,7 +509,7 @@ class DefineDualTransform(Scene):
         func_tex[0].scale_in_place(1.5)
 
         func_tex = VGroup(
-            VGroup(*[func_tex[i] for i in 0, 1, 2, -2, -1]),
+            VGroup(*[func_tex[i] for i in (0, 1, 2, -2, -1)]),
             func_input
         )
         func_tex.next_to(self.equals, LEFT)
@@ -528,7 +528,7 @@ class DefineDualTransform(Scene):
         ])
         self.play(*[
             Write(VGroup(vect_brace, vect_brace.tex))
-            for vect_brace in v_brace, w_brace
+            for vect_brace in (v_brace, w_brace)
         ])
         self.wait()
         self.play(Write(func_tex))

--- a/old_projects/eola/chapter9.py
+++ b/old_projects/eola/chapter9.py
@@ -559,9 +559,9 @@ class IntroduceJennifer(JenniferScene):
             ]),
             [
                 ApplyMethod(pi.change_mode, "plain") 
-                for pi in self.jenny, self.you
+                for pi in (self.jenny, self.you)
             ],
-            [mob.restore for mob in b1, b2, b1.label, b2.label]
+            [mob.restore for mob in (b1, b2, b1.label, b2.label)]
         ))
         self.jenny.bubble.restore()
 
@@ -1548,7 +1548,7 @@ class JennyWatchesRotation(JenniferScene):
         self.play(*it.chain(
             [
                 Rotate(mob, np.pi/2, run_time = 3)
-                for mob in self.jenny_plane, self.b1, self.b2
+                for mob in (self.jenny_plane, self.b1, self.b2)
             ],
             map(Animation, [jenny, jenny.bubble, matrix])
         ))
@@ -1757,7 +1757,7 @@ class JennyWatchesRotationWithMatrixAndVector(JenniferScene):
         self.play(*it.chain(
             [
                 Rotate(mob, np.pi/2, run_time = 3) 
-                for mob in self.jenny_plane, self.b1, self.b2, vector
+                for mob in (self.jenny_plane, self.b1, self.b2, vector)
             ],
             map(Animation, [self.jenny, matrix, vector_array]),
         ))

--- a/old_projects/eola/footnote.py
+++ b/old_projects/eola/footnote.py
@@ -1,4 +1,5 @@
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 class OpeningQuote(Scene):
     def construct(self):

--- a/old_projects/eola/footnote2.py
+++ b/old_projects/eola/footnote2.py
@@ -37,7 +37,7 @@ class ColumnsRepresentBasisVectors(Scene):
         matrix = Matrix([[3, 1], [4, 1], [5, 9]])
         i_hat_words, j_hat_words = [
             TextMobject("Where $\\hat{\\%smath}$ lands"%char)
-            for char in "i", "j"
+            for char in ("i", "j")
         ]
         i_hat_words.set_color(X_COLOR)
         i_hat_words.next_to(ORIGIN, LEFT).to_edge(UP)
@@ -166,7 +166,7 @@ class DescribeColumnsInSpecificTransformation(Scene):
         ])
         matrix.set_color_columns(X_COLOR, Y_COLOR)
         mob_matrix = matrix.get_mob_matrix()
-        i_col, j_col = [VMobject(*mob_matrix[:,i]) for i in 0, 1]
+        i_col, j_col = [VMobject(*mob_matrix[:,i]) for i in (0, 1)]
         for col, char, vect in zip([i_col, j_col], ["i", "j"], [UP, DOWN]):
             color = col[0].get_color()
             col.words = TextMobject("Where $\\hat\\%smath$ lands"%char)
@@ -572,7 +572,7 @@ class DotProductPreview(VectorScene):
         dot_product = np.dot(self.v.get_end(), self.w.get_end())
         v_norm, w_norm = [
             np.linalg.norm(vect.get_end())
-            for vect in self.v, self.w
+            for vect in (self.v, self.w)
         ]
         projected_w = Vector(
             self.v.get_end()*dot_product/(v_norm**2),
@@ -595,7 +595,7 @@ class DotProductPreview(VectorScene):
                 Line(ORIGIN, norm*RIGHT), 
                 UP
             )
-            for norm in 1, self.v.get_length(), dot_product
+            for norm in (1, self.v.get_length(), dot_product)
         ]
         length_texs = list(it.starmap(TexMobject, [
             ("1",),

--- a/old_projects/eulers_characteristic_formula.py
+++ b/old_projects/eulers_characteristic_formula.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -13,7 +14,7 @@ from mobject.region import  *
 import displayer as disp
 from scene.scene import Scene, GraphScene
 from scene.graphs import *
-from moser_main import EulersFormula
+from .moser_main import EulersFormula
 from script_wrapper import command_line_create_scene
 
 MOVIE_PREFIX = "ecf_graph_scenes/"
@@ -726,7 +727,7 @@ class ExamplesOfGraphs(GraphScene):
             found = False
             while True:
                 try:
-                    cycle1, cycle2 = region_pairs.next()
+                    cycle1, cycle2 = next(region_pairs)
                 except:
                     return
                 shared = set(cycle1).intersection(cycle2)

--- a/old_projects/fourier.py
+++ b/old_projects/fourier.py
@@ -35,7 +35,7 @@ def get_fourier_graph(
     graph.set_color(color)
     f_min, f_max = [
         axes.x_axis.point_to_number(graph.points[i])
-        for i in 0, -1
+        for i in (0, -1)
     ]
     graph.underlying_function = lambda f : axes.y_axis.point_to_number(
         graph.point_from_proportion((f - f_min)/(f_max - f_min))
@@ -291,7 +291,7 @@ class AddingPureFrequencies(PiCreatureScene):
             self.pi_creature.change, "thinking",
             *[
                 ShowCreation(graph, run_time = 4, rate_func = None)
-                for graph in self.A_graph, self.D_graph
+                for graph in (self.A_graph, self.D_graph)
             ]
         )
         self.wait()
@@ -322,7 +322,7 @@ class AddingPureFrequencies(PiCreatureScene):
             map(MoveToTarget, movers),
             [
                 ApplyMethod(mob.shift, FRAME_Y_RADIUS*DOWN, remover = True)
-                for mob in  randy, speaker
+                for mob in  (randy, speaker)
             ]
         ))
         self.wait()
@@ -1114,7 +1114,7 @@ class WrapCosineGraphAroundCircle(FourierMachineScene):
             DashedLine(
                 ORIGIN, 2*UP, color = RED
             ).move_to(axes.coords_to_point(x, 0), DOWN)
-            for x in 1, 2
+            for x in (1, 2)
         ])
         words = self.get_bps_label()
         words.save_state()
@@ -1714,7 +1714,7 @@ class ShowLowerFrequency(DrawFrequencyPlot):
             DashedLine(ORIGIN, 1.5*UP).move_to(
                 axes.coords_to_point(x, 0), DOWN
             )
-            for x in 1, 2
+            for x in (1, 2)
         ])
         bps_label = self.get_bps_label(2)
         bps_label.save_state()
@@ -1866,7 +1866,7 @@ class ShowLinearity(DrawFrequencyPlot):
                 scale_val = 0.5,
                 shift_val = 0.55,
             )
-            for freq in low_freq, high_freq
+            for freq in (low_freq, high_freq)
         ]
         sum_graph = self.get_time_graph(
             lambda t : sum([
@@ -2120,7 +2120,7 @@ class ShowCommutativeDiagram(ShowLinearity):
                 ReplacementTransform(
                     getattr(ta, attr), getattr(fa, attr)
                 )
-                for attr in "x_axis", "y_axis", "graph"
+                for attr in ("x_axis", "y_axis", "graph")
             ]
             anims += [
                 GrowArrow(ta.arrow),
@@ -2308,7 +2308,7 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
 
         func = lambda t : sum([
             np.cos(TAU*f*t)
-            for f in 0.5, 0.7, 1.0, 1.2, 3.0,
+            for f in (0.5, 0.7, 1.0, 1.2, 3.0,)
         ])
         graph = axes.get_graph(func)
         graph.set_color(BLUE)
@@ -2457,7 +2457,7 @@ class FilterOutHighPitch(AddingPureFrequencies, ShowCommutativeDiagram):
                 start_stroke_width = 5,
                 **kwargs
             )
-            for n in 5, 7, 10, 12
+            for n in (5, 7, 10, 12)
         ]
 
 class AskAboutInverseFourier(TeacherStudentsScene):
@@ -2788,7 +2788,7 @@ class WriteComplexExponentialExpression(DrawFrequencyPlot):
         #Show arc
         arc, circle = [
             Line(ORIGIN, t*UP)
-            for t in get_t(), TAU
+            for t in (get_t(), TAU)
         ]
         for mob in arc, circle:
             mob.insert_n_anchor_points(20)
@@ -3315,7 +3315,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
             axes.get_graph(
                 graph.underlying_function, x_min = 0, x_max = t_max,
             ).match_style(graph)
-            for t_max in 3, 6
+            for t_max in (3, 6)
         ]
         for g in short_graph, long_graph:
             self.get_polarized_mobject(g, freq = self.initial_winding_frequency)
@@ -3400,7 +3400,7 @@ class ScaleUpCenterOfMass(WriteComplexExponentialExpression):
                         0.5, 1, smooth(a)
                     )
                 )
-                for mob in long_graph, long_graph.polarized_mobject
+                for mob in (long_graph, long_graph.polarized_mobject)
             ],
             run_time = 2
         )
@@ -3843,7 +3843,7 @@ class BoundsAtInfinity(SummarizeFormula):
         bound_rects.set_color(TEAL)
         inf_bounds = VGroup(*[
             VGroup(TexMobject(s + "\\infty"))
-            for s in "-", "+"
+            for s in ("-", "+")
         ])
         decimal_bounds = VGroup(*[DecimalNumber(0) for x in range(2)])
         for bound, inf_bound, d_bound in zip(bounds, inf_bounds, decimal_bounds):
@@ -3928,7 +3928,7 @@ class BoundsAtInfinity(SummarizeFormula):
     def get_time_interval(self, t1, t2):
         line = Line(*[
             self.axes.coords_to_point(t, 0)
-            for t in t1, t2
+            for t in (t1, t2)
         ])
         rect = Rectangle(
             stroke_width = 0,

--- a/old_projects/fractal_dimension.py
+++ b/old_projects/fractal_dimension.py
@@ -1,4 +1,6 @@
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 def break_up(mobject, factor = 1.3):
     mobject.scale_in_place(factor)
@@ -498,7 +500,7 @@ class ExamplesOfDimension(Scene):
     def construct(self):
         labels = VGroup(*[
             TextMobject("%s-dimensional"%s)
-            for s in "1.585", "1.262", "1.21"
+            for s in ("1.585", "1.262", "1.21")
         ])
         fractals = VGroup(*[
             Sierpinski(order = 7),
@@ -548,7 +550,7 @@ class DimensionForNaturalNumbers(Scene):
     def construct(self):
         labels = VGroup(*[
             TextMobject("%d-dimensional"%d)
-            for d in 1, 2, 3
+            for d in (1, 2, 3)
         ])
         for label, vect in zip(labels, [LEFT, ORIGIN, RIGHT]):
             label.to_edge(vect)
@@ -2380,7 +2382,7 @@ class DifferentSlopesAtDifferentScales(IntroduceLogLogPlot):
         words.to_edge(RIGHT)
         arrows = VGroup(*[
             Arrow(words.get_left(), self.input_to_graph_point(x))
-            for x in 1, 7, 12
+            for x in (1, 7, 12)
         ])
 
 
@@ -2567,7 +2569,7 @@ class WhatSlopeDoesLogLogPlotApproach(IntroduceLogLogPlot):
         words = TextMobject(self.words)
         p1, p2 = [
             data_dots[int(alpha*len(data_dots))].get_center()
-            for alpha in 0.3, 0.5
+            for alpha in (0.3, 0.5)
         ]
         words.rotate(Line(p1, p2).get_angle())
         words.next_to(p1, RIGHT, aligned_edge = DOWN, buff = 1.5)
@@ -2639,7 +2641,7 @@ class SmoothBritainLogLogPlot(IntroduceLogLogPlot):
 
         p1, p2, p3, p4 = [
             self.input_to_graph_point(x)
-            for x in 1, 2, 7, 8
+            for x in (1, 2, 7, 8)
         ]
         interim_point1 = p2[0]*RIGHT + p1[1]*UP
         interim_point2 = p4[0]*RIGHT + p3[1]*UP
@@ -2742,7 +2744,7 @@ class CompareBritainAndNorway(Scene):
                 mob.set_stroke, None, 0,
                 mob.set_fill, BLUE, 1
             ]
-            for mob in britain, norway
+            for mob in (britain, norway)
         ]))
         self.wait(2)
 

--- a/old_projects/generate_logo.py
+++ b/old_projects/generate_logo.py
@@ -43,7 +43,7 @@ class LogoGeneration(Scene):
             self.interpolation_factor
         )
         for mob, color in [(iris, self.sphere_brown), (circle, self.circle_brown)]:
-            mob.set_color(color, lambda (x, y, z) : x < 0 and y > 0)
+            mob.set_color(color, lambda x_y_z : x_y_z[0] < 0 and x_y_z[1] > 0)
             mob.set_color(
                 "black", 
                 lambda point: np.linalg.norm(point) < \

--- a/old_projects/hanoi.py
+++ b/old_projects/hanoi.py
@@ -93,7 +93,7 @@ class CountingScene(Scene):
         added_anims += self.get_new_configuration_animations()
         while continue_rolling_over:          
             moving_dot.target.replace(
-                self.dot_template_iterators[place].next()
+                next(self.dot_template_iterators[place])
             )
             if run_all_at_once:
                 denom = float(num_rollovers+1)
@@ -267,7 +267,7 @@ class TowersOfHanoiScene(Scene):
         peg.move_to(self.middle_peg_bottom, DOWN)
         self.pegs = VGroup(*[
             peg.copy().shift(vect)
-            for vect in self.peg_spacing*LEFT, ORIGIN, self.peg_spacing*RIGHT
+            for vect in (self.peg_spacing*LEFT, ORIGIN, self.peg_spacing*RIGHT)
         ])
         self.add(self.pegs)
         if self.include_peg_labels:
@@ -1357,7 +1357,7 @@ class IntroduceSolveByCounting(TowersOfHanoiScene):
         ])
         bit_mobs.scale(2)
         self.bit_mobs_iter = it.cycle(bit_mobs)
-        self.curr_bit_mob = self.bit_mobs_iter.next()
+        self.curr_bit_mob = next(self.bit_mobs_iter)
 
         for bit_mob in bit_mobs:
             bit_mob.align_data(self.curr_bit_mob)
@@ -1370,7 +1370,7 @@ class IntroduceSolveByCounting(TowersOfHanoiScene):
     def get_increment_animation(self):
         return Succession(
             Transform(
-                self.curr_bit_mob, self.bit_mobs_iter.next(),
+                self.curr_bit_mob, next(self.bit_mobs_iter),
                 submobject_mode = "lagged_start",
                 path_arc = -np.pi/3
             ),
@@ -1836,7 +1836,7 @@ class ShowFourDiskFourBitsParallel(IntroduceSolveByCounting):
 
     def get_increment_animation(self):
         return Transform(
-            self.curr_bit_mob, self.bit_mobs_iter.next(),
+            self.curr_bit_mob, next(self.bit_mobs_iter),
             path_arc = -np.pi/3,
         )
  
@@ -2259,7 +2259,7 @@ class SolveConstrainedByCounting(ConstrainedTowersOfHanoiScene):
             ternary_mobs.add(ternary_mob)
         ternary_mobs.next_to(self.peg_labels, DOWN)
         self.ternary_mob_iter = it.cycle(ternary_mobs)
-        self.curr_ternary_mob = self.ternary_mob_iter.next()
+        self.curr_ternary_mob = next(self.ternary_mob_iter)
         self.add(self.curr_ternary_mob)
 
         for index in get_ternary_ruler_sequence(self.num_disks-1):
@@ -2270,7 +2270,7 @@ class SolveConstrainedByCounting(ConstrainedTowersOfHanoiScene):
     def increment_animation(self):
         return Succession(
             Transform(
-                self.curr_ternary_mob, self.ternary_mob_iter.next(),
+                self.curr_ternary_mob, next(self.ternary_mob_iter),
                 submobject_mode = "lagged_start",
                 path_arc = np.pi/6,
             ),
@@ -2429,7 +2429,7 @@ class TernaryCountingSelfSimilarPattern(Scene):
         ])
         ternary_mobs.scale(2)
         ternary_mob_iter = it.cycle(ternary_mobs)
-        curr_ternary_mob = ternary_mob_iter.next()
+        curr_ternary_mob = next(ternary_mob_iter)
 
         for trits in ternary_mobs:
             trits.align_data(curr_ternary_mob)
@@ -2437,7 +2437,7 @@ class TernaryCountingSelfSimilarPattern(Scene):
                 trit.set_color(color)
         def get_increment():
             return Transform(
-                curr_ternary_mob, ternary_mob_iter.next(),
+                curr_ternary_mob, next(ternary_mob_iter),
                 submobject_mode = "lagged_start",
                 path_arc = -np.pi/3
             )
@@ -2504,7 +2504,7 @@ class SolveConstrainedWithTernaryCounting(ConstrainedTowersOfHanoiScene):
 
     def increment_number(self, run_time = 1):
         self.play(Transform(
-            self.curr_ternary_mob, self.ternary_mob_iter.next(),
+            self.curr_ternary_mob, next(self.ternary_mob_iter),
             path_arc = -np.pi/3,
             submobject_mode = "lagged_start", 
             run_time = run_time,
@@ -2512,7 +2512,7 @@ class SolveConstrainedWithTernaryCounting(ConstrainedTowersOfHanoiScene):
 
     def move_next_disk(self, run_time = None, stay_on_peg = False):
         self.move_disk(
-            self.disk_index_iter.next(), 
+            next(self.disk_index_iter), 
             run_time = run_time,
             stay_on_peg = stay_on_peg
         )
@@ -2986,7 +2986,7 @@ class IntroduceGraphStructure(SierpinskiGraphScene):
             vect = -vect
 
     def define_edges(self):
-        nodes = [self.nodes[i] for i in 12, 14]
+        nodes = [self.nodes[i] for i in (12, 14)]
         for node, vect in zip(nodes, [LEFT, RIGHT]):
             node.save_state()
             node.generate_target()

--- a/old_projects/highD.py
+++ b/old_projects/highD.py
@@ -1937,7 +1937,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
             self.circle.copy().move_to(
                 self.plane.coords_to_point(*coords)
             ).set_color(GREY)
-            for coords in (1, 1), (-1, 1), (-1, -1)
+            for coords in ((1, 1), (-1, 1), (-1, -1))
         ])
         line = Line(
             self.plane.coords_to_point(-1, -1),
@@ -2055,7 +2055,7 @@ class TwoDBoxWithSliders(TwoDimensionalCase):
                     mob.shift,
                     slider.number_to_point(1) - slider.number_to_point(-1)
                 )
-                for mob in slider.real_estate_ticks, slider.dial
+                for mob in (slider.real_estate_ticks, slider.dial)
             ]
         )
         slider.center_value = 1
@@ -2657,7 +2657,7 @@ class TwoDInnerSphereTouchingBox(TwoDBoxWithSliders, PiCreatureScene):
                 radius = radius*self.plane.x_unit_size,
                 color = GREEN
             ).move_to(self.plane.coords_to_point(0, 0))
-            for radius in np.sqrt(2)-1, 1
+            for radius in (np.sqrt(2)-1, 1)
         ]
         randy = self.randy
         tangency_points = VGroup(*[

--- a/old_projects/hilbert/fractal_porn.py
+++ b/old_projects/hilbert/fractal_porn.py
@@ -228,7 +228,7 @@ class FromKochToSpaceFilling(Scene):
         words.to_edge(UP)
         koch, sharper_koch, duller_koch = curves = [
             CurveClass(order = 1)
-            for CurveClass in StraightKoch, SharperKoch, DullerKoch
+            for CurveClass in (StraightKoch, SharperKoch, DullerKoch)
         ]
         arcs = [
             Arc(
@@ -276,11 +276,11 @@ class FromKochToSpaceFilling(Scene):
             text.to_edge(UP)
         sharper, duller, space_filling = [
             CurveClass(order = 1).shift(3*LEFT)
-            for CurveClass in SharperKoch, DullerKoch, SpaceFillingKoch
+            for CurveClass in (SharperKoch, DullerKoch, SpaceFillingKoch)
         ]
         shaper_f, duller_f, space_filling_f = [
             CurveClass(order = self.max_order).shift(3*RIGHT)
-            for CurveClass in SharperKoch, DullerKoch, SpaceFillingKoch
+            for CurveClass in (SharperKoch, DullerKoch, SpaceFillingKoch)
         ]
 
         self.add(words[0])

--- a/old_projects/hilbert/section1.py
+++ b/old_projects/hilbert/section1.py
@@ -101,7 +101,7 @@ class AboutSpaceFillingCurves(TransformOverIncreasingOrders):
         self.wait()
         self.play(*[
             ShimmerIn(mob)
-            for mob in infinity, rightarrow, N
+            for mob in (infinity, rightarrow, N)
         ] + [
             ApplyMethod(question_mark.next_to, rightarrow, UP),
         ])
@@ -540,11 +540,11 @@ class ThinkInTermsOfReverseMapping(Scene):
         arrow2 = Arrow(4*RIGHT+UP, dot2, color = color2, buff = 0.1)
         dot3, arrow3 = [
             mob.copy().shift(5*LEFT+UP)
-            for mob in dot1, arrow1
+            for mob in (dot1, arrow1)
         ]
         dot4, arrow4 = [
             mob.copy().shift(5*LEFT+0.9*UP)
-            for mob in dot2, arrow2
+            for mob in (dot2, arrow2)
         ]
 
         self.add(grid, freq_line, arrow)
@@ -659,7 +659,7 @@ class TellMathematicianFriend(Scene):
         mathy, bubble = get_mathy_and_bubble()
         squiggle_mouth = mathy.mouth.copy()
         squiggle_mouth.apply_function(
-            lambda (x, y, z) : (x, y+0.02*np.sin(50*x), z)
+            lambda x_y_z : (x_y_z[0], x_y_z[1]+0.02*np.sin(50*x_y_z[0]), x_y_z[2])
         )
         bubble.ingest_submobjects()        
         bubble.write("Why not use a Hilbert curve \\textinterrobang ")
@@ -898,7 +898,7 @@ class HilbertBetterThanSnakeQ(Scene):
                 CurveClass(order = n)
                 for n in range(2, 7)
             ]
-            for CurveClass in HilbertCurve, SnakeCurve
+            for CurveClass in (HilbertCurve, SnakeCurve)
         ]
         for curve in hilbert_curves+snake_curves:
             curve.scale(0.8)
@@ -949,7 +949,7 @@ class IncreaseResolution(Scene):
                 2**order, 2**order,
                 stroke_width = 1
             ).shift(0.3*DOWN)
-            for order in 6, 7
+            for order in (6, 7)
         ]
         grid = grids[0]
         side_brace = Brace(grid, LEFT)
@@ -995,7 +995,7 @@ class IncreasingResolutionWithSnakeCurve(Scene):
                     (0.7, RED)
                 ]
             ])
-            for curve in start_curve, end_curve
+            for curve in (start_curve, end_curve)
         ]
         self.add(start_curve)
         self.wait()

--- a/old_projects/hilbert/section2.py
+++ b/old_projects/hilbert/section2.py
@@ -190,7 +190,7 @@ class HistoryOfDiscover(Scene):
         peano_curve.to_corner(UP+LEFT)
         squares = Mobject(*[
             Square(side_length=3, color=WHITE).replace(curve)
-            for curve in hilbert_curve, peano_curve
+            for curve in (hilbert_curve, peano_curve)
         ])
 
 
@@ -499,15 +499,15 @@ class FormalDefinitionOfContinuity(Scene):
         self.input_dot = Dot(color = self.input_color)
         self.output_dot = self.input_dot.copy().set_color(self.output_color)
         left, right = self.interval.get_left(), self.interval.get_right()
-        self.input_homotopy = lambda (x, y, z, t) : (x, y, t) + interpolate(left, right, t)
+        self.input_homotopy = lambda x_y_z_t : (x_y_z_t[0], x_y_z_t[1], x_y_z_t[3]) + interpolate(left, right, x_y_z_t[3])
         output_size = self.output.get_num_points()-1
         output_points = self.output.points        
-        self.output_homotopy = lambda (x, y, z, t) : (x, y, z) + output_points[int(t*output_size)]
+        self.output_homotopy = lambda x_y_z_t1 : (x_y_z_t1[0], x_y_z_t1[1], x_y_z_t1[2]) + output_points[int(x_y_z_t1[3]*output_size)]
 
     def get_circles_and_points(self, min_input, max_input):
         input_left, input_right = [
             self.interval.number_to_point(num)
-            for num in min_input, max_input
+            for num in (min_input, max_input)
         ]
         input_circle = Circle(
             radius = np.linalg.norm(input_left-input_right)/2,
@@ -811,7 +811,7 @@ class WonderfulPropertyOfPseudoHilbertCurves(Scene):
             FadeOut(arrow),
             *[
                 FadeIn(func_parts[i])
-                for i in 0, 1, 2, 4
+                for i in (0, 1, 2, 4)
             ]
         )
         for num in range(2,9):

--- a/old_projects/inventing_math.py
+++ b/old_projects/inventing_math.py
@@ -9,6 +9,7 @@ from random import sample
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
+from functools import reduce
 
 # from inventing_math_images import *
 
@@ -351,7 +352,7 @@ class YouAsMathematician(Scene):
         bubble.clear()
         dot_pair = [
             Dot(density = 3*DEFAULT_POINT_DENSITY_1D).shift(x+UP)
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         self.add(you, explanation)
         self.play(
@@ -376,7 +377,7 @@ class YouAsMathematician(Scene):
         self.add(*dot_pair)
         two_arrows = [
             Arrow(x, direction = x).shift(UP).nudge()
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         self.play(*[ShowCreation(a) for a in two_arrows])
         self.play(BlinkPiCreature(you))
@@ -412,7 +413,7 @@ class DotsGettingCloser(Scene):
     def construct(self):
         dots = [
             Dot(radius = 3*Dot.DEFAULT_RADIUS).shift(3*x)
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         self.add(*dots)
         self.wait()
@@ -428,7 +429,7 @@ class ZoomInOnInterval(Scene):
         interval = zero_to_one_interval().split()
 
         new_line = deepcopy(number_line)
-        new_line.set_color("black", lambda (x,y,z) : x < 0 or x > 1 or y < -0.2)
+        new_line.set_color("black", lambda x_y_z1 : x_y_z1[0] < 0 or x_y_z1[0] > 1 or x_y_z1[1] < -0.2)
         # height = new_line.get_height()
         new_line.scale(2*INTERVAL_RADIUS)
         new_line.shift(INTERVAL_RADIUS*LEFT)
@@ -465,7 +466,7 @@ class DanceDotOnInterval(Scene):
         interval = zero_to_one_interval()
         dots = [
             Dot(radius = 3*Dot.DEFAULT_RADIUS).shift(INTERVAL_RADIUS*x+UP)
-            for x in LEFT, RIGHT
+            for x in (LEFT, RIGHT)
         ]
         color_range = Color("green").range_to("yellow", num_written_terms)
         conv_sum = TexMobject(sum_terms, size = "\\large").split()
@@ -480,7 +481,7 @@ class DanceDotOnInterval(Scene):
             shift_val = 2*RIGHT*INTERVAL_RADIUS*(1-prop)*(prop**count)
             start = dots[0].get_center()
             line = Line(start, start + shift_val*RIGHT)
-            line.set_color(color_range.next())
+            line.set_color(next(color_range))
             self.play(
                 ApplyMethod(dots[0].shift, shift_val),
                 ShowCreation(line)
@@ -570,7 +571,7 @@ class SeeNumbersApproachOne(Scene):
             ).scale(1+1.0/2.0**x).shift(
                 INTERVAL_RADIUS*RIGHT +\
                 (INTERVAL_RADIUS/2.0**x)*LEFT
-            ).set_color(colors.next())
+            ).set_color(next(colors))
             for x in range(num_dots)
         ])
 
@@ -661,7 +662,7 @@ class ListOfPartialSums(Scene):
         ).split())
         numbers, equals, sums = [
             all_terms[range(k, 12, 3)]
-            for k in 0, 1, 2
+            for k in (0, 1, 2)
         ]
         dots = all_terms[12]
         one = all_terms[-3]
@@ -755,7 +756,7 @@ class CircleZoomInOnOne(Scene):
 
         self.play(*[
             DelayByOrder(FadeIn(mob))
-            for mob in arrow, curr_num
+            for mob in (arrow, curr_num)
         ])
         self.wait()
         for num in numbers[1:] + [text]:
@@ -775,16 +776,16 @@ class ZoomInOnOne(Scene):
     def construct(self):
         num_iterations = 8
         number_line = NumberLine(interval_size = 1, radius = FRAME_X_RADIUS+2)
-        number_line.filter_out(lambda (x, y, z):abs(y)>0.1)
+        number_line.filter_out(lambda x_y_z2:abs(x_y_z2[1])>0.1)
         nl_with_nums = deepcopy(number_line).add_numbers()
         self.play(ApplyMethod(nl_with_nums.shift, 2*LEFT))
         zero, one, two = [
             TexMobject(str(n)).scale(0.5).shift(0.4*DOWN+2*(-1+n)*RIGHT)
-            for n in 0, 1, 2
+            for n in (0, 1, 2)
         ]
         self.play(
             FadeOut(nl_with_nums),
-            *[Animation(mob) for mob in zero, one, two, number_line]
+            *[Animation(mob) for mob in (zero, one, two, number_line)]
         )
         self.remove(nl_with_nums, number_line, zero, two)
         powers_of_10 = [10**(-n) for n in range(num_iterations+1)]
@@ -796,7 +797,7 @@ class ZoomInOnOne(Scene):
 
     def zoom_with_numbers(self, numbers, next_numbers):
         all_numbers = map(
-            lambda (n, u): TexMobject(str(n)).scale(0.5).shift(0.4*DOWN+2*u*RIGHT),
+            lambda n_u: TexMobject(str(n_u[0])).scale(0.5).shift(0.4*DOWN+2*n_u[1]*RIGHT),
             zip(numbers+next_numbers, it.cycle([-1, 1]))
         )
 
@@ -807,7 +808,7 @@ class ZoomInOnOne(Scene):
                 interval_size = 1, 
                 density = scale_factor*DEFAULT_POINT_DENSITY_1D
             ).filter_out(
-                lambda (x, y, z):abs(y)>0.1
+                lambda x_y_z:abs(x_y_z[1])>0.1
             ).scale(1.0/scale_factor**x)
             for x in range(num_levels)
         ]
@@ -823,7 +824,7 @@ class ZoomInOnOne(Scene):
                 2*LEFT*(scale_factor-1)*(-1)**i, 
                 **kwargs
             )
-            for i in 0, 1
+            for i in (0, 1)
         ]+[
             Transform(Point(0.4*DOWN + u*0.2*RIGHT), num, **kwargs)
             for u, num in zip([-1, 1], all_numbers[2:])
@@ -917,7 +918,7 @@ class DefineInfiniteSum(Scene):
         ]
         self.play(*[
             Transform(lines[x], lines[x+1], run_time = 3.0)
-            for x in 0, 2
+            for x in (0, 2)
         ])
 
 
@@ -982,7 +983,7 @@ class ChopIntervalInProportions(Scene):
                     TexMobject("\\frac{%d}{%d}"%(k, (10**(count+1))))
                     for count in range(num_terms)
                 ]
-                for k in 9, 1
+                for k in (9, 1)
             ]
         if mode == "p":
             num_terms = 4         
@@ -1359,7 +1360,7 @@ class SumPowersOfTwoAnimation(Scene):
         topbrace = Underbrace(top_brace_left, right).rotate(np.pi, RIGHT)
         bottombrace = Underbrace(bottom_brace_left, right)
         colors = Color("yellow").range_to("purple", iterations)
-        curr_dots.set_color(colors.next())
+        curr_dots.set_color(next(colors))
         equation = TexMobject(
             "1+2+4+\\cdots+2^n=2^{n+1} - 1",
             size = "\\Huge"
@@ -1386,7 +1387,7 @@ class SumPowersOfTwoAnimation(Scene):
             shift_val = (2**n)*(dot_width+dot_buff)
             right += shift_val
             new_dots = Mobject(new_dot, curr_dots)
-            new_dots.set_color(colors.next()).shift(shift_val)
+            new_dots.set_color(next(colors)).shift(shift_val)
             alt_bottombrace = deepcopy(bottombrace).shift(shift_val)
             alt_bottom_num = deepcopy(bottom_num).shift(shift_val)
             alt_topbrace = deepcopy(alt_bottombrace).rotate(np.pi, RIGHT)
@@ -1655,9 +1656,9 @@ class TriangleInequality(Scene):
         self.play(ShowCreation(ac_line), FadeIn(ac_copy))
         self.wait()
         self.play(*[
-            ShowCreation(line) for line in ab_line, bc_line
+            ShowCreation(line) for line in (ab_line, bc_line)
         ]+[
-            FadeIn(dist) for dist in ab_copy, bc_copy
+            FadeIn(dist) for dist in (ab_copy, bc_copy)
         ])
         self.wait()
         self.play(*[
@@ -1665,7 +1666,7 @@ class TriangleInequality(Scene):
             for pair in zip(all_copies, all_dists)
         ]+[
             FadeIn(mob)
-            for mob in plus, greater_than
+            for mob in (plus, greater_than)
         ])
         self.wait()
 
@@ -1844,7 +1845,7 @@ class RoomsAndSubroomsWithNumbers(Scene):
                 return mob
             self.play(*[
                 ApplyFunction(transform, mob)
-                for mob in zero_copy, power_mob_copy
+                for mob in (zero_copy, power_mob_copy)
             ])
             last_left_mob = zero
             for n in range(power+1, 2*power):
@@ -1852,7 +1853,7 @@ class RoomsAndSubroomsWithNumbers(Scene):
                 shift_val = left_mob.get_center()-last_left_mob.get_center()
                 self.play(*[
                     ApplyMethod(mob.shift, shift_val)
-                    for mob in zero_copy, power_mob_copy
+                    for mob in (zero_copy, power_mob_copy)
                 ])
                 num_mobs[n] = TexMobject(str(n))
                 num_mobs[n].scale(1.0/(power_of_divisor(n, 2)+1))
@@ -1901,7 +1902,7 @@ class RoomsAndSubroomsWithNumbers(Scene):
             self.clear_way_for_text(text, cluster)
             self.add(*cluster)          
             pairs = filter(
-                lambda (a, b) : (a-b)%(2**count) == 0 and (a-b)%(2**(count+1)) != 0,
+                lambda a_b : (a_b[0]-a_b[1])%(2**count) == 0 and (a_b[0]-a_b[1])%(2**(count+1)) != 0,
                 it.combinations(range(16), 2)
             )
             for pair in sample(pairs, min(10, len(pairs))):
@@ -1922,7 +1923,8 @@ class RoomsAndSubroomsWithNumbers(Scene):
     def clear_way_for_text(text, mobjects):
         right, top, null = np.max(text.points, 0)
         left, bottom, null = np.min(text.points, 0)
-        def filter_func((x, y, z)):
+        def filter_func(xxx_todo_changeme):
+            (x, y, z) = xxx_todo_changeme
             return x>left and x<right and y>bottom and y<top
         for mobject in mobjects:
             mobject.filter_out(filter_func)
@@ -1957,7 +1959,7 @@ class DeduceWhereNegativeOneFalls(Scene):
             rest_time = 0.3 + 1.0/(n+1)
             new_args = [
                 TextMobject("$%d$"%k).scale(1.5)
-                for k in 2**n-1, 2**n
+                for k in (2**n-1, 2**n)
             ]
             for new_arg, old_arg in zip(new_args, last_args):
                 new_arg.shift(old_arg.get_center())
@@ -2015,7 +2017,7 @@ class PAdicMetric(Scene):
         self.add(curr, text)
         self.wait()        
         for prime, count in zip(primes, it.count()):
-            prime.scale(1.0).set_color(colors.next())
+            prime.scale(1.0).set_color(next(colors))
             prime.shift(center_of_mass([p_str.get_top(), p_str.get_center()]))
             self.play(DelayByOrder(Transform(curr, prime)))
             self.wait()

--- a/old_projects/inventing_math_images.py
+++ b/old_projects/inventing_math_images.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -7,7 +8,7 @@ import sys
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
-from inventing_math import divergent_sum, draw_you
+from .inventing_math import divergent_sum, draw_you
 
 
 

--- a/old_projects/leibniz.py
+++ b/old_projects/leibniz.py
@@ -1,4 +1,5 @@
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 # revert_to_original_skipping_status
 
@@ -840,7 +841,7 @@ class CountLatticePoints(LatticePointScene):
                     "\\approx \\pi", "(", R, ")^2"
                 )
             ).arrange_submobjects(RIGHT)
-            for R in "10", "1{,}000{,}000", "R"
+            for R in ("10", "1{,}000{,}000", "R")
         ])
         radius_10_eq, radius_million_eq, radius_R_eq = equations
         for eq in equations:
@@ -1747,7 +1748,7 @@ class NameGaussianIntegers(LatticePointScene):
         integers.add_background_rectangle()
         arrows = VGroup(*[
             Arrow(integers.get_top(), mob, tip_length = 0.15)
-            for mob in a, b
+            for mob in (a, b)
         ])
         self.add_foreground_mobjects(label, integers, arrows)
 
@@ -1836,7 +1837,7 @@ class NameGaussianIntegers(LatticePointScene):
                     self.plane.coords_to_point(x, u*y),
                     color = PINK,
                 )
-                for u in 1, -1
+                for u in (1, -1)
             ])
             dot.conjugate_dot = self.circle_dots[-i]
 
@@ -1979,7 +1980,7 @@ class IntroduceGaussianPrimes(LatticePointScene, PiCreatureScene):
 
         labels = [
             TexMobject(tex).add_background_rectangle()
-            for tex in "5", "2+i", "2-i", "-1+2i", "-1-2i", "-2-i", "-2+i"
+            for tex in ("5", "2+i", "2-i", "-1+2i", "-1-2i", "-2-i", "-2+i")
         ]
         five_label, p1_label, p2_label, p3_label, p4_label, p5_label, p6_label = labels
         vects = [
@@ -2393,7 +2394,7 @@ class FactorTwo(LatticePointScene):
         two_dot.set_color(YELLOW)
         factor_dots = VGroup(*[
             Dot(self.plane.coords_to_point(1, u))
-            for u in 1, -1
+            for u in (1, -1)
         ])
         two_label = TexMobject("2").next_to(two_dot, DOWN)
         two_label.set_color(YELLOW)
@@ -2888,7 +2889,7 @@ class ThreeOutputsAsLatticePointsContinued(ThreeOutputsAsLatticePoints):
             dot.add(line)
         words_group = VGroup(*[
             TextMobject("Multiply by $%s$"%s)
-            for s in "1", "i", "-1", "-i"
+            for s in ("1", "i", "-1", "-i")
         ])
         for words, color in zip(words_group, self.colors):
             words.add_background_rectangle()
@@ -3212,7 +3213,7 @@ class SummarizeCountingRule(Show125Circle):
 
         three, five, thirteen = [
             factorization.get_part_by_tex(str(n), substring = False)
-            for n in 3, 5, 13
+            for n in (3, 5, 13)
         ]
         three_power = factorization.get_part_by_tex("^4")
         five_power = factorization.get_part_by_tex("^3")
@@ -3583,7 +3584,7 @@ class IntroduceChi(FactorizationPattern):
             )
             braces = [
                 Brace(expression[i], UP) 
-                for i in 0, 2, 4
+                for i in (0, 2, 4)
             ]
             for brace, n in zip(braces, [x, y, x*y]):
                 output = chi_func(n)
@@ -4350,7 +4351,7 @@ class AddUpGrid(Scene):
                 rect.copy().move_to(self.radicals[N-1], LEFT)
                 for N in numbers
             ])
-            for numbers in [6, 12], [2, 3, 5, 7, 11]
+            for numbers in ([6, 12], [2, 3, 5, 7, 11])
         ]
         prime_rects.set_color(GREEN)
 

--- a/old_projects/matrix_as_transform_2d.py
+++ b/old_projects/matrix_as_transform_2d.py
@@ -93,9 +93,11 @@ class ExamplesOfOneDimensionalLinearTransforms(ShowMultiplication):
 
 class ExamplesOfNonlinearOneDimensionalTransforms(NumberLineScene):
     def construct(self):
-        def sinx_plux_x((x, y, z)):
+        def sinx_plux_x(xxx_todo_changeme):
+            (x, y, z) = xxx_todo_changeme
             return (np.sin(x) + 1.2*x, y, z)
-        def shift_zero((x, y, z)):
+        def shift_zero(xxx_todo_changeme2):
+            (x, y, z) = xxx_todo_changeme2
             return (2*x+4, y, z)
         self.nonlinear = TextMobject("Not a Linear Transform")
         self.nonlinear.set_color(LIGHT_RED).to_edge(UP, buff = 1.5)
@@ -187,10 +189,10 @@ class TransformScene2D(Scene):
         )
         self.add(self.x_arrow, self.y_arrow)
         self.number_plane.filter_out(
-            lambda (x, y, z) : (0 < x) and (x < 1) and (abs(y) < 0.1)
+            lambda x_y_z : (0 < x_y_z[0]) and (x_y_z[0] < 1) and (abs(x_y_z[1]) < 0.1)
         )
         self.number_plane.filter_out(
-            lambda (x, y, z) : (0 < y) and (y < 1) and (abs(x) < 0.1)
+            lambda x_y_z1 : (0 < x_y_z1[1]) and (x_y_z1[1] < 1) and (abs(x_y_z1[0]) < 0.1)
         )
         return self
 
@@ -293,9 +295,11 @@ class ExamplesOfTwoDimensionalLinearTransformations(ShowMatrixTransform):
 class ExamplesOfNonlinearTwoDimensionalTransformations(Scene):
     def construct(self):
         Scene.construct(self)
-        def squiggle((x, y, z)):
+        def squiggle(xxx_todo_changeme3):
+            (x, y, z) = xxx_todo_changeme3
             return (x+np.sin(y), y+np.cos(x), z)
-        def shift_zero((x, y, z)):
+        def shift_zero(xxx_todo_changeme4):
+            (x, y, z) = xxx_todo_changeme4
             return (2*x + 3*y + 4, -1*x+y+2, z)
         self.nonlinear = TextMobject("Nonlinear Transform")
         self.nonlinear.set_color(LIGHT_RED)
@@ -382,10 +386,12 @@ class TrickyExamplesOfNonlinearTwoDimensionalTransformations(Scene):
             UP*FRAME_Y_RADIUS+RIGHT*FRAME_X_RADIUS,
             density = 10*DEFAULT_POINT_DENSITY_1D
         )
-        def sunrise((x, y, z)):
+        def sunrise(xxx_todo_changeme5):
+            (x, y, z) = xxx_todo_changeme5
             return ((FRAME_Y_RADIUS+y)*x, y, z)
 
-        def squished((x, y, z)):
+        def squished(xxx_todo_changeme6):
+            (x, y, z) = xxx_todo_changeme6
             return (x + np.sin(x), y+np.sin(y), z)
 
         self.get_blackness()
@@ -534,7 +540,7 @@ class Show90DegreeRotation(TransformScene2D):
         self.wait()
         self.play(*[
             RotationAsTransform(mob, run_time = 2.0)
-            for mob in self.number_plane, self.x_arrow, self.y_arrow
+            for mob in (self.number_plane, self.x_arrow, self.y_arrow)
         ])
         self.wait()
 

--- a/old_projects/moser_intro.py
+++ b/old_projects/moser_intro.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 import operator as op
@@ -12,13 +13,13 @@ CIRCLE_DENSITY = DEFAULT_POINT_DENSITY_1D*RADIUS
 
 
 def logo_to_circle():
-    from generate_logo import DARK_BROWN, LOGO_RADIUS
+    from .generate_logo import DARK_BROWN, LOGO_RADIUS
     sc = Scene()
     small_circle = Circle(
         density = CIRCLE_DENSITY,
         color = 'skyblue'
     ).scale(LOGO_RADIUS).set_color(
-        DARK_BROWN, lambda (x, y, z) : x < 0 and y > 0
+        DARK_BROWN, lambda x_y_z : x_y_z[0] < 0 and x_y_z[1] > 0
     )
     big_circle = Circle(density = CIRCLE_DENSITY).scale(RADIUS)
     sc.add(small_circle)

--- a/old_projects/moser_main.py
+++ b/old_projects/moser_main.py
@@ -10,6 +10,7 @@ import inspect
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
+from functools import reduce
 
 RADIUS            = FRAME_Y_RADIUS - 0.1
 CIRCLE_DENSITY    = DEFAULT_POINT_DENSITY_1D*RADIUS
@@ -677,7 +678,7 @@ class GraphsAndEulersFormulaJoke(Scene):
             lambda t : (10*t, ((10*t)**3 - 10*t), 0),
             expected_measure = 40.0
         )
-        graph.filter_out(lambda (x, y, z) : abs(y) > FRAME_Y_RADIUS)
+        graph.filter_out(lambda x_y_z : abs(x_y_z[1]) > FRAME_Y_RADIUS)
         self.add(axes)
         self.play(ShowCreation(graph), run_time = 1.0)
         eulers = TexMobject("e^{\pi i} = -1").shift((0, 3, 0))
@@ -1568,7 +1569,7 @@ class ExplainNChoose2Formula(Scene):
         ])
         self.play(*[
             ApplyMethod(mob.shift, (0, 1, 0))
-            for mob in parens, a_mob, b_mob
+            for mob in (parens, a_mob, b_mob)
         ])
         parens_copy = deepcopy(parens).shift((0, -2, 0))
         a_center = a_mob.get_center()

--- a/old_projects/mug.py
+++ b/old_projects/mug.py
@@ -1247,7 +1247,7 @@ class ShowRule(TeacherStudentsScene):
                 color = WHITE,
                 buff = SMALL_BUFF
             )
-            for mob in new_vertex, new_region
+            for mob in (new_vertex, new_region)
         ])
         for word, arrow in zip(["Either", "or"], arrows):
             word_mob = TextMobject(word)

--- a/old_projects/music_and_measure.py
+++ b/old_projects/music_and_measure.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -7,7 +8,7 @@ import sys
 from fractions import Fraction, gcd
 
 from big_ol_pile_of_manim_imports import *
-from inventing_math import Underbrace
+from .inventing_math import Underbrace
 
 import random
 
@@ -212,7 +213,7 @@ class IntervalScene(NumberLineScene):
         all_rationals = rationals()
         count = 0
         while True:
-            fraction = all_rationals.next()
+            fraction = next(all_rationals)
             count += 1
             if num_intervals >= num_fractions:
                 break
@@ -314,7 +315,7 @@ class ChallengeOne(Scene):
         top_vibrations = [
             Vibrate(
                 num_periods = freq, run_time = 3.0,
-                center = 2*UP, color = colors.next()
+                center = 2*UP, color = next(colors)
             )
             for freq in [1, 2, 5.0/3, 4.0/3, 2]
         ]
@@ -581,7 +582,7 @@ class PatternInFrequencies(Scene):
         )
         anims = [
             ApplyMethod(mob.shift, setup_width*LEFT, **kwargs)
-            for mob in top_lines, bottom_lines
+            for mob in (top_lines, bottom_lines)
         ]
         anim_mobs = [anim.mobject for anim in anims]
         self.play(
@@ -614,12 +615,12 @@ class CompareFractionComplexity(Scene):
         self.add(simple, complicated)
         self.play(*[
             ShowCreation(arrow)
-            for arrow in arrow1, arrow2
+            for arrow in (arrow1, arrow2)
         ])
         self.wait()
         self.play(*[
             DelayByOrder(ApplyMethod(frac[1].set_color, "yellow"))
-            for frac in frac0, frac1
+            for frac in (frac0, frac1)
         ])
         self.play(
             FadeIn(indicates),
@@ -851,7 +852,7 @@ class AllValuesBetween1And2(NumberLineScene):
         }
         self.play(*[
             ApplyMethod(mob.shift, RIGHT, **kwargs)
-            for mob in r, top_arrow
+            for mob in (r, top_arrow)
         ])
         self.wait() 
         self.remove(r, top_arrow)
@@ -930,10 +931,10 @@ class DefineOpenInterval(IntervalScene):
         left_arrow = Arrow(a.get_corner(DOWN+LEFT), left)
         right_arrow = Arrow(b.get_corner(DOWN+RIGHT), right)
 
-        self.play(*[ShimmerIn(mob) for mob in a, less_than1, x])
+        self.play(*[ShimmerIn(mob) for mob in (a, less_than1, x)])
         self.play(ShowCreation(left_arrow))
         self.wait()
-        self.play(*[ShimmerIn(mob) for mob in less_than2, b])
+        self.play(*[ShimmerIn(mob) for mob in (less_than2, b)])
         self.play(ShowCreation(right_arrow))
         self.wait()
 
@@ -1229,7 +1230,7 @@ class StepsToSolution(IntervalScene):
         arrow = Arrow(ORIGIN, RIGHT).next_to(dots)
         one = TexMobject("1").next_to(arrow)
         self.ones.append(one)
-        self.play(*[ShowCreation(mob) for mob in dots, arrow, one])
+        self.play(*[ShowCreation(mob) for mob in (dots, arrow, one)])
         self.wait()
 
     def multiply_by_epsilon(self):

--- a/old_projects/nn/network.py
+++ b/old_projects/nn/network.py
@@ -8,6 +8,7 @@ using backpropagation.  Note that I have focused on making the code
 simple, easily readable, and easily modifiable.  It is not optimized,
 and omits many desirable features.
 """
+from __future__ import print_function
 
 #### Libraries
 # Standard library
@@ -221,7 +222,7 @@ def test_network():
             n_right += 1
         else:
             n_wrong += 1
-    print(n_right, n_wrong, float(n_right)/(n_right + n_wrong))
+    print((n_right, n_wrong, float(n_right)/(n_right + n_wrong)))
 
 def layer_to_image_array(layer):
     w = int(np.ceil(np.sqrt(len(layer))))

--- a/old_projects/nn/part1.py
+++ b/old_projects/nn/part1.py
@@ -339,7 +339,7 @@ class ExampleThrees(PiCreatureScene):
         three_mob_copy = three_mob[1].copy()
         three_mob_copy.sort_submobjects(lambda p : np.dot(p, DOWN+RIGHT))
 
-        braces = VGroup(*[Brace(three_mob, v) for v in LEFT, UP])
+        braces = VGroup(*[Brace(three_mob, v) for v in (LEFT, UP)])
         brace_labels = VGroup(*[
             brace.get_text("28px")
             for brace in braces
@@ -1070,7 +1070,7 @@ class IntroduceEachLayer(PreviewMNistNetwork):
         neurons.space_out_submobjects(1.3)
         neurons.to_edge(DOWN)
 
-        braces = VGroup(*[Brace(neurons, vect) for vect in LEFT, UP])
+        braces = VGroup(*[Brace(neurons, vect) for vect in (LEFT, UP)])
         labels = VGroup(*[
             brace.get_tex("28", buff = SMALL_BUFF) 
             for brace in braces
@@ -1517,7 +1517,7 @@ class BreakUpMacroPatterns(IntroduceEachLayer):
         image_map = get_organized_images()
         two, three, five = mobs = [
             MNistMobject(image_map[n][0])
-            for n in 2, 3, 5
+            for n in (2, 3, 5)
         ]
         self.added_patterns = VGroup()
         for mob in mobs:
@@ -1846,7 +1846,7 @@ class BreakUpMicroPatterns(BreakUpMacroPatterns):
         image_map = get_organized_images()
         digits = VGroup(*[
             MNistMobject(image_map[n][1])
-            for n in 1, 4, 7
+            for n in (1, 4, 7)
         ])
         digits.arrange_submobjects(RIGHT)
         digits.next_to(randy, RIGHT)
@@ -1892,7 +1892,7 @@ class SecondLayerIsLittleEdgeLayer(IntroduceEachLayer):
         layers = self.network_mob.layers
         nine_im, loop_im, line_im = images = [
             Image.open(get_full_raster_image_path("handwritten_%s"%s))
-            for s in "nine", "upper_loop", "right_line"
+            for s in ("nine", "upper_loop", "right_line")
         ]
         nine_array, loop_array, line_array = [
             np.array(im)[:,:,0]/255.0
@@ -1929,7 +1929,7 @@ class SecondLayerIsLittleEdgeLayer(IntroduceEachLayer):
 
         loop, line = [
             ImageMobject(layer_to_image_array(array.flatten()))
-            for array in loop_array, line_array
+            for array in (loop_array, line_array)
         ]
         for mob, color in (loop, YELLOW), (line, RED):
             make_transparent(mob)
@@ -2571,7 +2571,7 @@ class IntroduceWeights(IntroduceEachLayer):
                 self.negative_weights_color,
                 0.5
             )
-            for y in 6, 10
+            for y in (6, 10)
             for x in range(14-4, 14+4)
         ])
         self.wait(2)
@@ -2597,7 +2597,7 @@ class IntroduceWeights(IntroduceEachLayer):
         d = int(np.sqrt(len(pixels)))
         return VGroup(*it.chain(*[
             pixels[d*n + d/2 - 4 : d*n + d/2 + 4]
-            for n in 6, 10
+            for n in (6, 10)
         ]))
 
     def make_edges_weighted(self, edges, weights):
@@ -2637,7 +2637,7 @@ class MotivateSquishing(Scene):
                 weighted_sum.get_bottom(),
                 number_line.number_to_point(n),
             )
-            for n in -3, 3
+            for n in (-3, 3)
         ]
 
         self.play(Write(number_line))
@@ -2761,7 +2761,7 @@ class IntroduceSigmoid(GraphScene):
                 x_max = x_max,
                 color = color,
             ).set_stroke(width = 4)
-            for func in lambda x : 0, sigmoid
+            for func in (lambda x : 0, sigmoid)
         ]
 
         self.play(ShowCreation(line))
@@ -3542,7 +3542,7 @@ class IntroduceWeightMatrix(NetworkScene):
         self.wait()
         self.play(*[
             LaggedStart(Indicate, mob, rate_func = there_and_back)
-            for mob in a_labels, a_labels_in_sum
+            for mob in (a_labels, a_labels_in_sum)
         ])
         self.wait()
 
@@ -3573,7 +3573,7 @@ class IntroduceWeightMatrix(NetworkScene):
                 "\\cdots",
                 "w_{%s, n}"%i,
             ]))
-            for i in "1", "k"
+            for i in ("1", "k")
         ]
         dots_row = VGroup(*map(TexMobject, [
             "\\vdots", "\\vdots", "\\ddots", "\\vdots"
@@ -3678,7 +3678,7 @@ class IntroduceWeightMatrix(NetworkScene):
     def show_meaning_of_lower_rows(self, arrow, brace, row_rect, result_terms):
         n1, n2, nk = neurons = VGroup(*[
             self.network_mob.layers[1].neurons[i]
-            for i in 0, 1, -1
+            for i in (0, 1, -1)
         ])
         for n in neurons:
             n.save_state()
@@ -4074,7 +4074,7 @@ class NeuronIsFunction(MoreHonestMNistNetworkPreview):
                 run_time = 2, 
                 submobject_mode = "lagged_start"
             )
-            for mob in self.network_mob.layers, self.network_mob.edge_groups
+            for mob in (self.network_mob.layers, self.network_mob.edge_groups)
         ]
         anims += [
             FadeOut(self.neuron_arrow),

--- a/old_projects/nn/part2.py
+++ b/old_projects/nn/part2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import os.path
 import cv2
@@ -460,7 +461,7 @@ class MNistDescription(Scene):
         ]
 
         for i, td_group in enumerate(training_data_groups):
-            print i
+            print(i)
             group = Group(*[
                 self.get_digit_pair(v_in, v_out)
                 for v_in, v_out in td_group
@@ -656,7 +657,7 @@ class IntroduceCostFunction(PreviewLearning):
         )
         symbols = VGroup(*[
             formula.get_parts_by_tex(tex)
-            for tex in "=", "+", "dots"
+            for tex in ("=", "+", "dots")
         ])
 
         w_labels.set_color(self.positive_edge_color)
@@ -774,7 +775,7 @@ class IntroduceCostFunction(PreviewLearning):
                 FadeIn, group,
                 run_time = 3,
             )
-            for group in neurons, edges
+            for group in (neurons, edges)
         ])
 
     def feed_in_example(self):
@@ -885,7 +886,7 @@ class IntroduceCostFunction(PreviewLearning):
         desired_layer = self.desired_last_layer
         decimal_groups = VGroup(*[
             self.num_vect_to_decimals(self.layer_to_num_vect(l))
-            for l in layer, desired_layer
+            for l in (layer, desired_layer)
         ])
 
         terms = VGroup()
@@ -1060,7 +1061,7 @@ class IntroduceCostFunction(PreviewLearning):
             random_v = np.random.random(10)
             new_decimal_groups = VGroup(*[
                 self.num_vect_to_decimals(v)
-                for v in random_v, out_vect
+                for v in (random_v, out_vect)
             ])
             for ds, nds in zip(decimal_groups, new_decimal_groups):
                 for old_d, new_d in zip(ds, nds):
@@ -1077,7 +1078,7 @@ class IntroduceCostFunction(PreviewLearning):
             self.add(new_image_group)
             image_group = new_image_group
 
-            self.wait(wait_times.next())
+            self.wait(next(wait_times))
 
     ####
 
@@ -1465,7 +1466,7 @@ class SingleVariableCostFunction(GraphScene):
             VGroup(cf[0], cf[2]).set_color(RED)
         big_brace, lil_brace = [
             Brace(cf[1], DOWN)
-            for cf in cf1, cf2
+            for cf in (cf1, cf2)
         ]
         big_brace_text = big_brace.get_text("Weights and biases")
         lil_brace_text = lil_brace.get_text("Single input")

--- a/old_projects/nn/part3.py
+++ b/old_projects/nn/part3.py
@@ -2255,7 +2255,7 @@ class SimplestNetworkExample(PreviewLearning):
     def label_neurons(self):
         neurons = VGroup(*[
             self.network_mob.layers[i].neurons[0]
-            for i in -1, -2
+            for i in (-1, -2)
         ])
         decimals = VGroup()
         a_labels = VGroup()
@@ -2374,7 +2374,7 @@ class SimplestNetworkExample(PreviewLearning):
         cost_equation.to_corner(UP+RIGHT)
         C0, a, y = [
             cost_equation.get_part_by_tex(tex)
-            for tex in "C_0", "a^{(L)}", "y"
+            for tex in ("C_0", "a^{(L)}", "y")
         ]
         y.set_color(YELLOW)
 
@@ -2577,7 +2577,7 @@ class SimplestNetworkExample(PreviewLearning):
         self.play(MoveToTarget(C0))
         self.play(*it.chain(*[
             [ShowCreation(line), line.flash]
-            for line in a_to_c_line, y_to_c_line
+            for line in (a_to_c_line, y_to_c_line)
         ]))
         self.wait(2)
 
@@ -2895,7 +2895,7 @@ class SimplestNetworkExample(PreviewLearning):
         dC_dw = self.dC_dw
         del_syms = [
             getattr(self, attr)
-            for attr in "del_wL", "del_zL", "del_aL", "del_C0"
+            for attr in ("del_wL", "del_zL", "del_aL", "del_C0")
         ]
 
         dz_dw = TexMobject(
@@ -3088,7 +3088,7 @@ class SimplestNetworkExample(PreviewLearning):
                 neuron.set_fill, None, target_o,
                 *[
                     ChangingDecimal(d, lambda a : neuron.get_fill_opacity())
-                    for d in decimal, moving_decimals[0]
+                    for d in (decimal, moving_decimals[0])
                 ]
             )
         self.play(*map(FadeOut, [double_arrow, moving_decimals]))
@@ -3726,8 +3726,8 @@ class GeneralFormulas(SimplestNetworkExample):
             all_subscript_rects.add(subscript_rects)
 
         start_labels, start_arrows = [
-            VGroup(*map(VGroup, [group[i][0] for i in 0, 1])).copy()
-            for group in all_labels, all_arrows
+            VGroup(*map(VGroup, [group[i][0] for i in (0, 1)])).copy()
+            for group in (all_labels, all_arrows)
         ]
         for label in start_labels:
             label[0][-1].set_color(BLACK)
@@ -3856,7 +3856,7 @@ class GeneralFormulas(SimplestNetworkExample):
 
         self.play(*[
             ReplacementTransform(mob, mob.target)
-            for mob in aj, yj
+            for mob in (aj, yj)
         ])
         self.play(LaggedStart(FadeIn, to_fade_in))
         self.wait(2)
@@ -4050,7 +4050,7 @@ class GeneralFormulas(SimplestNetworkExample):
         neurons = self.network_mob.layers[-1].neurons
         labels, arrows, decimals = [
             VGroup(*[getattr(n, attr) for n in neurons])
-            for attr in "label", "arrow", "decimal"
+            for attr in ("label", "arrow", "decimal")
         ]
         edges = VGroup(*[n.edges_in[1] for n in neurons])
         labels[0].generate_target()

--- a/old_projects/nn/playground.py
+++ b/old_projects/nn/playground.py
@@ -3,6 +3,7 @@
 
 import sys
 import os.path
+from functools import reduce
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from constants import *

--- a/old_projects/patreon.py
+++ b/old_projects/patreon.py
@@ -19,7 +19,7 @@ class SideGigToFullTime(Scene):
         dollar_sign = TexMobject("\\$")
         cross = VGroup(*[
             Line(vect, -vect, color = RED)
-            for vect in UP+RIGHT, UP+LEFT
+            for vect in (UP+RIGHT, UP+LEFT)
         ])
         cross.scale_to_fit_height(dollar_sign.get_height())
         no_money = VGroup(dollar_sign, cross)

--- a/old_projects/playground_counting_in_binary.py
+++ b/old_projects/playground_counting_in_binary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -12,6 +13,7 @@ from constants import *
 from mobject.region import  *
 from scene.scene import Scene, SceneFromVideo
 from script_wrapper import command_line_create_scene
+from functools import reduce
 
 MOVIE_PREFIX = "counting_in_binary/"
 

--- a/old_projects/putnam.py
+++ b/old_projects/putnam.py
@@ -25,7 +25,7 @@ class IntroducePutnam(Scene):
                 TextMobject("%s%d)"%(c, i))
                 for i in range(1, 7)
             ]).arrange_submobjects(DOWN, buff = MED_LARGE_BUFF)
-            for c in "A", "B"
+            for c in ("A", "B")
         ]).arrange_submobjects(RIGHT, buff = FRAME_X_RADIUS - MED_SMALL_BUFF)
         question_groups.to_edge(LEFT)
         question_groups.to_edge(DOWN, MED_LARGE_BUFF)

--- a/old_projects/pythagorean_proof.py
+++ b/old_projects/pythagorean_proof.py
@@ -324,7 +324,7 @@ class DrawCSquareWithAllTraingles(Scene):
             toggle_vector = [False]*4
         self.c_square = c_square().center()
         vertices = it.cycle(self.c_square.get_vertices())
-        last_vertex = vertices.next()
+        last_vertex = next(vertices)
         have_letters = False
         self.triangles = []
         for vertex, should_flip in zip(vertices, toggle_vector):
@@ -385,8 +385,8 @@ class ZoomInOnTroublePoint(Scene):
         circle = Circle(radius = 2.5, color = WHITE)
         angle1_arc = Circle(color = WHITE)
         angle2_arc = Circle(color = WHITE).scale(0.5)
-        angle1_arc.filter_out(lambda (x, y, z) : not (x > 0 and y > 0 and y < x/3))
-        angle2_arc.filter_out(lambda (x, y, z) : not (x < 0 and y > 0 and y < -3*x))
+        angle1_arc.filter_out(lambda x_y_z2 : not (x_y_z2[0] > 0 and x_y_z2[1] > 0 and x_y_z2[1] < x_y_z2[0]/3))
+        angle2_arc.filter_out(lambda x_y_z3 : not (x_y_z3[0] < 0 and x_y_z3[1] > 0 and x_y_z3[1] < -3*x_y_z3[0]))
 
         self.add_mobjects_among(locals().values())
         self.add_elbow()        
@@ -422,10 +422,10 @@ class DrawTriangleWithAngles(Scene):
         vertices = triangle.get_vertices()
         kwargs = {"color" : WHITE}
         angle1_arc = Circle(radius = 0.4, **kwargs).filter_out(
-            lambda (x, y, z) : not(x > 0 and y < 0 and y < -3*x)
+            lambda x_y_z : not(x_y_z[0] > 0 and x_y_z[1] < 0 and x_y_z[1] < -3*x_y_z[0])
         ).shift(vertices[1])
         angle2_arc = Circle(radius = 0.2, **kwargs).filter_out(
-            lambda (x, y, z) : not(x < 0 and y > 0 and y < -3*x)
+            lambda x_y_z1 : not(x_y_z1[0] < 0 and x_y_z1[1] > 0 and x_y_z1[1] < -3*x_y_z1[0])
         ).shift(vertices[2])
         alpha = TexMobject("\\alpha")
         beta = TexMobject("90-\\alpha")

--- a/old_projects/qa_round_two.py
+++ b/old_projects/qa_round_two.py
@@ -100,7 +100,7 @@ class PowersOfTwo(Scene):
                 two_to_ten.get_corner(vect+RIGHT),
                 mob[0].get_corner(vect+LEFT),
             )
-            for vect in UP, DOWN
+            for vect in (UP, DOWN)
         ])
         two_to_ten.save_state()
         two_to_ten.replace(mob[0])

--- a/old_projects/tattoo.py
+++ b/old_projects/tattoo.py
@@ -404,7 +404,7 @@ class ExplainTrigFunctionDistances(TrigRepresentationsScene, PiCreatureScene):
 
         sec_dot, csc_dot = [
             Dot(line.get_end(), color = line.get_color())
-            for line in sec_line, csc_line
+            for line in (sec_line, csc_line)
         ]
         sec_group.add(sec_dot)
         csc_group.add(csc_dot)

--- a/old_projects/tau_poem.py
+++ b/old_projects/tau_poem.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import numpy as np
 import itertools as it
 from copy import deepcopy
@@ -7,7 +8,7 @@ import sys
 
 from big_ol_pile_of_manim_imports import *
 from script_wrapper import command_line_create_scene
-from generate_logo import LogoGeneration
+from .generate_logo import LogoGeneration
 
 POEM_LINES = """Fixed poorly in notation with that two,
 you shine so loud that you deserve a name.
@@ -388,7 +389,7 @@ class TauPoem(Scene):
         grid.add(TexMobject("e^{ix}").shift(grid_center+UP+RIGHT))
         circle.set_color("white")
         tau_line = Line(
-            *[np.pi*interval_size*vect for vect in LEFT, RIGHT],
+            *[np.pi*interval_size*vect for vect in (LEFT, RIGHT)],
             density = 5*DEFAULT_POINT_DENSITY_1D
         )
         tau_line.set_color("red")
@@ -475,7 +476,8 @@ class TauPoem(Scene):
         ])
         for index in range(circle.points.shape[0]):
             circle.rgbas
-        def trianglify((x, y, z)):
+        def trianglify(xxx_todo_changeme):
+            (x, y, z) = xxx_todo_changeme
             norm = np.linalg.norm((x, y, z))
             comp = complex(x, y)*complex(0, 1)
             return (

--- a/old_projects/triangle_of_power/intro.py
+++ b/old_projects/triangle_of_power/intro.py
@@ -20,7 +20,7 @@ class TrigAnimation(Animation):
         circle = Circle(color = WHITE)
         self.trig_lines = [
             Line(ORIGIN, RIGHT, color = color)
-            for color in self.sin_color, self.cos_color, self.tan_color
+            for color in (self.sin_color, self.cos_color, self.tan_color)
         ]
         mobject = VMobject(
             x_axis, y_axis, circle, 
@@ -348,7 +348,7 @@ class WhatTheHell(Scene):
             last = mob
         q_marks = VMobject(*[
             TexMobject("?!").next_to(arrow, RIGHT)
-            for arrow in arrow1, arrow2
+            for arrow in (arrow1, arrow2)
         ])
         q_marks.set_color(RED_D)
         everyone = VMobject(exp, rad, log, arrow1, arrow2, q_marks)
@@ -466,11 +466,11 @@ class HaveToShare(Scene):
         VMobject(*words).center()
         left_dot, top_dot, bottom_dot = [
             Dot(point, radius = 0.1)
-            for point in ORIGIN, RIGHT+0.5*UP, RIGHT+0.5*DOWN
+            for point in (ORIGIN, RIGHT+0.5*UP, RIGHT+0.5*DOWN)
         ]
         line1, line2 = [
             Line(left_dot.get_center(), dot.get_center(), buff = 0)
-            for dot in top_dot, bottom_dot
+            for dot in (top_dot, bottom_dot)
         ]
         share = VMobject(left_dot, top_dot, bottom_dot, line1, line2)
         share.next_to(words[1], RIGHT, buff = 1)

--- a/old_projects/triangle_of_power/triangle.py
+++ b/old_projects/triangle_of_power/triangle.py
@@ -1,5 +1,6 @@
 import numbers
 from big_ol_pile_of_manim_imports import *
+from functools import reduce
 
 OPERATION_COLORS = [YELLOW, GREEN, BLUE_B]
 
@@ -319,7 +320,7 @@ class SixDifferentInverses(Scene):
         assert(lil_top is not None and lil_symbol is not None)
         cancel_parts = [
             VMobject(top.triangle, top.values[symbol_index])
-            for top in lil_top, big_top
+            for top in (lil_top, big_top)
         ]
         new_symbol = lil_symbol.copy()
         new_symbol.replace(right_symbol)
@@ -608,7 +609,7 @@ class RightStaysConstantQ(Scene):
     def construct(self):
         top1, top2, top3 = old_tops = [
             TOP(None, s, "8")
-            for s in "x", "y", TexMobject("x?y")
+            for s in ("x", "y", TexMobject("x?y"))
         ]
         q_mark = TexMobject("?").scale(2)
         equation = VMobject(
@@ -617,11 +618,11 @@ class RightStaysConstantQ(Scene):
         equation.arrange_submobjects(buff = 0.7)
         symbols_at_top = VMobject(*[
             top.values[1]
-            for top in top1, top2, top3
+            for top in (top1, top2, top3)
         ])
         symbols_at_lower_right = VMobject(*[
             top.put_on_vertex(0, top.values[1].copy())
-            for top in top1, top2, top3
+            for top in (top1, top2, top3)
         ])
         old_style_eq1 = TexMobject("\\sqrt[x]{8} ? \\sqrt[y]{8} = \\sqrt[x?y]{8}")
         old_style_eq1.set_color(BLUE)

--- a/old_projects/triples.py
+++ b/old_projects/triples.py
@@ -1113,7 +1113,7 @@ class OneMoreExample(Scene):
             Transform(second_line[3], minus),
             FadeOut(VGroup(*[
                 second_line[i]
-                for i in 4, 6, 7
+                for i in (4, 6, 7)
             ])),
             second_line[5].shift, 0.35*RIGHT,
         )
@@ -1514,7 +1514,7 @@ class WriteGeneralFormula(GeneralExample):
                 run_time = 5,
                 lag_ratio = 0.2
             )
-            for mob in pair_mobs, triple_mobs
+            for mob in (pair_mobs, triple_mobs)
         ])
 
 class VisualizeZSquared(Scene):
@@ -1608,7 +1608,7 @@ class VisualizeZSquared(Scene):
         for z in z_list:
             z_point, square_point, mid_point = [
                 self.background_plane.number_to_point(z**p)
-                for p in 1, 2, 1.5
+                for p in (1, 2, 1.5)
             ]
             angle = Line(mid_point, square_point).get_angle()
             angle -= Line(z_point, mid_point).get_angle()
@@ -1671,7 +1671,7 @@ class VisualizeZSquared(Scene):
             self.background_plane.point_to_coords(
                 u*FRAME_X_RADIUS*RIGHT + u*FRAME_Y_RADIUS*UP
             )
-            for u in -1, 1
+            for u in (-1, 1)
         ]
         x_min, y_min = map(int, min_corner[:2])
         x_max, y_max = map(int, max_corner[:2])
@@ -1844,7 +1844,7 @@ class VisualizeZSquared(Scene):
             c = int(abs(z))
             a_label, b_label, c_label = labels = [
                 TexMobject(str(num))
-                for num in a, b, c
+                for num in (a, b, c)
             ]
             for label in b_label, c_label:
                 label.add_background_rectangle()
@@ -2048,7 +2048,7 @@ class DrawSingleRadialLine(PointsWeMiss):
         )
         added_dots = VGroup(*[
             Dot(self.background_plane.coords_to_point(3*k, 4*k))
-            for k in 2, 3, 5
+            for k in (2, 3, 5)
         ])
         added_dots.set_color(GREEN)
 
@@ -2307,7 +2307,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
                 run_time = 2,
                 path_arc = -np.pi/3
             )
-            for tex  in "a", "b", "c", "^2", "+", "="
+            for tex  in ("a", "b", "c", "^2", "+", "=")
         ] + [
             ReplacementTransform(
                 top_line.get_parts_by_tex("1"),
@@ -2320,7 +2320,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
                 run_time = 2,
                 rate_func = squish_rate_func(smooth, 0, 0.5)
             )
-            for tex in "(", ")", "over",
+            for tex in ("(", ")", "over",)
         ])
         self.wait(2)
         self.play(Write(circle_label))
@@ -2387,7 +2387,7 @@ class RationalPointsOnUnitCircle(DrawRadialLines):
     def get_unit_circle(self):
         template_line = Line(*[
             self.background_plane.number_to_point(z)
-            for z in -1, 1
+            for z in (-1, 1)
         ])
         circle = Circle(color = GREEN)
         circle.replace(template_line, dim_to_match = 0)
@@ -2415,7 +2415,7 @@ class ProjectPointsOntoUnitCircle(DrawRadialLines):
     def add_unit_circle(self):
         template_line = Line(*[
             self.background_plane.number_to_point(n)
-            for n in -1, 1
+            for n in (-1, 1)
         ])
         circle = Circle(color = BLUE)
         circle.replace(template_line, dim_to_match = 0)
@@ -2534,7 +2534,7 @@ class SupposeMissingPoint(PointsWeMiss):
         dot, line = self.dot, self.line
         template_line = Line(*[
             self.background_plane.number_to_point(n)
-            for n in -1, 1
+            for n in (-1, 1)
         ])
         circle = Circle(color = GREEN)
         circle.replace(template_line, dim_to_match = 0)
@@ -2893,10 +2893,10 @@ class FinalProof(RationalPointsOnUnitCircle):
                 rhs.get_part_by_tex(tex),
                 run_time = 2
             )
-            for tex in "u", "v"
+            for tex in ("u", "v")
         ] + [
             Write(rhs.get_part_by_tex(tex))
-            for tex in "=", "over"
+            for tex in ("=", "over")
         ])
         self.wait(2)
         self.play(
@@ -2917,7 +2917,7 @@ class BitOfCircleGeometry(Scene):
         circle = Circle(color = BLUE, radius = 3)
         p0, p1, p2 = [
             circle.point_from_proportion(alpha)
-            for alpha in 0, 0.15, 0.55
+            for alpha in (0, 0.15, 0.55)
         ]
         O = circle.get_center()
         O_dot = Dot(O, color = WHITE)

--- a/old_projects/uncertainty.py
+++ b/old_projects/uncertainty.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import scipy
 from big_ol_pile_of_manim_imports import *
 from old_projects.fourier import *
@@ -628,7 +629,7 @@ class ShowPlan(PiCreatureScene):
         )
         self.add(pulse)
         count = it.count() #TODO, this is not a great hack...
-        while not pulse.is_finished() and count.next() < 15:
+        while not pulse.is_finished() and next(count) < 15:
             self.play(
                 morty.look_at, pulse.mobject,
                 run_time = 0.5
@@ -1467,7 +1468,7 @@ class CenterOfMassDescription(FourierRecapScene):
                 angle = factor*angle,
                 radius = 0.5,
             )
-            for factor in 1, 2
+            for factor in (1, 2)
         ]
         theta = TexMobject("\\theta")
         theta.shift(1.5*arc.point_from_proportion(0.5))
@@ -1984,7 +1985,7 @@ class IntroduceDopplerRadar(Scene):
         )
         v_line_pair = VGroup(*[
             v_line.copy().shift(u*0.6*RIGHT)
-            for u in -1, 1
+            for u in (-1, 1)
         ])
         v_line = VGroup(v_line)
 
@@ -2492,7 +2493,7 @@ class AmbiguityInLongEchos(IntroduceDopplerRadar, PiCreatureScene):
 
         noise_function = lambda t : np.sum([
             0.5*np.sin(f*t)/f 
-            for f in 2, 3, 5, 7, 11, 13
+            for f in (2, 3, 5, 7, 11, 13)
         ])
         noisy_graph = self.axes.get_graph(
             lambda t : sum_graph.underlying_function(t)*(1+noise_function(t)),
@@ -3303,7 +3304,7 @@ class AskPhysicists(PiCreatureScene):
 
         physies = VGroup(*[
             PiCreature(color = c).flip()
-            for c in GREY, LIGHT_GREY, DARK_GREY
+            for c in (GREY, LIGHT_GREY, DARK_GREY)
         ])
         physies.arrange_submobjects(RIGHT, buff = MED_SMALL_BUFF)
         physies.scale(scale_factor)
@@ -4149,7 +4150,7 @@ class ProbabalisticDetection(FourierTransformOfWaveFunction):
 
         v_lines = VGroup(*[
             DashedLine(ORIGIN, 3*UP).move_to(point, DOWN)
-            for point in rect.get_left(), rect.get_right()
+            for point in (rect.get_left(), rect.get_right())
         ])
         
         self.play(
@@ -4550,7 +4551,7 @@ class Promotion(PiCreatureScene):
             ),
             FadeOut(book),
         )
-        print self.num_plays
+        print(self.num_plays)
         self.play(
             FadeOut(words),
             ShowCreation(rect),
@@ -4732,7 +4733,7 @@ class Thumbnail(Scene):
         )
         graphs = VGroup(*[
             axes.get_graph(get_func(a))
-            for a in 10, 3, 1, 0.3, 0.1,
+            for a in (10, 3, 1, 0.3, 0.1,)
         ])
         graphs.arrange_submobjects(DOWN, buff = 0.6)
         graphs.to_corner(UP+LEFT)

--- a/old_projects/waves.py
+++ b/old_projects/waves.py
@@ -1260,7 +1260,7 @@ class ShowVectorEquation(Scene):
                 x_max = 4/f,
                 num_steps = 20/f,
             )
-            for f in 1, 0.25,
+            for f in (1, 0.25,)
         ])
 
         group = VGroup(axes, t, cos, high_f_graph, *fx_group)
@@ -1451,7 +1451,7 @@ class ShowVectorEquation(Scene):
         ])
         ket_rects = VGroup(*map(SurroundingRectangle, kets))
         ket_rects.set_color(WHITE)
-        unit_vectors = VGroup(*[Vector(2*vect) for vect in RIGHT, UP])
+        unit_vectors = VGroup(*[Vector(2*vect) for vect in (RIGHT, UP)])
         unit_vectors.set_fill(YELLOW)
 
         self.play(
@@ -1640,7 +1640,7 @@ class ShowTipToTailSum(ShowVectorEquation):
                 "\\cos(", "2\\pi", "f", "t", ")",
                 "|\\!\\%sarrow\\rangle"%s
             )
-            for s in "right", "up"
+            for s in ("right", "up")
         ])
         for ket in kets:
             ket.set_color_by_tex_to_color_map({
@@ -2155,7 +2155,7 @@ class ShowPolarizingFilter(DirectionOfPolarizationScene):
                 decimal.align_data(new_decimal)
                 families = [
                     mob.family_members_with_points()
-                    for mob in decimal, new_decimal
+                    for mob in (decimal, new_decimal)
                 ]
                 for sm1, sm2 in zip(*families):
                     sm1.interpolate(sm1, sm2, 1)
@@ -2369,7 +2369,7 @@ class EnergyOfWavesTeacherPortion(TeacherStudentsScene):
         s1, s2 = self.get_students()[:2]
         b1, b2 = [
             ThoughtBubble(direction = v).scale(0.5)
-            for v in LEFT, RIGHT
+            for v in (LEFT, RIGHT)
         ]
         b1.pin_to(s1)
         b2.pin_to(s2)
@@ -3388,7 +3388,7 @@ class ThreeFilters(ShootPhotonThroughFilter):
         n = self.n_lines
         start, end = [
             (f.point_from_proportion(0.75) if f is not None else None)
-            for f in filter1, filter2
+            for f in (filter1, filter2)
         ]
         if start is None:
             start = end + self.line_start_length*LEFT
@@ -3883,7 +3883,7 @@ class CompareWaveEquations(TeacherStudentsScene):
     def show_complex_plane(self):
         new_alpha, new_beta = terms = [
             self.equation.get_part_by_tex(tex).copy()
-            for tex in "alpha", "beta"
+            for tex in ("alpha", "beta")
         ]
         for term in terms:
             term.save_state()

--- a/old_projects/wcat.py
+++ b/old_projects/wcat.py
@@ -665,7 +665,7 @@ class PairOfPairBecomeRectangle(Scene):
 
         rectangle = Polygon(*[
             dots[i].get_center()
-            for i in 0, 2, 1, 3
+            for i in (0, 2, 1, 3)
         ])
         rectangle.set_color(BLUE)
         self.play(
@@ -882,7 +882,7 @@ class AskAbouPairType(TeacherStudentsScene):
         """)
         self.play(*[
             ApplyMethod(self.get_students()[i].change_mode, "confused")
-            for i in 0, 2
+            for i in (0, 2)
         ])
         self.random_blink(3)
 
@@ -950,7 +950,7 @@ class DefineUnorderedPair(ClosedLoopScene):
         dots = self.dots
         dots.set_color(PURPLE_B)
 
-        labels = VGroup(*[subtitle[i].copy() for i in 0, 2])
+        labels = VGroup(*[subtitle[i].copy() for i in (0, 2)])
         for label, vect in zip(labels, [LEFT, RIGHT]):
             label.next_to(dots, vect, LARGE_BUFF)
         arrows = [
@@ -1098,7 +1098,7 @@ class RepresentPairInUnitSquare(ClosedLoopScene):
         self.wait()
         self.play(*[
             Rotate(mob, np.pi/2, about_point = interval.get_left())
-            for mob in vert_interval, self.dots[1]
+            for mob in (vert_interval, self.dots[1])
         ])
 
         #Find interior point
@@ -1205,7 +1205,7 @@ class EdgesOfSquare(Scene):
                 square.get_corner(vect+LEFT),
                 square.get_corner(vect+RIGHT),
             )
-            for vect in DOWN, UP
+            for vect in (DOWN, UP)
         ])
         y_edges.set_color(BLUE)
         x_edges = VGroup(*[
@@ -1213,7 +1213,7 @@ class EdgesOfSquare(Scene):
                 square.get_corner(vect+DOWN),
                 square.get_corner(vect+UP),
             )
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         x_edges.set_color(MAROON_B)
         return x_edges, y_edges
@@ -1229,7 +1229,7 @@ class EdgesOfSquare(Scene):
                 ))
                 for alpha in alpha_range
             ])
-            for vect in LEFT, RIGHT            
+            for vect in (LEFT, RIGHT)            
         ]
         for group in dot_groups:
             group.set_color_by_gradient(YELLOW, PURPLE_B)
@@ -1238,7 +1238,7 @@ class EdgesOfSquare(Scene):
                 TexMobject("(%s, %s)"%(a, b)).scale(0.7)
                 for b in alpha_range
             ])
-            for a in 0, 1
+            for a in (0, 1)
         ]
         for dot_group, label_group in zip(dot_groups, label_groups):
             for dot, label in zip(dot_group, label_group):
@@ -1261,7 +1261,7 @@ class EdgesOfSquare(Scene):
                 ])
                 for edge in edges
             ]).set_color(edges.get_color())
-            for edges in x_edges, y_edges
+            for edges in (x_edges, y_edges)
         ]
 
 class EndpointsGluedTogether(ClosedLoopScene):
@@ -1281,7 +1281,7 @@ class EndpointsGluedTogether(ClosedLoopScene):
         self.loop = line
         dots = VGroup(*[
             Dot(line.get_critical_point(vect))
-            for vect in LEFT, RIGHT
+            for vect in (LEFT, RIGHT)
         ])
         dots.set_color(BLUE)
 
@@ -1640,7 +1640,7 @@ class FoldUnitSquare(EdgesOfSquare):
     def get_point_from_coords(self, x, y):
         left, right, bottom, top = [
             self.triangles.get_edge_center(vect)
-            for vect in LEFT, RIGHT, DOWN, UP
+            for vect in (LEFT, RIGHT, DOWN, UP)
         ]
         x_point = interpolate(left, right, x)
         y_point = interpolate(bottom, top, y)

--- a/old_projects/zeta.py
+++ b/old_projects/zeta.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from big_ol_pile_of_manim_imports import *
 
 import mpmath
@@ -1800,7 +1801,7 @@ class ShowZetaOnHalfPlane(ZetaTransformationScene):
 
         line = Line(*map(self.z_to_point, [
             complex(np.euler_gamma, u*FRAME_Y_RADIUS)
-            for u in 1, -1
+            for u in (1, -1)
         ]))
         line.set_color(YELLOW)
         arrows = [
@@ -1826,9 +1827,9 @@ class ShowZetaOnHalfPlane(ZetaTransformationScene):
                     vert_vect+RIGHT,
                     vert_vect+(FRAME_X_RADIUS+1)*horiz_vect
                 )
-                for vert_vect in UP, DOWN
+                for vert_vect in (UP, DOWN)
             ])
-            for horiz_vect in RIGHT, LEFT
+            for horiz_vect in (RIGHT, LEFT)
         ]
         right_i_lines.set_color(YELLOW)
         left_i_lines.set_color(BLUE)
@@ -1913,7 +1914,7 @@ class ShowConditionalDefinition(Scene):
         something_else = TextMobject("Something else...")
         conditions = VGroup(*[
             TextMobject("if Re$(s) %s 1$"%s)
-            for s in ">", "\\le"
+            for s in (">", "\\le")
         ])
         definitions = VGroup(sigma, something_else)
         definitions.arrange_submobjects(DOWN, buff = MED_LARGE_BUFF, aligned_edge = LEFT)

--- a/once_useful_constructs/counting.py
+++ b/once_useful_constructs/counting.py
@@ -107,7 +107,7 @@ class CountingScene(Scene):
                 added_anims += self.get_digit_increment_animations()
                 first_move = False
             moving_dot.target.replace(
-                self.dot_template_iterators[place].next()
+                next(self.dot_template_iterators[place])
             )
             self.play(MoveToTarget(moving_dot), *added_anims, **kwargs)
             self.curr_configurations[place].add(moving_dot)

--- a/once_useful_constructs/fractals.py
+++ b/once_useful_constructs/fractals.py
@@ -21,6 +21,7 @@ from utils.space_ops import rotate_vector
 from utils.space_ops import rotation_matrix
 
 from constants import *
+from functools import reduce
 
 def rotate(points, angle = np.pi, axis = OUT):
     if axis is None:

--- a/once_useful_constructs/graph_theory.py
+++ b/once_useful_constructs/graph_theory.py
@@ -9,6 +9,7 @@ from constants import *
 from scene.scene import Scene
 from utils.rate_functions import there_and_back
 from utils.space_ops import center_of_mass
+from functools import reduce
 
 
 class Graph():
@@ -272,7 +273,7 @@ class GraphScene(Scene):
             cycle = self.graph.region_cycles[0]
         time_per_edge = run_time / len(cycle)
         next_in_cycle = it.cycle(cycle)
-        next_in_cycle.next()#jump one ahead
+        next(next_in_cycle)#jump one ahead
         self.traced_cycle = Mobject(*[
             Line(self.points[i], self.points[j]).set_color(color)
             for i, j in zip(cycle, next_in_cycle)

--- a/once_useful_constructs/matrix_multiplication.py
+++ b/once_useful_constructs/matrix_multiplication.py
@@ -20,7 +20,7 @@ class NumericalMatrixMultiplication(Scene):
     def construct(self):
         left_string_matrix, right_string_matrix = [
             np.array(matrix).astype("string")
-            for matrix in self.left_matrix, self.right_matrix
+            for matrix in (self.left_matrix, self.right_matrix)
         ]
         if right_string_matrix.shape[0] != left_string_matrix.shape[1]:
             raise Exception("Incompatible shapes for matrix multiplication")
@@ -95,7 +95,7 @@ class NumericalMatrixMultiplication(Scene):
         )
         circles = VGroup(*[
             entry.get_point_mobject()
-            for entry in l_matrix[0][0], r_matrix[0][0]
+            for entry in (l_matrix[0][0], r_matrix[0][0])
         ])
         (m, k), n = l_matrix.shape, r_matrix.shape[1]
         for mob in result_matrix.flatten():

--- a/primes.py
+++ b/primes.py
@@ -1,4 +1,6 @@
-from big_ol_pile_of_manim_imports import *
+from __future__ import print_function
+from __future__ import absolute_import
+from .big_ol_pile_of_manim_imports import *
 
 def is_prime(n):
 
@@ -68,15 +70,15 @@ class Primes(Scene):
         #            73      79      83        89       97
 
         nb_primes = len(primes_list)
-        print nb_primes
+        print(nb_primes)
 
         prime_points_radius = 3.2
         angles = np.arange(TAU/4, -3*TAU/4, -TAU/float(nb_primes))
-        print len(angles), angles
+        print(len(angles), angles)
         prime_points = [prime_points_radius * (np.cos(theta) * RIGHT
                          + np.sin(theta) * UP)
                             for theta in angles]
-        print len(prime_points)
+        print(len(prime_points))
 
         wheel = Wheel()
         
@@ -116,7 +118,7 @@ class Primes(Scene):
                 full_wheel = VGroup(wheel,number).copy()
                 full_wheel_copy = full_wheel.copy()
                 full_wheel_copy.scale(0.15).move_to(prime_points[j])
-                print j
+                print(j)
                 j += 1
                 self.play(
                     Transform(full_wheel, full_wheel_copy)
@@ -162,7 +164,7 @@ class Wheel(VMobject):
     def update_sectors(self, new_angles, new_colors):
 
         if len(new_angles) > self.nb_sectors:
-            raise "More angles than sectors!"
+            raise Exception("More angles than sectors!")
         
         for i in range(len(new_angles), self.nb_sectors):
             new_angles = np.append(new_angles, 0)

--- a/scene/graph_scene.py
+++ b/scene/graph_scene.py
@@ -146,7 +146,7 @@ class GraphScene(Scene):
         x_max = None,
         ):
         if color is None:
-            color = self.default_graph_colors_cycle.next()
+            color = next(self.default_graph_colors_cycle)
         if x_min is None:
             x_min = self.x_min
         if x_max is None:

--- a/scene/sample_space_scene.py
+++ b/scene/sample_space_scene.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from constants import *
 
-from scene.scene import Scene
+from .scene.scene import Scene
 
 from animation.animation import Animation
 from animation.transform import MoveToTarget

--- a/scene/scene.py
+++ b/scene/scene.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import inspect
 import itertools as it
@@ -390,8 +391,8 @@ class Scene(Container):
         def compile_method(state):
             if state["curr_method"] is None:
                 return
-            mobject = state["curr_method"].im_self
-            if state["last_method"] and state["last_method"].im_self is mobject:
+            mobject = state["curr_method"].__self__
+            if state["last_method"] and state["last_method"].__self__ is mobject:
                 animations.pop()
                 #method should already have target then.
             else:
@@ -401,7 +402,7 @@ class Scene(Container):
                 method_kwargs = state["method_args"].pop()
             else:
                 method_kwargs = {}
-            state["curr_method"].im_func(
+            state["curr_method"].__func__(
                 mobject.target, 
                 *state["method_args"],
                 **method_kwargs

--- a/scene/scene_from_video.py
+++ b/scene/scene_from_video.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import cv2
 import itertools as it

--- a/scene/vector_space_scene.py
+++ b/scene/vector_space_scene.py
@@ -385,7 +385,7 @@ class LinearTransformationScene(VectorScene):
             new_matrix[:2, :2] = transposed_matrix
             transposed_matrix = new_matrix
         elif transposed_matrix.shape != (3, 3):
-            raise "Matrix has bad dimensions"
+            raise Exception("Matrix has bad dimensions")
         return lambda point: np.dot(point, transposed_matrix)
 
     def get_piece_movement(self, pieces):

--- a/stage_scenes.py
+++ b/stage_scenes.py
@@ -1,13 +1,14 @@
+from __future__ import absolute_import
 import inspect
 import itertools as it
 import os
 import shutil
 import sys
 
-from constants import ANIMATIONS_DIR
-from constants import STAGED_SCENES_DIR
-from extract_scene import get_module
-from extract_scene import is_scene
+from .constants import ANIMATIONS_DIR
+from .constants import STAGED_SCENES_DIR
+from .extract_scene import get_module
+from .extract_scene import is_scene
 
 
 def get_sorted_scene_names(module_name):

--- a/utils/config_ops.py
+++ b/utils/config_ops.py
@@ -1,5 +1,6 @@
 import inspect
 import operator as op
+from functools import reduce
 
 def instantiate(obj):
     """

--- a/utils/iterables.py
+++ b/utils/iterables.py
@@ -1,5 +1,6 @@
 import itertools as it
 import numpy as np
+from functools import reduce
 
 def remove_list_redundancies(l):
     """
@@ -86,8 +87,8 @@ def make_even_by_cycling(iterable_1, iterable_2):
     cycle1 = it.cycle(iterable_1)
     cycle2 = it.cycle(iterable_2)
     return (
-        [cycle1.next() for x in range(length)],
-        [cycle2.next() for x in range(length)]
+        [next(cycle1) for x in range(length)],
+        [next(cycle2) for x in range(length)]
     )
 
 def composition(func_list):

--- a/utils/simple_functions.py
+++ b/utils/simple_functions.py
@@ -1,5 +1,6 @@
 import numpy as np
 import operator as op
+from functools import reduce
 
 def sigmoid(x):
     return 1.0/(1 + np.exp(-x))

--- a/utils/space_ops.py
+++ b/utils/space_ops.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from constants import OUT
 from constants import RIGHT
+from functools import reduce
 
 #Matrix operations
 


### PR DESCRIPTION
Another shot at #183

Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.
* Run __futurize --stage1__ http://python-future.org/futurize_cheatsheet.html
* ~~Adjust adjust some __lambda__ and __tuple__ expressions to be compatible with Python 3.~~

Fixes #182 and helps with  #128

__Ready for review.__  Python 3 syntax compatibility does _not_ mean that the port is complete.  