### PR TITLE
Adds option to fix SVGs.

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -135,6 +135,7 @@ for folder in [FILE_DIR, RASTER_IMAGE_DIR, SVG_IMAGE_DIR, ANIMATIONS_DIR, TEX_DI
         os.makedirs(folder)
 
 TEX_USE_CTEX = False
+TEX_FIX_SVG = False
 TEX_TEXT_TO_REPLACE = "YourTextHere"
 TEMPLATE_TEX_FILE = os.path.join(THIS_DIR, "tex_template.tex" if not TEX_USE_CTEX
     else "ctex_template.tex")

--- a/utils/tex_file_writing.py
+++ b/utils/tex_file_writing.py
@@ -5,6 +5,7 @@ import hashlib
 from constants import TEX_DIR
 from constants import TEX_TEXT_TO_REPLACE
 from constants import TEX_USE_CTEX
+from constants import TEX_FIX_SVG
 
 
 def tex_hash(expression, template_tex_file_body):
@@ -96,4 +97,15 @@ def dvi_to_svg(dvi_file, regen_if_exists=False):
             get_null()
         ]
         os.system(" ".join(commands))
+
+        if TEX_FIX_SVG:
+            commands = [
+                "cairosvg",
+                result,
+                "-f",
+                "svg",
+                "-o",
+                result
+            ]
+            os.system(" ".join(commands))
     return result


### PR DESCRIPTION
Adds a new option to the constants.py, `TEX_FIX_SVG`. This is False by default, but can be enabled to use cairosvg to fix SVGs automatically. 

This allows the use of some fonts and shapes that might otherwise be problematic, as per issue #329. 