### PR TITLE
Scale SVGMobject about origin

### DIFF
--- a/mobject/svg/svg_mobject.py
+++ b/mobject/svg/svg_mobject.py
@@ -267,10 +267,10 @@ class SVGMobject(VMobject):
             scale_values = string_to_numbers(transform)
             if len(scale_values) == 2:
                 scale_x, scale_y = scale_values
-                mobject.scale(np.array([scale_x, scale_y, 1]))
+                mobject.scale(np.array([scale_x, scale_y, 1]), about_point=ORIGIN)
             elif len(scale_values) == 1:
                 scale = scale_values[0]
-                mobject.scale(np.array([scale,scale,1]), about_point = ORIGIN)
+                mobject.scale(np.array([scale, scale, 1]), about_point=ORIGIN)
         except:
             pass
 


### PR DESCRIPTION
I don't think this is nearly as bad a problem as I thought it was in #360. It seems that scaling only affects the appearance of the SVGMobject, but not its position.
