### PR TITLE
Scene file writer refactor

### DIFF
--- a/active_projects/clacks/name_bump.py
+++ b/active_projects/clacks/name_bump.py
@@ -80,5 +80,4 @@ class NameBump(BlocksAndWallExample):
 #         write_to_movie=True,
 #         output_file_name=file_name,
 #         camera_config=PRODUCTION_QUALITY_CAMERA_CONFIG,
-#         frame_duration=PRODUCTION_QUALITY_FRAME_DURATION,
 #     )

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -30,6 +30,7 @@ class Camera(object):
         "background_image": None,
         "pixel_height": DEFAULT_PIXEL_HEIGHT,
         "pixel_width": DEFAULT_PIXEL_WIDTH,
+        "frame_duration": DEFAULT_FRAME_DURATION,
         # Note: frame height and width will be resized to match
         # the pixel aspect ratio
         "frame_height": FRAME_HEIGHT,

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -155,6 +155,7 @@ def get_module(file_name):
 
 
 def get_configuration(args):
+    module = get_module(args.file)
     file_writer_config = {
         # By default, write to file
         "write_to_movie": args.write_to_movie or not args.save_last_frame,
@@ -165,8 +166,10 @@ def get_configuration(args):
         "movie_file_extension": ".mov" if args.transparent else ".mp4",
         "file_name": args.file_name,
     }
+    if hasattr(module, "OUTPUT_DIRECTORY"):
+        file_writer_config["output_directory"] = module.OUTPUT_DIRECTORY
     config = {
-        "module": get_module(args.file),
+        "module": module,
         "scene_names": args.scene_names,
         "open_video_upon_completion": args.preview,
         "show_file_in_finder": args.show_file_in_finder,

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -181,43 +181,7 @@ def get_configuration(args):
     }
 
     # Camera configuration
-    config["camera_config"] = {}
-    if args.low_quality:
-        config["camera_config"].update(manimlib.constants.LOW_QUALITY_CAMERA_CONFIG)
-        config["frame_duration"] = manimlib.constants.LOW_QUALITY_FRAME_DURATION
-    elif args.medium_quality:
-        config["camera_config"].update(manimlib.constants.MEDIUM_QUALITY_CAMERA_CONFIG)
-        config["frame_duration"] = manimlib.constants.MEDIUM_QUALITY_FRAME_DURATION
-    else:
-        config["camera_config"].update(manimlib.constants.PRODUCTION_QUALITY_CAMERA_CONFIG)
-        config["frame_duration"] = manimlib.constants.PRODUCTION_QUALITY_FRAME_DURATION
-
-    # If the resolution was passed in via -r
-    if args.resolution:
-        if "," in args.resolution:
-            height_str, width_str = args.resolution.split(",")
-            height = int(height_str)
-            width = int(width_str)
-        else:
-            height = int(args.resolution)
-            width = int(16 * height / 9)
-        config["camera_config"].update({
-            "pixel_height": height,
-            "pixel_width": width,
-        })
-
-    if args.color:
-        try:
-            config["camera_config"]["background_color"] = colour.Color(args.color)
-        except AttributeError as err:
-            print("Please use a valid color")
-            print(err)
-            sys.exit(2)
-
-    # If rendering a transparent image/move, make sure the
-    # scene has a background opacity of 0
-    if args.transparent:
-        config["camera_config"]["background_opacity"] = 0
+    config["camera_config"] = get_camera_configuration(args)
 
     # Arguments related to skipping
     stan = config["start_at_animation_number"]
@@ -234,3 +198,42 @@ def get_configuration(args):
         config["start_at_animation_number"],
     ])
     return config
+
+
+def get_camera_configuration(args):
+    camera_config = {}
+    if args.low_quality:
+        camera_config.update(manimlib.constants.LOW_QUALITY_CAMERA_CONFIG)
+    elif args.medium_quality:
+        camera_config.update(manimlib.constants.MEDIUM_QUALITY_CAMERA_CONFIG)
+    else:
+        camera_config.update(manimlib.constants.PRODUCTION_QUALITY_CAMERA_CONFIG)
+
+    # If the resolution was passed in via -r
+    if args.resolution:
+        if "," in args.resolution:
+            height_str, width_str = args.resolution.split(",")
+            height = int(height_str)
+            width = int(width_str)
+        else:
+            height = int(args.resolution)
+            width = int(16 * height / 9)
+        camera_config.update({
+            "pixel_height": height,
+            "pixel_width": width,
+        })
+
+    if args.color:
+        try:
+            camera_config["background_color"] = colour.Color(args.color)
+        except AttributeError as err:
+            print("Please use a valid color")
+            print(err)
+            sys.exit(2)
+
+    # If rendering a transparent image/move, make sure the
+    # scene has a background opacity of 0
+    if args.transparent:
+        camera_config["background_opacity"] = 0
+
+    return camera_config

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -82,33 +82,34 @@ NO_SCENE_MESSAGE = """
    There are no scenes inside that module
 """
 
-LOW_QUALITY_FRAME_DURATION = 1. / 15
-MEDIUM_QUALITY_FRAME_DURATION = 1. / 30
-PRODUCTION_QUALITY_FRAME_DURATION = 1. / 60
-
 # There might be other configuration than pixel shape later...
 PRODUCTION_QUALITY_CAMERA_CONFIG = {
     "pixel_height": 1440,
     "pixel_width": 2560,
+    "frame_rate": 60,
 }
 
 HIGH_QUALITY_CAMERA_CONFIG = {
     "pixel_height": 1080,
     "pixel_width": 1920,
+    "frame_rate": 30,
 }
 
 MEDIUM_QUALITY_CAMERA_CONFIG = {
     "pixel_height": 720,
     "pixel_width": 1280,
+    "frame_rate": 30,
 }
 
 LOW_QUALITY_CAMERA_CONFIG = {
     "pixel_height": 480,
     "pixel_width": 854,
+    "frame_rate": 15,
 }
 
 DEFAULT_PIXEL_HEIGHT = PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_height"]
 DEFAULT_PIXEL_WIDTH = PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_width"]
+DEFAULT_FRAME_DURATION = 30
 
 DEFAULT_POINT_DENSITY_2D = 25
 DEFAULT_POINT_DENSITY_1D = 250

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -67,16 +67,16 @@ def is_child_scene(obj, module):
     return True
 
 
-def prompt_user_for_choice(name_to_obj):
-    num_to_name = {}
-    names = sorted(name_to_obj.keys())
-    for count, name in zip(it.count(1), names):
+def prompt_user_for_choice(scene_classes):
+    num_to_class = {}
+    for count, scene_class in zip(it.count(1), scene_classes):
+        name = scene_class.__name__
         print("%d: %s" % (count, name))
-        num_to_name[count] = name
+        num_to_class[count] = scene_class
     try:
         user_input = input(manimlib.constants.CHOOSE_NUMBER_MESSAGE)
         return [
-            name_to_obj[num_to_name[int(num_str)]]
+            num_to_class[int(num_str)]
             for num_str in user_input.split(",")
         ]
     except KeyError:
@@ -84,54 +84,70 @@ def prompt_user_for_choice(name_to_obj):
         sys.exit(2)
         user_input = input(manimlib.constants.CHOOSE_NUMBER_MESSAGE)
         return [
-            name_to_obj[num_to_name[int(num_str)]]
+            num_to_class[int(num_str)]
             for num_str in user_input.split(",")
         ]
     except EOFError:
         sys.exit(1)
 
 
-def get_scene_classes(scene_names_to_classes, config):
-    if len(scene_names_to_classes) == 0:
+def get_scenes_to_render(scene_classes, config):
+    if len(scene_classes) == 0:
         print(manimlib.constants.NO_SCENE_MESSAGE)
         return []
     if config["write_all"]:
-        return list(scene_names_to_classes.values())
-    scene_classes = []
+        return scene_classes
+    result = []
     for scene_name in config["scene_names"]:
-        if scene_name in scene_names_to_classes:
-            scene_classes.append(scene_names_to_classes[scene_name])
-        elif scene_name != "":
+        found = False
+        for scene_class in scene_classes:
+            if scene_class.__name__ == scene_name:
+                result.append(scene_class)
+                found = True
+                break
+        if not found and (scene_name != ""):
             print(
                 manimlib.constants.SCENE_NOT_FOUND_MESSAGE.format(
                     scene_name
                 ),
                 file=sys.stderr
             )
-    if scene_classes:
-        return scene_classes
-    return prompt_user_for_choice(scene_names_to_classes)
+    if result:
+        return result
+    return prompt_user_for_choice(scene_classes)
+
+
+def get_scene_classes_from_module(module):
+    if hasattr(module, "ALL_SCENE_CLASSES"):
+        return module.ALL_SCENE_CLASSES
+    else:
+        return [
+            member[1]
+            for member in inspect.getmembers(
+                module,
+                lambda x: is_child_scene(x, module)
+            )
+        ]
 
 
 def main(config):
     module = config["module"]
-    scene_names_to_classes = dict(
-        inspect.getmembers(module, lambda x: is_child_scene(x, module))
-    )
+    all_scene_classes = get_scene_classes_from_module(module)
+    scene_classes_to_render = get_scenes_to_render(all_scene_classes, config)
 
     scene_kwargs = dict([
         (key, config[key])
         for key in [
             "camera_config",
-            "skip_animations",
             "file_writer_config",
+            "skip_animations",
             "start_at_animation_number",
             "end_at_animation_number",
             "leave_progress_bars",
         ]
     ])
 
-    for SceneClass in get_scene_classes(scene_names_to_classes, config):
+    for SceneClass in scene_classes_to_render:
         try:
             # By invoking, this renders the full scene
             scene = SceneClass(**scene_kwargs)

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -123,7 +123,6 @@ def main(config):
         (key, config[key])
         for key in [
             "camera_config",
-            "frame_duration",
             "skip_animations",
             "file_writer_config",
             "start_at_animation_number",

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -84,9 +84,9 @@ class SceneFileWriter(object):
 
     def get_movie_directory(self):
         pixel_height = self.scene.camera.pixel_height
-        frame_duration = self.scene.frame_duration
+        frame_rate = self.scene.camera.frame_rate
         return "{}p{}".format(
-            pixel_height, int(1.0 / frame_duration)
+            pixel_height, frame_rate
         )
 
     def get_image_directory(self):
@@ -178,8 +178,9 @@ class SceneFileWriter(object):
             self.add_frames(*[frame] * n_frames)
             b = datetime.datetime.now()
             time_diff = (b - a).total_seconds()
-            if time_diff < self.frame_duration:
-                sleep(self.frame_duration - time_diff)
+            frame_duration = 1 / self.scene.camera.frame_rate
+            if time_diff < frame_duration:
+                sleep(frame_duration - time_diff)
 
     def finish(self):
         if self.write_to_movie:
@@ -197,7 +198,7 @@ class SceneFileWriter(object):
         self.partial_movie_file_path = file_path
         self.temp_partial_movie_file_path = temp_file_path
 
-        fps = int(1 / self.scene.frame_duration)
+        fps = self.scene.camera.frame_rate
         height = self.scene.camera.get_pixel_height()
         width = self.scene.camera.get_pixel_width()
 

--- a/manimlib/scene/scene_from_video.py
+++ b/manimlib/scene/scene_from_video.py
@@ -4,6 +4,7 @@ import cv2
 from manimlib.scene.scene import Scene
 
 
+# TODO, is this depricated?
 class SceneFromVideo(Scene):
     def construct(self, file_name,
                   freeze_last_frame=True,
@@ -14,7 +15,7 @@ class SceneFromVideo(Scene):
             int(cap.get(cv2.cv.CV_CAP_PROP_FRAME_WIDTH))
         )
         fps = cap.get(cv2.cv.CV_CAP_PROP_FPS)
-        self.frame_duration = 1.0 / fps
+        self.camera.frame_rate = fps
         frame_count = int(cap.get(cv2.cv.CV_CAP_PROP_FRAME_COUNT))
         if time_range is None:
             start_frame = 0

--- a/manimlib/scene/three_d_scene.py
+++ b/manimlib/scene/three_d_scene.py
@@ -1,7 +1,7 @@
 from manimlib.animation.transform import ApplyMethod
 from manimlib.camera.three_d_camera import ThreeDCamera
 from manimlib.constants import DEGREES
-from manimlib.constants import PRODUCTION_QUALITY_FRAME_DURATION
+from manimlib.constants import PRODUCTION_QUALITY_CAMERA_CONFIG
 from manimlib.continual_animation.update import ContinualGrowValue
 from manimlib.mobject.coordinate_systems import ThreeDAxes
 from manimlib.mobject.geometry import Line
@@ -146,7 +146,7 @@ class SpecialThreeDScene(ThreeDScene):
 
     def __init__(self, **kwargs):
         digest_config(self, kwargs)
-        if self.frame_duration == PRODUCTION_QUALITY_FRAME_DURATION:
+        if self.camera.get_pixel_width() == PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_width"]:
             config = {}
         else:
             config = self.low_quality_config

--- a/manimlib/stream_starter.py
+++ b/manimlib/stream_starter.py
@@ -31,7 +31,6 @@ def start_livestream(to_twitch=False, twitch_key=None):
                 "end_at_animation_number": None,
                 "skip_animations": False,
                 "camera_config": manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG,
-                "frame_duration": manimlib.constants.MEDIUM_QUALITY_FRAME_DURATION,
                 "livestreaming": True,
                 "to_twitch": to_twitch,
                 "twitch_key": twitch_key,

--- a/old_projects/bell.py
+++ b/old_projects/bell.py
@@ -2360,7 +2360,7 @@ class ReEmphasizeVennDiagram(VennDiagramProofByContradiction):
         C_freq = -0.7
 
         self.time = 0
-        dt = self.frame_duration
+        dt = 1 / self.camera.frame_rate
 
         def move_around(total_time):
             self.time
@@ -2371,7 +2371,7 @@ class ReEmphasizeVennDiagram(VennDiagramProofByContradiction):
                 new_B_to_C = rotate_vector(B_to_C, self.time*C_freq)
                 A_group.shift(B_center + new_B_to_A - center_of_mass(A_ref))
                 C_group.shift(B_center + new_B_to_C - center_of_mass(C_ref))
-                self.wait(self.frame_duration)
+                self.wait(dt)
 
         move_around(3)
         self.add(self.footnote)

--- a/stage_scenes.py
+++ b/stage_scenes.py
@@ -37,7 +37,6 @@ def stage_animations(module_name):
         return
     output_directory_kwargs = {
         "camera_config": PRODUCTION_QUALITY_CAMERA_CONFIG,
-        "frame_duration": PRODUCTION_QUALITY_FRAME_DURATION,
     }
     animation_dir = get_movie_output_directory(
         scene_classes[0], **output_directory_kwargs


### PR DESCRIPTION
- Use frame_rate, instead of frame_duration, and make that part of the camera rather than the scene
- Allow scene extraction from a special file which contains an ALL_SCENE_CLASSES list and an OUTPUT_DIRECTORY. This is part of a move to make the output file organization independent from the source code organization