### PR TITLE
Update README for Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ python3 -m pip install -r requirements.txt
 python3 -m manim example_scenes.py SquareToCircle -pl
 ```
 
+### Directly (Windows)
+1. [Install FFmpeg](https://www.wikihow.com/Install-FFmpeg-on-Windows).
+2. Install Cairo. Download the wheel from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo. For most users, ``pycairo‑1.18.0‑cp37‑cp37m‑win32.whl`` will do fine.
+    ```sh
+    pip3 install C:\path\to\wheel\pycairo‑1.18.0‑cp37‑cp37m‑win32.whl
+    ```
+3. Install a LaTeX distibution. [MiKTeX](https://miktex.org/download) is recommended.
+
+4. [Install SoX](https://sourceforge.net/projects/sox/files/sox/).
+
+5. Install the remaining Python packages. Make sure that ``pycairo==1.17.1`` is changed to ``pycairo==1.18.0`` in requirements.txt.
+    ```sh
+    git clone https://github.com/3b1b/manim.git
+    cd manim
+    pip3 install -r requirements.txt
+    python3 manim.py example_scenes.py SquareToCircle -pl
+    ```
+
 ### Using `virtualenv` and `virtualenvwrapper`
 After installing `virtualenv` and `virtualenvwrapper`
 ```sh


### PR DESCRIPTION
Adds a section under "Installation" that details all the steps necessary to getting manim to run on Windows. Tested on several Windows 10 machines with unvarying success.

Many users have found it difficult to get manim working properly on Windows machines (see #483, #444, #369, #359, #353, and countless closed issues). I may write a much more detailed blog post for using manim on Windows in the future.