### PR TITLE
allow rendering scenes from any directory

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -1,6 +1,6 @@
 import argparse
 import colour
-import importlib
+import importlib.util
 import os
 import sys
 import types
@@ -79,7 +79,7 @@ def parse_cli():
 
 def get_module(file_name):
     if file_name == "-":
-        module = types.ModuleType("InputModule")
+        module = types.ModuleType("input_scenes")
         code = "from big_ol_pile_of_manim_imports import *\n\n" + sys.stdin.read()
         try:
             exec(code, module.__dict__)
@@ -88,8 +88,11 @@ def get_module(file_name):
             print(f"Failed to render scene: {str(e)}")
             sys.exit(2)
     else:
-        module_name = file_name.replace(".py", "").replace(os.sep, ".")
-        return importlib.import_module(module_name)
+        module_name = file_name.split(os.sep)[-1].replace(".py", "")
+        spec = importlib.util.spec_from_file_location(module_name, file_name)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
 
 
 def get_configuration(args):

--- a/manimlib/utils/output_directory_getters.py
+++ b/manimlib/utils/output_directory_getters.py
@@ -20,14 +20,7 @@ def guarantee_existance(path):
 
 
 def get_scene_output_directory(scene_class):
-    try:
-        file_path = os.path.abspath(inspect.getfile(scene_class))
-        file_path = os.path.relpath(file_path, THIS_DIR)
-        file_path = file_path.replace(".pyc", "")
-        file_path = file_path.replace(".py", "")
-        return guarantee_existance(os.path.join(VIDEO_DIR, file_path))
-    except TypeError:
-        return guarantee_existance(os.path.join(VIDEO_DIR, "input_scenes"))
+    return guarantee_existance(os.path.join(VIDEO_DIR, scene_class.__module__))
 
 
 def get_movie_output_directory(scene_class, camera_config, frame_duration):


### PR DESCRIPTION
As was mentioned in #389, manim fails to render scenes that aren't contained in the root directory. This PR fixes that issue.

Testing:
```
(manim) > mkdir test
(manim) > cd test/
(manim) > python -m manim --no_sound ~/Public/manim/example_scenes.py SquareToCircle -l
Media will be stored in media/. You can change this behavior by writing a different directory to media_dir.txt.
Writing to media/videos/example_scenes/480p15/SquareToCircleTemp.mp4
Animation 0: ShowCreationSquare: 100%|██████████████| 15/15 [00:00<00:00, 164.53it/s]
Animation 1: TransformSquareToCircle: 100%|█████████| 15/15 [00:00<00:00, 292.01it/s]
Animation 2: FadeOutSquareToSquare: 100%|███████████| 15/15 [00:00<00:00, 279.36it/s]
Played a total of 3 animations
(manim) > python -m manim --no_sound ~/Public/manim/example_scenes.py WarpSquare -l
Writing to media/videos/example_scenes/480p15/WarpSquareTemp.mp4
Animation 0: ApplyPointwiseFunctionSquareToSquare:  69%|▋| 31/45 [00:00<00:00, 308.88Animation 0: ApplyPointwiseFunctionSquareToSquare: 100%|█| 45/45 [00:00<00:00, 301.33it/s]
Played a total of 1 animations
(manim) > echo -e "class WarpSquare(Scene):
    def construct(self):
        square = Square()
        self.play(ApplyPointwiseFunction(
            lambda point: complex_to_R3(np.exp(R3_to_complex(point))),
            square
        ))
        self.wait()" | python -m manim - WarpSquare -l
Writing to media/videos/input_scenes/480p15/WarpSquareTemp.mp4
Animation 0: ApplyPointwiseFunctionSquareToSquare:  67%|▋| 30/45 [00:00<00:00, 296.82Animation 0: ApplyPointwiseFunctionSquareToSquare: 100%|█| 45/45 [00:00<00:00, 296.42it/s]
(manim) > tree media
media
├── designs
│   ├── raster_images
│   └── svg_images
└── videos
    ├── example_scenes
    │   └── 480p15
    │       ├── SquareToCircle.mp4
    │       └── WarpSquare.mp4
    ├── input_scenes
    │   └── 480p15
    │       └── WarpSquare.mp4
    └── staged_scenes

9 directories, 3 files
```