### PR TITLE
Fix the position of the y-axis label

### DIFF
--- a/manimlib/scene/graph_scene.py
+++ b/manimlib/scene/graph_scene.py
@@ -119,7 +119,7 @@ class GraphScene(Scene):
         if self.y_axis_label:
             y_label = TextMobject(self.y_axis_label)
             y_label.next_to(
-                y_axis.get_tick_marks(), UP + RIGHT,
+                y_axis.get_corner(UP + RIGHT), UP + RIGHT,
                 buff=SMALL_BUFF
             )
             y_label.shift_onto_screen()


### PR DESCRIPTION
When I run manim, the position of several things is slightly off.  This fixes the position of the y-axis label.  I am running Python 3.7.0

This following is a before shot.

![yaxislabel](https://user-images.githubusercontent.com/395296/53990819-c4d1f900-40ee-11e9-8e91-209a96a4e065.jpg)

The following is an after shot:

![yaxislabel_after](https://user-images.githubusercontent.com/395296/53990899-f6e35b00-40ee-11e9-907a-1c1f5eef36db.jpg)
