### PR TITLE
Made sure to always encode written TeX files as UTF-8

### DIFF
--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -1,6 +1,5 @@
 import os
 import hashlib
-import codecs
 
 from manimlib.constants import TEX_DIR
 from manimlib.constants import TEX_TEXT_TO_REPLACE

--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -1,5 +1,6 @@
 import os
 import hashlib
+import codecs
 
 from manimlib.constants import TEX_DIR
 from manimlib.constants import TEX_TEXT_TO_REPLACE
@@ -32,7 +33,7 @@ def generate_tex_file(expression, template_tex_file_body):
         new_body = template_tex_file_body.replace(
             TEX_TEXT_TO_REPLACE, expression
         )
-        with open(result, "w") as outfile:
+        with open(result, "w", encoding="utf-8") as outfile:
             outfile.write(new_body)
     return result
 


### PR DESCRIPTION
### Motivation
I have faced issues where German "umlauts" (such as `ä`, `ö` or `ü`) would not be encoded correctly, since the standard encoding on Windows is `Windows 1252` rather than `UTF-8`.

### Fix
This PR changes the TeX file encoding to be explicitly `UTF-8`.