### PR TITLE
Don't write media_dir

### DIFF
--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -19,8 +19,6 @@ if not os.path.isdir(MEDIA_DIR):
         f"Media will be stored in {MEDIA_DIR + os.sep}. You can change "
         "this behavior by writing a different directory to media_dir.txt."
     )
-with open("media_dir.txt", 'w') as media_file:
-    media_file.write(MEDIA_DIR)
 
 VIDEO_DIR = os.path.join(MEDIA_DIR, "videos")
 RASTER_IMAGE_DIR = os.path.join(MEDIA_DIR, "designs", "raster_images")


### PR DESCRIPTION
Currently, manim will always write `media_dir.txt` to the directory where it runs, even if the user sets the `FILE_DIR` and `MEDIA_DIR` environment variables. This is more of a security inconvenience than a security problem, but it's still rather impolite for manim to modify part of the filesystem without allowing the user to specify a different location.

Besides, this write isn't needed. If the media directory is read from `media_dir.txt`, then the file is already there. And if it is read from an environment variable, it can be passed via environment variable again.
