### PR TITLE
Optionally specify files directory with FILE_DIR environment variable

### DIFF
--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -28,7 +28,7 @@ SVG_IMAGE_DIR = os.path.join(MEDIA_DIR, "designs", "svg_images")
 SOUND_DIR = os.path.join(MEDIA_DIR, "designs", "sounds")
 ###
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
-FILE_DIR = os.path.join(THIS_DIR, "files")
+FILE_DIR = os.path.join(os.getenv("FILE_DIR", default=THIS_DIR), "files")
 TEX_DIR = os.path.join(FILE_DIR, "Tex")
 # These two may be depricated now.
 MOBJECT_DIR = os.path.join(FILE_DIR, "mobjects")


### PR DESCRIPTION
Unprivileged users are typically granted read-only access to library code for security reasons. Manim currently prevents this protection by writing to its own directory whenever a Scene generates latex. This change allows a user to specify a `files` directory through an environment variable.

Note that this, along with the option to specify `MEDIA_DIR` through an environment variable are only a temporary fix. The default behavior should be to write all files to a reasonable location that the user can access.