### PR TITLE
Fix fallback to plain pi creature and make once_useful_constructs into a package

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -144,7 +144,7 @@ with open(TEMPLATE_TEX_FILE, "r") as infile:
     TEMPLATE_TEXT_FILE_BODY = infile.read()
     TEMPLATE_TEX_FILE_BODY = TEMPLATE_TEXT_FILE_BODY.replace(
         TEX_TEXT_TO_REPLACE,
-        "\\begin{align*}" + TEX_TEXT_TO_REPLACE + "\\end{align*}",
+        "\\begin{align*}\n" + TEX_TEXT_TO_REPLACE + "\n\\end{align*}",
     )
 
 FFMPEG_BIN = "ffmpeg"

--- a/for_3b1b_videos/pi_creature.py
+++ b/for_3b1b_videos/pi_creature.py
@@ -1,5 +1,6 @@
 import numpy as np
 import warnings
+import os
 
 from constants import *
 
@@ -17,7 +18,12 @@ from utils.rate_functions import squish_rate_func
 from utils.rate_functions import there_and_back
 from utils.space_ops import get_norm
 
-PI_CREATURE_DIR = os.path.join(MEDIA_DIR, "designs", "PiCreature")
+pi_creature_dir_maybe = os.path.join(MEDIA_DIR, "designs", "PiCreature")
+if os.path.exists(pi_creature_dir_maybe):
+    PI_CREATURE_DIR = pi_creature_dir_maybe
+else:
+    PI_CREATURE_DIR = os.path.join(FILE_DIR)
+
 PI_CREATURE_SCALE_FACTOR = 0.5
 
 LEFT_EYE_INDEX = 0
@@ -63,7 +69,7 @@ class PiCreature(SVGMobject):
                 FILE_DIR,
                 "PiCreatures_plain.svg",
             )
-            SVGMobject.__init__(self, file_name=svg_file, **kwargs)
+            SVGMobject.__init__(self, mode="plain", file_name=svg_file, **kwargs)
 
         if self.flip_at_start:
             self.flip()

--- a/mobject/svg/svg_mobject.py
+++ b/mobject/svg/svg_mobject.py
@@ -43,7 +43,7 @@ class SVGMobject(VMobject):
 
     def __init__(self, file_name=None, **kwargs):
         digest_config(self, kwargs)
-        self.file_name = self.file_name or file_name
+        self.file_name = file_name or self.file_name
         self.ensure_valid_file()
         VMobject.__init__(self, **kwargs)
         self.move_into_position()

--- a/old_projects/eola/chapter0.py
+++ b/old_projects/eola/chapter0.py
@@ -1,4 +1,5 @@
 from big_ol_pile_of_manim_imports import *
+from once_useful_constructs import *
 
 EXAMPLE_TRANFORM = [[0, 1], [-1, 1]]
 TRANFORMED_VECTOR = [[1], [2]]
@@ -192,7 +193,7 @@ class AboutLinearAlgebra(Scene):
 
     def get_cross_product(self):
         return TexMobject("""
-            \\vec\\textbf{v} \\times \\textbf{w} = 
+            \\vec{\\textbf{v}} \\times \\textbf{w} =
             \\text{Det}\\left(
                 \\begin{array}{ccc}
                     \\hat{\imath} & \\hat{\jmath} & \\hat{k} \\\\
@@ -203,8 +204,8 @@ class AboutLinearAlgebra(Scene):
         """)
 
     def get_eigenvalue(self):
-        result = TextMobject("\\Text{Det}\\left(A - \\lambda I \\right) = 0")
-        result.submobjects[-5].set_color(YELLOW)
+        result = TexMobject("\\text{Det}\\left(A - \\lambda I \\right) = 0")
+        result.submobjects[0][-5].set_color(YELLOW)
         return result
 
     def get_matrix_multiplication_question(self):

--- a/once_useful_constructs/__init__.py
+++ b/once_useful_constructs/__init__.py
@@ -1,0 +1,28 @@
+import constants
+import os
+import importlib
+
+modules = filter(
+    lambda x: x.endswith(".py"),
+    os.listdir(constants.THIS_DIR + os.sep + "once_useful_constructs"),
+)
+modules = list(map(
+    lambda x: x[:x.find(".py")],
+    modules
+))
+for m in modules:
+    if m == "__init__":
+        continue
+    else:
+        importlib.import_module("once_useful_constructs." + m, package="once_useful_constructs")
+
+for m in modules:
+    if m == "__init__":
+        continue
+    m = globals()[m]
+    module_dict = m.__dict__
+    try:
+        to_import = m.__all__
+    except AttributeError:
+        to_import = [name for name in module_dict if not name.startswith('_')]
+    globals().update({name: module_dict[name] for name in to_import})


### PR DESCRIPTION
Although [scenes involving pi creatures are intended to fall back to the plain one](https://github.com/3b1b/manim/issues/18#issuecomment-299902614), the configuration for `PiCreature` mobjects actually prevents it from working.

This pr achieves three things:
1. Fix the logic preventing `PiCreatures` from falling back correctly
2. Make some of the latex in `/old_projects/eola/chapter0.py` more compliant (my latex compiler simply threw an error)
3. Make `/once_useful_constructs/__init__.py` into a package, so that scenes in `old_projects` can import it