### PR TITLE
Add option to suppress success/failure sound

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -40,6 +40,11 @@ def parse_cli():
         parser.add_argument("-n", "--start_at_animation_number")
         parser.add_argument("-r", "--resolution")
         parser.add_argument("-c", "--color")
+        parser.add_argument(
+            "--no_sound",
+            action="store_true",
+            help="Don't play a success/failure sound",
+        )
         module_location.add_argument(
             "--livestream",
             action="store_true",
@@ -120,6 +125,7 @@ def get_configuration(args):
         "output_name": output_name,
         "start_at_animation_number": args.start_at_animation_number,
         "end_at_animation_number": None,
+        "no_sound": args.no_sound,
     }
 
     # Camera configuration

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -126,13 +126,15 @@ def main(config):
     for SceneClass in get_scene_classes(scene_names_to_classes, config):
         try:
             handle_scene(SceneClass(**scene_kwargs), **config)
-            play_finish_sound()
+            if not config["no_sound"]:
+                play_finish_sound()
             sys.exit(0)
         except Exception:
             print("\n\n")
             traceback.print_exc()
             print("\n\n")
-            play_error_sound()
+            if not config["no_sound"]:
+                play_error_sound()
             sys.exit(2)
 
 


### PR DESCRIPTION
The success/failure sound isn't necessary when using manim as part of a larger application, so add an option to suppress it if desired.