### PR TITLE
Make manim installable using setuptools (setup.py)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,30 @@
 Manim is an animation engine for explanatory math videos. It's used to create precise animations programmatically, as seen in the videos at [3Blue1Brown](https://www.3blue1brown.com/).
 
 ## Installation
-Manim runs on python 3.7. You can install the python requirements with
+Manim runs on python 3.7. You can install the Python requirements with
 `python3 -m pip install -r requirements.txt`. System requirements are
-[cairo](https://www.cairographics.org), [latex](https://www.latex-project.org),
-[ffmpeg](https://www.ffmpeg.org), and [sox](http://sox.sourceforge.net).
+[cairo](https://www.cairographics.org), [ffmpeg](https://www.ffmpeg.org), [sox](http://sox.sourceforge.net), [latex](https://www.latex-project.org) (optional, if you want to use LaTeX).
 
 ### Directly
+Clone this repository and in that directory execute:
 ```sh
-git clone https://github.com/3b1b/manim.git
-cd manim
+# Install python requirements
 python3 -m pip install -r requirements.txt
+
+# Try it out
 python3 -m manim example_scenes.py SquareToCircle -pl
+```
+
+### Installing into your system
+For the previous "direct" method you always have to have this git repository. alternatively you can install it permanently in your system and run it on your own scene files:
+
+```sh
+# Inside repository - Install manim (also installs Python requirements)
+python3 -m pip install .
+
+# Now you don't need the repository anymore and can run it in other directories
+cd anywhere
+manim.py example_scenes.py SquareToCircle -pl
 ```
 
 ### Directly (Windows)

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -14,7 +14,7 @@ else:
         "Dropbox (3Blue1Brown)/3Blue1Brown Team Folder"
     )
 if not os.path.isdir(MEDIA_DIR):
-    MEDIA_DIR = "media"
+    MEDIA_DIR = "./media"
     print(
         f"Media will be stored in {MEDIA_DIR + os.sep}. You can change "
         "this behavior by writing a different directory to media_dir.txt."
@@ -26,7 +26,7 @@ SVG_IMAGE_DIR = os.path.join(MEDIA_DIR, "designs", "svg_images")
 SOUND_DIR = os.path.join(MEDIA_DIR, "designs", "sounds")
 ###
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
-FILE_DIR = os.path.join(os.getenv("FILE_DIR", default=THIS_DIR), "files")
+FILE_DIR = os.path.join(os.getenv("FILE_DIR", default="."), "files")
 TEX_DIR = os.path.join(FILE_DIR, "Tex")
 # These two may be depricated now.
 MOBJECT_DIR = os.path.join(FILE_DIR, "mobjects")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_namespace_packages
+
+
+setup(name='manim',
+      version='0.1.0',
+      description='Animation engine for explanatory math videos',
+      author='Grant Sanderson',
+      author_email='grant@3blue1brown.com',
+      url='https://github.com/3b1b/manim',
+      license='MIT',
+      packages=find_namespace_packages(),
+      install_requires=[
+         'colour',
+         'numpy',
+         'Pillow',
+         'progressbar',
+         'scipy',
+         'tqdm',
+         'opencv-python',
+         'pycairo',
+         'pydub',
+      ],
+      scripts=['manim.py', 'stage_scenes.py', 'big_ol_pile_of_manim_imports.py'],
+      package_data={'manimlib': ['*.tex', 'files/**']},
+)


### PR DESCRIPTION
I want to package manim for my distribution and made changes here so that it's easier for me and others to package it.

Now the project supports the standard Python packaging method of setuptools and we can install it using just `python3 -m pip install .` (even without a distribution packaging it). After installing we can use it in any directory - not just the source repository.

I'm still wondering which are the files that people are supposed to run.
`manim.py` is obviously the main one but does it allow access to all the functionality?
`stage_scenes.py` looks like it does something useful, but I can't figure out exactly what. See: #515 
`manimlib/extract_scene.py` has an `if __name__ == "__main__"` but that's broken because it doesn't call `main()` with all its parameters.

If you like the idea of it being packaged in distribution's package managers I'd also appreciate if you made a release on GitHub with a version number.