### PR TITLE
Update extract_scene.py

### DIFF
--- a/extract_scene.py
+++ b/extract_scene.py
@@ -145,6 +145,8 @@ def handle_scene(scene, **config):
         commands = ["open"]
         if (platform.system() == "Linux"):
             commands = ["xdg-open"]
+        elif (platform.system() == "Windows"):
+            commands = ["start"]    
 
         if config["show_file_in_finder"]:
             commands.append("-R")


### PR DESCRIPTION
Use the "start" command on Windows to open files instead of "open" on Mac OS or "xdg-open" on Linux.
This helps solving "The system cannot find the path specified" issue #173.