### PR TITLE
Fix --preview on cygwin

### DIFF
--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -35,8 +35,10 @@ def open_file_if_needed(file_writer, **config):
                 os.startfile(file_path)
             else:
                 commands = []
-                if (current_os == "Linux"):
+                if current_os == "Linux":
                     commands.append("xdg-open")
+                elif current_os.startswith("CYGWIN"):
+                    commands.append("cygstart")
                 else:  # Assume macOS
                     commands.append("open")
 


### PR DESCRIPTION
This is all that's needed to allow manim to be used on [cygwin](https://cygwin.com/) (beyond the normal installation of dependencies including building ffmpeg within cygwin, of course).

`startswith` is needed because the value depends on the windows version &mdash; for me, it's `CYGWIN_NT-10.0` (this happens with the actual `uname` command; it's not a python thing).  [Relevant code](https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=winsup/cygwin/uname.cc;h=306cdee4a32faff42c5d34d3293325511e8ca77a;hb=HEAD#l95).  `os.startfile` does not exist when using cygwin (same as actual linux).

[Man page for `cygstart`](http://www.polarhome.com/service/man/?qf=cygstart&tf=2&of=Cygwin&sf=1).