### PR TITLE
Added a way to easily customize the media directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ manim.sublime-project
 manim.sublime-workspace
 
 primes.py
+/media_dir.txt

--- a/constants.py
+++ b/constants.py
@@ -1,12 +1,40 @@
 import os
 import numpy as np
 
-# Things anyone wishing to use this repository for their
-# own use will want to change
-MEDIA_DIR = os.path.join(
-    os.path.expanduser('~'),
-    "Dropbox (3Blue1Brown)/3Blue1Brown Team Folder"
-)
+env_MEDIA_DIR = None
+MEDIA_DIR = "#ERROR#"
+
+try:
+    env_MEDIA_DIR = os.getenv("MEDIA_DIR")
+except NameError:
+    try:
+        env_MEDIA_DIR = os.environ['MEDIA_DIR']
+    except KeyError:
+        pass
+
+if not (env_MEDIA_DIR is None):
+    MEDIA_DIR = env_MEDIA_DIR
+elif os.path.exists("media_dir.txt"):
+    with open("media_dir.txt", 'rU') as media_file:
+        MEDIA_DIR = media_file.readline()
+    if MEDIA_DIR[-1] in ['\n', '\r']:
+        raise Exception("media_dir.txt must be a single-line text file pointing at the media_dir place")
+else:
+    MEDIA_DIR = os.path.join(
+        os.path.expanduser('~'),
+        "Dropbox (3Blue1Brown)/3Blue1Brown Team Folder"
+    )
+
+if not os.path.exists(MEDIA_DIR):
+    raise Exception("""
+        Redefine MEDIA_DIR by changing the MEDIA_DIR
+        environment constant or by changing
+        media_dir.txt to point to a valid directory
+        where movies and images will be written
+    """)
+
+with open("media_dir.txt", 'w') as media_file:
+    media_file.write(MEDIA_DIR)
 #
 
 
@@ -97,12 +125,6 @@ TEX_IMAGE_DIR = TEX_DIR  # TODO, What is this doing?
 MOBJECT_DIR = os.path.join(FILE_DIR, "mobjects")
 IMAGE_MOBJECT_DIR = os.path.join(MOBJECT_DIR, "image")
 
-if not os.path.exists(MEDIA_DIR):
-    raise Exception("""
-        Redefine MEDIA_DIR in constants.py to point to
-        a valid directory where movies and images will
-        be written
-    """)
 for folder in [FILE_DIR, RASTER_IMAGE_DIR, SVG_IMAGE_DIR, ANIMATIONS_DIR, TEX_DIR,
                TEX_IMAGE_DIR, MOBJECT_DIR, IMAGE_MOBJECT_DIR,
                STAGED_SCENES_DIR]:

--- a/constants.py
+++ b/constants.py
@@ -16,9 +16,7 @@ if not (env_MEDIA_DIR is None):
     MEDIA_DIR = env_MEDIA_DIR
 elif os.path.exists("media_dir.txt"):
     with open("media_dir.txt", 'rU') as media_file:
-        MEDIA_DIR = media_file.readline()
-    if MEDIA_DIR[-1] in ['\n', '\r']:
-        raise Exception("media_dir.txt must be a single-line text file pointing at the media_dir place")
+        MEDIA_DIR = media_file.readline().strip()
 else:
     MEDIA_DIR = os.path.join(
         os.path.expanduser('~'),


### PR DESCRIPTION
This pull request adds an easy way to reconfigure the media directories:
- You can have the environment variable MEDIA_DIR set, in which case it will use this and remember it
- You can have already set once the MEDIA_DIR environment variable, in which case it will use the last set
- Otherwise, it will defaults to a default directory.
In all cases, it will remember the choice and write it in a file (which is used in case you don't have the MEDIA_DIR variable set).