### PR TITLE
Fix alignment of minus sign to numbers

### DIFF
--- a/manimlib/mobject/numbers.py
+++ b/manimlib/mobject/numbers.py
@@ -62,7 +62,8 @@ class DecimalNumber(VMobject):
         # to the bottom
         for i, c in enumerate(num_string):
             if c == "-" and len(num_string) > i + 1:
-                self[i].align_to(self[i + 1], alignment_vect=UP)
+                self[i].align_to(self[i + 1], UP)
+                self[i].shift(self[i+1].get_height() * DOWN / 2)
             elif c == ",":
                 self[i].shift(self[i].get_height() * DOWN / 2)
         if self.unit and self.unit.startswith("^"):

--- a/manimlib/scene/graph_scene.py
+++ b/manimlib/scene/graph_scene.py
@@ -109,6 +109,7 @@ class GraphScene(Scene):
             numbers_with_elongated_ticks=self.y_labeled_nums,
             color=self.axes_color,
             line_to_number_vect=LEFT,
+            label_direction=LEFT,
         )
         y_axis.shift(self.graph_origin - y_axis.number_to_point(0))
         y_axis.rotate(np.pi / 2, about_point=y_axis.number_to_point(0))


### PR DESCRIPTION
This fixes the alignment of the minus sign to negative numbers.

The `align_to` method was being called with an optional argument `alignment_vec` that did not do anything.

This is a before shot:

![53990899-f6e35b00-40ee-11e9-907a-1c1f5eef36db](https://user-images.githubusercontent.com/395296/54055032-66218380-41b1-11e9-935e-f6a1de95f1e6.jpg)

This is an after shot:

![Screen Shot 2019-03-08 at 2 46 38 PM](https://user-images.githubusercontent.com/395296/54055047-6d489180-41b1-11e9-830e-9a4eb7df654f.jpg)
