### PR TITLE
SVG single-factor scaling

### DIFF
--- a/mobject/svg/svg_mobject.py
+++ b/mobject/svg/svg_mobject.py
@@ -264,8 +264,13 @@ class SVGMobject(VMobject):
             if not transform.startswith(prefix) or not transform.endswith(suffix):
                 raise Exception()
             transform = transform[len(prefix):-len(suffix)]
-            scale_x, scale_y = string_to_numbers(transform)
-            mobject.scale(np.array([scale_x, scale_y, 1]))
+            scale_values = string_to_numbers(transform)
+            if len(scale_values) == 2:
+                scale_x, scale_y = scale_values
+                mobject.scale(np.array([scale_x, scale_y, 1]))
+            elif len(scale_values) == 1:
+                scale = scale_values[0]
+                mobject.scale(np.array([scale,scale,1]), about_point = ORIGIN)
         except:
             pass
 


### PR DESCRIPTION
Some fonts (like mathpazo) produce svg files which use single scale-factor transform (like `transform=scale(1.3)`). Previously the behavior of this code was to throw an unpacking exception in the try block, which resulted in the font glyphs misrendering. 

I would think that the `about_point` should be `ORIGIN` for the [scale_x, scale_y, 1] block as well, but I only put that change in the `elif` clause so that the proposed change would be non-breaking.