### PR TITLE
Added the option to change color in extract scene.

### DIFF
--- a/extract_scene.py
+++ b/extract_scene.py
@@ -16,6 +16,8 @@ from scene.scene import Scene
 from utils.sounds import play_error_sound
 from utils.sounds import play_finish_sound
 
+from colour import Color
+
 HELP_MESSAGE = """
    Usage:
    python extract_scene.py <module> [<scene name>]
@@ -31,6 +33,7 @@ HELP_MESSAGE = """
    -t use transperency when exporting images
    -n specify the number of the animation to start from
    -r specify a resolution
+   -c specify a background color
 """
 SCENE_NOT_FOUND_MESSAGE = """
    That scene is not in the script
@@ -72,6 +75,7 @@ def get_configuration():
         parser.add_argument("-o", "--output_name")
         parser.add_argument("-n", "--start_at_animation_number")
         parser.add_argument("-r", "--resolution")
+        parser.add_argument("-c", "--color")
         args = parser.parse_args()
         if args.output_name is not None:
             output_name_root, output_name_ext = os.path.splitext(
@@ -134,6 +138,14 @@ def get_configuration():
             "pixel_height": height,
             "pixel_width": width,
         })
+
+    if args.color:
+        try:
+            config["camera_config"]["background_color"] = Color(args.color)
+        except AttributeError as err:
+            print("Please use a valid color")
+            print(err)
+            sys.exit(2)
 
     # If rendering a transparent image/move, make sure the
     # scene has a background opacity of 0


### PR DESCRIPTION
In accordance with Issue #281, this is simply a way to make color changing easier, especially for specific scenes. That said, I'm not sure if @3b1b wants this feature or not, especially since this can already be edited in configs for specific scenes. Nevertheless, it provides a similar method as transparency.

This edits the camera config in the same way as the resolution argument or transparency flag. Inputs can either be strings, 3 digit hex strings, or 6 digit hex strings. In a Unix terminal the hex strings will have to be prepended with a '\'.