### PR TITLE
Fix a TypeError when trying to use ArcBetweenPoint

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -117,7 +117,7 @@ class ArcBetweenPoints(Arc):
         distance_vector = end_point - start_point
         normal_vector = np.array([-distance_vector[1], distance_vector[0], 0])
         distance = get_norm(normal_vector)
-        normal_vector /= distance
+        normal_vector = np.true_divide(normal_vector, distance)
         if angle < 0:
             normal_vector *= -1
 


### PR DESCRIPTION
Calling `ArcBetweenPoints(np.array([-1,0,0]), np.array([1,2,0]))`
results in:
```
normal_vector /= distance
TypeError: ufunc 'true_divide' output (typecode 'd')
vided output parameter (typecode 'l') according to t
```

I was able to fix this by replacing `normal_vector /= distance` with `normal_vector = np.true_divide(normal_vector, distance)` on line 120 of mobject/geometry.py.

It works instead of causing the TypeError now:
![Graph. Seems to work.](https://i.imgur.com/QV9FEF0.png)