### PR TITLE
Fix height setting in Ellipse initialization

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -321,7 +321,7 @@ class Ellipse(Circle):
     def __init__(self, **kwargs):
         Circle.__init__(self, **kwargs)
         self.set_width(self.width, stretch=True)
-        self.set_height(self.width, stretch=True)
+        self.set_height(self.height, stretch=True)
 
 
 class AnnularSector(Arc):


### PR DESCRIPTION
The reason for this change is to fix a bug in `Ellipse` initialization. Currently it uses `self.width` for both `width and `height`, which creates a circle by  mistake.

The following code demonstrates this:

```
#!/usr/bin/env python

from big_ol_pile_of_manim_imports import *

class DrawEllipse(Scene):
    def construct(self):
        ellipse = Ellipse()
        self.play(ShowCreation(ellipse))
```

When run with the current code you get a circle, as shown in the first attachment:
<img width="245" alt="screen shot 2019-03-07 at 10 51 39 am" src="https://user-images.githubusercontent.com/308058/53969818-778e6100-40c7-11e9-9bef-cb8e1199d469.png">

When run with the change you get a proper ellipse:
<img width="316" alt="screen shot 2019-03-07 at 10 51 01 am" src="https://user-images.githubusercontent.com/308058/53969852-86751380-40c7-11e9-864d-5f8e654afce1.png">
