### PR TITLE
fix get_anchors for VectorizedPoints

### DIFF
--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -658,6 +658,8 @@ class VMobject(Mobject):
         return self.points[nppcc - 1::nppcc]
 
     def get_anchors(self):
+        if self.points.shape[0] == 1:
+            return self.points
         return np.array(list(it.chain(*zip(
             self.get_start_anchors(),
             self.get_end_anchors(),


### PR DESCRIPTION
Fixes `VectorizedPoint.get_anchors()`, which previously returned an empty array when called on a `VectorizedPoint` (https://github.com/3b1b/manim/issues/455).

I tested by running the code found in that issue and verifying that the rectangles were placed properly.