### PR TITLE
fix mishandled relative paths

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -165,6 +165,7 @@ def get_configuration(args):
         "png_mode": "RGBA" if args.transparent else "RGB",
         "movie_file_extension": ".mov" if args.transparent else ".mp4",
         "file_name": args.file_name,
+        "input_file_path": args.file,
     }
     if hasattr(module, "OUTPUT_DIRECTORY"):
         file_writer_config["output_directory"] = module.OUTPUT_DIRECTORY

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -76,8 +76,9 @@ class SceneFileWriter(object):
             ))
 
     def get_default_output_directory(self):
-        scene_module = self.scene.__class__.__module__
-        return scene_module.replace(".", os.path.sep)
+        filename = os.path.basename(self.input_file_path)
+        root, ext = os.path.splitext(filename)
+        return root if root else ext[1:]
 
     def get_default_file_name(self):
         return self.scene.__class__.__name__


### PR DESCRIPTION
The previous implementation of `get_default_output_directory()` used the relative path to the target module to create the output directory. This means that when the target module resides in a "sibling" directory (e.g. `../sibling_dir/scenes.py`), `get_default_output_directory()` would return an absolute path (`///sibling_dir/scenes`) and manim would attempt to write video there. This is not only unexpected but potentially dangerous, since files can be accidentally overwritten.

With this change, the default behavior is to save video in a directory under `VIDEO_DIR` named after the target module.