### PR TITLE
Fix bug for creating Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ While developing a scene, the `-sp` flags are helpful to just see what things lo
 ### Documentation
 Documentation is in progress at [manim.readthedocs.io](https://manim.readthedocs.io).
 
+Documentation Yiyu Version is also in progress at [niyiyu2316.github.io/manim/](https://niyiyu2316.github.io/manim/)
+
 ### Walkthrough
 Todd Zimmerman put together a [tutorial](https://talkingphysics.wordpress.com/2019/01/08/getting-started-animating-with-manim-and-python-3-7/) on getting started with manim, which has been updated to run on python 3.7.
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ While developing a scene, the `-sp` flags are helpful to just see what things lo
 ### Documentation
 Documentation is in progress at [manim.readthedocs.io](https://manim.readthedocs.io).
 
-Documentation Yiyu Version is also in progress at [niyiyu2316.github.io/manim/](https://niyiyu2316.github.io/manim/)
-
 ### Walkthrough
 Todd Zimmerman put together a [tutorial](https://talkingphysics.wordpress.com/2019/01/08/getting-started-animating-with-manim-and-python-3-7/) on getting started with manim, which has been updated to run on python 3.7.
 

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -156,7 +156,8 @@ class TexMobject(SingleStringTexMobject):
         split_list = split_string_list_to_isolate_substrings(
             tex_strings, *substrings_to_isolate
         )
-        split_list = list(map(str.strip, split_list))
+        split_list = [str(x).strip() for x in split_list]
+        #split_list = list(map(str.strip, split_list))
         split_list = [s for s in split_list if s != '']
         return split_list
 


### PR DESCRIPTION
Using python3.x,  and there is a problem creating Matrix(). 
Error:
`TypeError: descriptor 'strip' requires a 'str' object but received a 'numpy.int64'`
And it can be solved by modify manimlib/mobject/svg/tex_mobject.py.

I've tested it, and it seems that it works for now.

Besides, just ignore the other four Commits...