### PR TITLE
Remove relative import

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from .big_ol_pile_of_manim_imports import *
+from big_ol_pile_of_manim_imports import *
 
 # To watch one of these scenes, run the following:
 # python extract_scene.py file_name <SceneName> -p


### PR DESCRIPTION
Relative import was left in example_scenes.py after it had been removed from other files.