### PR TITLE
added import copy to camera.py

### DIFF
--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -2,6 +2,7 @@ from functools import reduce
 import itertools as it
 import operator as op
 import time
+import copy
 
 from PIL import Image
 from scipy.spatial.distance import pdist


### PR DESCRIPTION
The latest version of manim was giving a `NameError` in camera.py
```
Traceback (most recent call last):                                                                       
  File "/home/azazel/Documents/fossee/manim/manimlib/extract_scene.py", line 138, in main                
    handle_scene(SceneClass(**scene_kwargs), **config)                                                   
  File "/home/azazel/Documents/fossee/manim/manimlib/scene/scene.py", line 78, in __init__               
    self.construct(*self.construct_args)                                                                 
  File "/home/azazel/Documents/fossee/manim/holomorphic.py", line 33, in construct                       
    self.zoom_in_to_one_plus_half_i()                                                                    
  File "/home/azazel/Documents/fossee/manim/holomorphic.py", line 152, in zoom_in_to_one_plus_half_i     
    self.activate_zooming(animate=True)                                                                  
  File "/home/azazel/Documents/fossee/manim/manimlib/scene/zoomed_scene.py", line 63, in activate_zooming
    self.play(self.get_zoomed_display_pop_out_animation())                                               
  File "/home/azazel/Documents/fossee/manim/manimlib/scene/zoomed_scene.py", line 82, in get_zoomed_displ
ay_pop_out_animation                                                                                     
    display.save_state(use_deepcopy=True)                                                                
  File "/home/azazel/Documents/fossee/manim/manimlib/mobject/mobject.py", line 664, in save_state        
    self.saved_state = self.deepcopy()                                                                   
  File "/home/azazel/Documents/fossee/manim/manimlib/mobject/mobject.py", line 136, in deepcopy          
    return copy.deepcopy(self)                                                                           
  File "/usr/lib/python3.6/copy.py", line 180, in deepcopy                                               
    y = _reconstruct(x, memo, *rv)                                                                       
  File "/usr/lib/python3.6/copy.py", line 280, in _reconstruct                                           
    state = deepcopy(state, memo)                                                                        
  File "/usr/lib/python3.6/copy.py", line 150, in deepcopy                                               
    y = copier(x, memo)                                                                                  
  File "/usr/lib/python3.6/copy.py", line 240, in _deepcopy_dict                                         
    y[deepcopy(key, memo)] = deepcopy(value, memo)                                                       
  File "/usr/lib/python3.6/copy.py", line 161, in deepcopy                                               
    y = copier(memo)                                                                                     
  File "/home/azazel/Documents/fossee/manim/manimlib/camera/camera.py", line 64, in __deepcopy__
    return copy.copy(self)
NameError: name 'copy' is not defined

```

Simple fix of adding `import copy` to camera.py did it. The error can be reproduced in commit `9dafb85` by rendering `active_projects/holomorphic.py`'s  `AnalyzeZSquared`. 
(OS: Ubuntu 18.04)