### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/utils/simple_functions.py
+++ b/utils/simple_functions.py
@@ -2,6 +2,11 @@ import numpy as np
 import operator as op
 from functools import reduce
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 def sigmoid(x):
     return 1.0 / (1 + np.exp(-x))


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.