### PR TITLE
Use os.openfile() on Windows and gitignore media folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ ben_playground.py
 ben_cairo_test.py
 .floo
 .flooignore
+.vscode
 *.xml
 *.iml
+media
 manim.sublime-project
 manim.sublime-workspace
 

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -25,23 +25,33 @@ def handle_scene(scene, **config):
         config["show_file_in_finder"]
     ])
     if open_file:
-        commands = ["open"]
-        if (platform.system() == "Linux"):
-            commands = ["xdg-open"]
-        elif (platform.system() == "Windows"):
-            commands = ["start"]
-
-        if config["show_file_in_finder"]:
-            commands.append("-R")
+        current_os = platform.system()
+        file_path = None
 
         if config["show_last_frame"]:
-            commands.append(scene.get_image_file_path())
+            file_path = scene.get_image_file_path()
         else:
-            commands.append(scene.get_movie_file_path())
-        # commands.append("-g")
-        FNULL = open(os.devnull, 'w')
-        sp.call(commands, stdout=FNULL, stderr=sp.STDOUT)
-        FNULL.close()
+            file_path = scene.get_movie_file_path()
+
+        if current_os == "Windows":
+            os.startfile(file_path)
+        else:
+            commands = []
+
+            if (current_os == "Linux"):
+                commands.append("xdg-open")
+            else: # Assume macOS
+                commands.append("open")
+
+            if config["show_file_in_finder"]:
+                commands.append("-R")
+
+            commands.append(file_path)
+
+            # commands.append("-g")
+            FNULL = open(os.devnull, 'w')
+            sp.call(commands, stdout=FNULL, stderr=sp.STDOUT)
+            FNULL.close()
 
     if config["quiet"]:
         sys.stdout.close()


### PR DESCRIPTION
## Motivation
Previously, `manim` would fail when trying to open the finished video on Windows:

```
Writing to media\videos\..\example_scenes\480p15\SquareToCircleTemp.mp4
Animation 0: ShowCreationSquare: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 15/15 [00:00<00:00, 87.73it/s]
Animation 1: TransformSquareToCircle: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 15/15 [00:00<00:00, 155.48it/s]
Animation 2: FadeOutSquareToSquare: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 15/15 [00:00<00:00, 149.59it/s]
Played a total of 3 animations

Traceback (most recent call last):
  File "D:\git\manim\manimlib\extract_scene.py", line 128, in main
    handle_scene(SceneClass(**scene_kwargs), **config)
  File "D:\git\manim\manimlib\extract_scene.py", line 43, in handle_scene
    sp.call(commands, stdout=FNULL, stderr=sp.STDOUT)
  File "C:\Users\fw\scoop\apps\python\current\lib\subprocess.py", line 317, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\Users\fw\scoop\apps\python\current\lib\subprocess.py", line 769, in __init__
    restore_signals, start_new_session)
  File "C:\Users\fw\scoop\apps\python\current\lib\subprocess.py", line 1172, in _execute_child
    startupinfo)
FileNotFoundError: [WinError 2] The system cannot find the file specified

The system cannot find the path specified.
```

The (platform-dependent) [`os.startfile`](https://docs.python.org/3/library/os.html#os.startfile) function fixes this issue.

Furthermore, the default `media` folder is not used by the repository, so it seemed reasonable to `gitignore` it (together with a few config files used by VSCode, a popular text editor).

## Changes

This PR uses `os.startfile` (instead of a shell command) on Windows while leaving the mechanism on macOS and Linux unchanged.

Additionally, it provides a two new "gitignores" as mentioned above.

## Testing

I have successfully tested this branch on Windows 10 and macOS High Sierra using the `SquareToCircle` scene:

```bash
python3 -m manim example_scenes.py SquareToCircle -pl
```