### PR TITLE
 Explicit tuple required in comprehension in Python 3 

### DIFF
--- a/old_projects/bell.py
+++ b/old_projects/bell.py
@@ -1,4 +1,3 @@
-
 from big_ol_pile_of_manim_imports import *
 
 from tqdm import tqdm as ProgressDisplay
@@ -219,7 +218,7 @@ class PhotonsThroughPerpendicularFilters(PhotonPassesCompletelyOrNotAtAll):
                 color = here.get_color(),
                 normal_vector = DOWN+OUT,
             )
-            for here, x in (here1, 0), (here2, 4)
+            for here, x in ((here1, 0), (here2, 4))
         ]
         prob_text.add(*arrows)
 
@@ -2454,19 +2453,3 @@ class NoFirstMeasurementPreferenceBasedOnDirection(ShowVariousFilterPairs):
         )
         self.add_foreground_mobject(all_pre_lines)
         self.wait(7)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/old_projects/eoc/chapter6.py
+++ b/old_projects/eoc/chapter6.py
@@ -396,7 +396,7 @@ class SlopeOfCircleExample(ZoomedScene):
                     equation[1][i].copy(),
                     derivative[j],
                 )
-                for i, j in (1, 0), (0, 1)
+                for i, j in ((1, 0), (0, 1))
             ]
         )
         self.play(Write(dx, run_time = 1))
@@ -406,7 +406,7 @@ class SlopeOfCircleExample(ZoomedScene):
                 equation[1][i].copy(),
                 derivative[j],
             )
-            for i, j in (2, 4), (3, 6), (4, 5)
+            for i, j in ((2, 4), (3, 6), (4, 5))
         ])
         self.play(Write(dy, run_time = 1))
         self.play(Blink(morty)) 
@@ -415,7 +415,7 @@ class SlopeOfCircleExample(ZoomedScene):
                 equation[1][i].copy(),
                 derivative[j],
             )
-            for i, j in (-3, -2), (-2, -1), (-1, -1)
+            for i, j in ((-3, -2), (-2, -1), (-1, -1))
         ])
         self.wait()
 
@@ -2668,60 +2668,4 @@ class Thumbnail(AlternateExample):
         self.draw_graph()
         self.graphs.set_stroke(width = 8)
         self.remove(self.formula)
-
-
         self.add(title)
-
-
-
-
-
-
-
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Fixes two of the problems below...

[flake8](http://flake8.pycqa.org) testing of https://github.com/3b1b/manim on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./old_projects/bell.py:222:38: E999 SyntaxError: invalid syntax
            for here, x in (here1, 0), (here2, 4)
                                     ^
./old_projects/borsuk.py:217:11: E999 SyntaxError: invalid syntax
         y=lambda m: m1.get
          ^
./old_projects/eoc/chapter6.py:399:35: E999 SyntaxError: invalid syntax
                for i, j in (1, 0), (0, 1)
                                  ^
./old_projects/nn/network.py:258:16: F821 undefined name 'get_norm'
        norm = get_norm(gradient)
               ^
./old_projects/nn/network.py:264:15: F821 undefined name 'get_norm'
        print(get_norm(old_pre_sig_guess - pre_sig_guess))
              ^
3     E999 SyntaxError: invalid syntax
2     F821 undefined name 'get_norm'
5
```