### PR TITLE
from utils.space_ops import get_norm

### DIFF
--- a/old_projects/nn/network.py
+++ b/old_projects/nn/network.py
@@ -12,14 +12,15 @@ and omits many desirable features.
 
 #### Libraries
 # Standard library
+import os
+import pickle
 import random
 
 # Third-party libraries
 import numpy as np
-import os
 from PIL import Image
-import pickle
 from nn.mnist_loader import load_data_wrapper
+from utils.space_ops import get_norm
 
 NN_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 # PRETRAINED_DATA_FILE = os.path.join(NN_DIRECTORY, "pretrained_weights_and_biases_80")


### PR DESCRIPTION
__get_norm()__ is called on lines 259 and 265 but it is never imported or defined.

[flake8](http://flake8.pycqa.org) testing of https://github.com/3b1b/manim on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./old_projects/bell.py:222:38: E999 SyntaxError: invalid syntax
            for here, x in (here1, 0), (here2, 4)
                                     ^
./old_projects/borsuk.py:217:11: E999 SyntaxError: invalid syntax
         y=lambda m: m1.get
          ^
./old_projects/eoc/chapter6.py:399:35: E999 SyntaxError: invalid syntax
                for i, j in (1, 0), (0, 1)
                                  ^
./old_projects/nn/network.py:258:16: F821 undefined name 'get_norm'
        norm = get_norm(gradient)
               ^
./old_projects/nn/network.py:264:15: F821 undefined name 'get_norm'
        print(get_norm(old_pre_sig_guess - pre_sig_guess))
              ^
3     E999 SyntaxError: invalid syntax
2     F821 undefined name 'get_norm'
5
```