### PR TITLE
Fix Ellipse constructor: 'width' is not defined

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -316,8 +316,8 @@ class Ellipse(Circle):
 
     def __init__(self, **kwargs):
         Circle.__init__(self, **kwargs)
-        self.set_width(width, stretch=True)
-        self.set_height(width, stretch=True)
+        self.set_width(self.width, stretch=True)
+        self.set_height(self.width, stretch=True)
 
 
 class AnnularSector(Arc):


### PR DESCRIPTION
Constructing an ellipse before gave the error "name 'width' is not defined"

I got this error when running the tutorial at https://github.com/zimmermant/manim_tutorial/blob/master/manim_tutorial_P37.py.

python3 -m manim manim_tutorial_P37.py MoreShapes -pl

Traceback (most recent call last):
  File "/Users/jeanwhitmore/Code/python3/manim/manimlib/extract_scene.py", line 153, in main
    scene = SceneClass(**scene_kwargs)
  File "/Users/jeanwhitmore/Code/python3/manim/manimlib/scene/scene.py", line 52, in __init__
    self.construct()
  File "manim_tutorial_P37.py", line 33, in construct
    ellipse=Ellipse(width=3, height=1, color=RED)
  File "/Users/jeanwhitmore/Code/python3/manim/manimlib/mobject/geometry.py", line 319, in __init__
    self.set_width(width, stretch=True)
NameError: name 'width' is not defined

After this fix, the Ellipse can be constructed and the animation is generated.

(Another shape is still broken, and I will try to fix that, too.)

Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
