### PR TITLE
Typo fix: remove redundant "the" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Try running the following:
 ```sh
 python3 -m manim example_scenes.py SquareToCircle -pl
 ```
-The -p is for previewing, meaning the the video file will automatically open when it is done rendering.
+The -p is for previewing, meaning the video file will automatically open when it is done rendering.
 Use -l for a faster rendering at a lower quality.
 Use -s to skip to the end and just show the final frame.
 Use -n (number) to skip ahead to the n'th animation of a scene.


### PR DESCRIPTION
Just a small README typo fix.