### PR TITLE
[CONFIG] Add opencv-python in requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ Pillow==3.4.2
 progressbar==2.3
 scipy==0.17.1
 tqdm==4.7.1
+opencv-python==3.1.0
 git+https://github.com/scottopell/aggdraw-64bits@c95aac4369038706943fd0effb7d888683860e5a#egg=aggdraw


### PR DESCRIPTION
All in the title.

If I don't install `opencv-python` under Ubuntu, I get the following error:
```
$ python extract_scene.py example_scenes.py SquareToCircle -pl
Traceback (most recent call last):
  File "extract_scene.py", line 266, in <module>
    main()
  File "extract_scene.py", line 223, in main
    module = get_module(config["file"])
  File "extract_scene.py", line 219, in get_module
    return get_module_posix(file_name)
  File "extract_scene.py", line 213, in get_module_posix
    last_module = imp.load_module(part, *load_args)
  File "/home/frozar/wk/manim/./example_scenes.py", line 3, in <module>
    from big_ol_pile_of_manim_imports import *
  File "/home/frozar/wk/manim/big_ol_pile_of_manim_imports.py", line 66, in <module>
    from scene.scene_from_video import *
  File "/home/frozar/wk/manim/scene/scene_from_video.py", line 3, in <module>
    import cv2
ImportError: No module named cv2
```