### PR TITLE
Fixed `temp_file_path` to be more specific in adding the "_temp." string to file name

### DIFF
--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -199,7 +199,7 @@ class SceneFileWriter(object):
     
     def open_movie_pipe(self):
         file_path = self.get_next_partial_movie_path()
-        temp_file_path = file_path[:file_path.index(self.movie_file_extension)] + '_temp.' + file_path[file_path.index(self.movie_file_extension)+1:]
+        temp_file_path = file_path[:-len(self.movie_file_extension)] + '_temp.' + file_path[-len(self.movie_file_extension)+1:]
 
         self.partial_movie_file_path = file_path
         self.temp_partial_movie_file_path = temp_file_path

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -108,16 +108,6 @@ class SceneFileWriter(object):
             )
         )
         return result
-    
-    def get_next_temp_partial_movie_path(self):
-        result = os.path.join(
-            self.partial_movie_directory,
-            "{:05}_temp{}".format(
-                self.scene.num_plays,
-                self.movie_file_extension,
-            )
-        )
-        return result
 
     def get_movie_file_path(self):
         return self.movie_file_path
@@ -209,7 +199,7 @@ class SceneFileWriter(object):
     
     def open_movie_pipe(self):
         file_path = self.get_next_partial_movie_path()
-        temp_file_path = self.get_next_temp_partial_movie_path()
+        temp_file_path = file_path[:file_path.index(self.movie_file_extension)] + '_temp.' + file_path[file_path.index(self.movie_file_extension)+1:]
 
         self.partial_movie_file_path = file_path
         self.temp_partial_movie_file_path = temp_file_path

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -199,7 +199,7 @@ class SceneFileWriter(object):
 
     def open_movie_pipe(self):
         file_path = self.get_next_partial_movie_path()
-        temp_file_path = file_path.replace(".", "_temp.")
+        temp_file_path = file_path[:file_path.index('.', -4)] + '_temp.' + file_path[file_path.index('.',-4)+1:]
 
         self.partial_movie_file_path = file_path
         self.temp_partial_movie_file_path = temp_file_path

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -108,6 +108,7 @@ class SceneFileWriter(object):
             )
         )
         return result
+    
     def get_next_temp_partial_movie_path(self):
         result = os.path.join(
             self.partial_movie_directory,
@@ -205,6 +206,7 @@ class SceneFileWriter(object):
         if self.save_last_frame:
             self.scene.update_frame(ignore_skipping=True)
             self.save_image(self.scene.get_image())
+    
     def open_movie_pipe(self):
         file_path = self.get_next_partial_movie_path()
         temp_file_path = self.get_next_temp_partial_movie_path()

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -108,6 +108,15 @@ class SceneFileWriter(object):
             )
         )
         return result
+    def get_next_temp_partial_movie_path(self):
+        result = os.path.join(
+            self.partial_movie_directory,
+            "{:05}_temp{}".format(
+                self.scene.num_plays,
+                self.movie_file_extension,
+            )
+        )
+        return result
 
     def get_movie_file_path(self):
         return self.movie_file_path
@@ -196,10 +205,9 @@ class SceneFileWriter(object):
         if self.save_last_frame:
             self.scene.update_frame(ignore_skipping=True)
             self.save_image(self.scene.get_image())
-
     def open_movie_pipe(self):
         file_path = self.get_next_partial_movie_path()
-        temp_file_path = file_path[:file_path.index('.', -4)] + '_temp.' + file_path[file_path.index('.',-4)+1:]
+        temp_file_path = self.get_next_temp_partial_movie_path()
 
         self.partial_movie_file_path = file_path
         self.temp_partial_movie_file_path = temp_file_path

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -199,7 +199,7 @@ class SceneFileWriter(object):
     
     def open_movie_pipe(self):
         file_path = self.get_next_partial_movie_path()
-        temp_file_path = file_path[:-len(self.movie_file_extension)] + '_temp.' + file_path[-len(self.movie_file_extension)+1:]
+        temp_file_path = os.path.splitext(file_path)[0] + '_temp' + self.movie_file_extension
 
         self.partial_movie_file_path = file_path
         self.temp_partial_movie_file_path = temp_file_path

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -196,7 +196,7 @@ class SceneFileWriter(object):
         if self.save_last_frame:
             self.scene.update_frame(ignore_skipping=True)
             self.save_image(self.scene.get_image())
-    
+
     def open_movie_pipe(self):
         file_path = self.get_next_partial_movie_path()
         temp_file_path = os.path.splitext(file_path)[0] + '_temp' + self.movie_file_extension


### PR DESCRIPTION
1. The motivation for making this change (or link the relevant issues)
I kept getting an error:
`/Users/rodrigo_temp.castellon/Desktop/misc/pi-day/manim/media/videos/example_scenes/480p15/partial_movie_files/SquareToCircle/00000_temp.mp4: No such file or directory`

Notice how this path doesn't actually exist since `rodrigo_temp.castellon` is not a valid directory, it used to be `rodrigo.castellon`.

So, the code used to produce the temp file path didn't take into account the possibility of paths including periods in other places other than right before the file extension.

2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
It completely resolved the issue I was having -- manim works perfectly now for me -- and seems to have no other side effects (it's just one line that changes).
