### PR TITLE
Create manimlib.imports

### DIFF
--- a/active_projects/aliquot.py
+++ b/active_projects/aliquot.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 def get_factors(n):

--- a/active_projects/eola2/cramer.py
+++ b/active_projects/eola2/cramer.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 X_COLOR = GREEN
 Y_COLOR = RED

--- a/active_projects/eola2/determinant_puzzle.py
+++ b/active_projects/eola2/determinant_puzzle.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class WorkOutNumerically(Scene):

--- a/active_projects/eola2/gauss.py
+++ b/active_projects/eola2/gauss.py
@@ -1,6 +1,6 @@
 from fractions import Fraction
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from functools import reduce
 
 

--- a/active_projects/eop/bayes.py
+++ b/active_projects/eop/bayes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 #revert_to_original_skipping_status
 

--- a/active_projects/eop/bayes_footnote.py
+++ b/active_projects/eop/bayes_footnote.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from active_projects.eop.bayes import IntroducePokerHand
 

--- a/active_projects/eop/birthday.py
+++ b/active_projects/eop/birthday.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Birthday(Scene):
 

--- a/active_projects/eop/chapter0.py
+++ b/active_projects/eop/chapter0.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Introduction(TeacherStudentsScene):
 

--- a/active_projects/eop/chapter0/intro.py
+++ b/active_projects/eop/chapter0/intro.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Introduction(TeacherStudentsScene):
 

--- a/active_projects/eop/chapter1/all_sequences.py
+++ b/active_projects/eop/chapter1/all_sequences.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 class ShuffleThroughAllSequences(Scene):

--- a/active_projects/eop/chapter1/area_model_bayes.py
+++ b/active_projects/eop/chapter1/area_model_bayes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
        
 
 class IllustrateAreaModelBayes(Scene):

--- a/active_projects/eop/chapter1/area_model_erf.py
+++ b/active_projects/eop/chapter1/area_model_erf.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eoc.chapter8 import *
 
 import scipy.special

--- a/active_projects/eop/chapter1/area_model_expectation.py
+++ b/active_projects/eop/chapter1/area_model_expectation.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 

--- a/active_projects/eop/chapter1/brick_row_scene.py
+++ b/active_projects/eop/chapter1/brick_row_scene.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 

--- a/active_projects/eop/chapter1/entire_brick_wall.py
+++ b/active_projects/eop/chapter1/entire_brick_wall.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 from active_projects.eop.chapter1.brick_row_scene import BrickRowScene
 

--- a/active_projects/eop/chapter1/intro.py
+++ b/active_projects/eop/chapter1/intro.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 class Chapter1OpeningQuote(OpeningQuote):

--- a/active_projects/eop/chapter1/just_randy_flipping_coin.py
+++ b/active_projects/eop/chapter1/just_randy_flipping_coin.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 class JustFlipping(Scene):

--- a/active_projects/eop/chapter1/million_flips.py
+++ b/active_projects/eop/chapter1/million_flips.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 

--- a/active_projects/eop/chapter1/morph_brick_row_into_histogram.py
+++ b/active_projects/eop/chapter1/morph_brick_row_into_histogram.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 class GenericMorphBrickRowIntoHistogram(Scene):

--- a/active_projects/eop/chapter1/prob_dist_visuals.py
+++ b/active_projects/eop/chapter1/prob_dist_visuals.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 

--- a/active_projects/eop/chapter1/quiz_result.py
+++ b/active_projects/eop/chapter1/quiz_result.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 from active_projects.eop.independence import *
 

--- a/active_projects/eop/chapter1/show_proportion.py
+++ b/active_projects/eop/chapter1/show_proportion.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class ProbabilityRect(VMobject):

--- a/active_projects/eop/chapter1/show_uncertainty_darts.py
+++ b/active_projects/eop/chapter1/show_uncertainty_darts.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 

--- a/active_projects/eop/chapter1/show_uncertainty_dice.py
+++ b/active_projects/eop/chapter1/show_uncertainty_dice.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 class ShowUncertaintyDice(Scene):

--- a/active_projects/eop/chapter1/show_uncertainty_disease.py
+++ b/active_projects/eop/chapter1/show_uncertainty_disease.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 

--- a/active_projects/eop/chapter1/stacking_coins.py
+++ b/active_projects/eop/chapter1/stacking_coins.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 

--- a/active_projects/eop/chapter1/think_about_coin.py
+++ b/active_projects/eop/chapter1/think_about_coin.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 
 class RandyThinksAboutCoin(PiCreatureScene):

--- a/active_projects/eop/chapter1/various_intro_visuals.py
+++ b/active_projects/eop/chapter1/various_intro_visuals.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusable_imports import *
 from active_projects.eop.combinations import *
 from active_projects.eop.independence import *

--- a/active_projects/eop/chapter1/what_does_probability_mean.py
+++ b/active_projects/eop/chapter1/what_does_probability_mean.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class WhatDoesItReallyMean(TeacherStudentsScene):

--- a/active_projects/eop/chapter2/permutation_grid.py
+++ b/active_projects/eop/chapter2/permutation_grid.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 def print_permutation(index_list):
 

--- a/active_projects/eop/combinations.py
+++ b/active_projects/eop/combinations.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 #revert_to_original_skipping_status
 

--- a/active_projects/eop/independence.py
+++ b/active_projects/eop/independence.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from scene.scene import ProgressDisplay
 import scipy

--- a/active_projects/eop/pascal.py
+++ b/active_projects/eop/pascal.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from once_useful_constructs.combinatorics import *
 
 nb_levels = 5

--- a/active_projects/eop/reusables/brick_row.py
+++ b/active_projects/eop/reusables/brick_row.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.eop.reusables.eop_helpers import *
 from active_projects.eop.reusables.eop_constants import *
 from active_projects.eop.reusables.upright_coins import *

--- a/active_projects/eop/reusables/histograms.py
+++ b/active_projects/eop/reusables/histograms.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from random import *
 
 def text_range(start,stop,step): # a range as a list of strings

--- a/active_projects/eop/what_does_probability_mean.py
+++ b/active_projects/eop/what_does_probability_mean.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class WhatDoesItReallyMean(TeacherStudentsScene):
 

--- a/active_projects/holomorphic.py
+++ b/active_projects/holomorphic.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class ComplexAnalysisOverlay(Scene):

--- a/active_projects/ode/part1/pendulum.py
+++ b/active_projects/ode/part1/pendulum.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part1.shared_constructs import *
 
 

--- a/active_projects/ode/part1/phase_space.py
+++ b/active_projects/ode/part1/phase_space.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part1.shared_constructs import *
 from active_projects.ode.part1.pendulum import Pendulum
 

--- a/active_projects/ode/part1/pi_scenes.py
+++ b/active_projects/ode/part1/pi_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part1.shared_constructs import *
 
 

--- a/active_projects/ode/part1/shared_constructs.py
+++ b/active_projects/ode/part1/shared_constructs.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 Lg_formula_config = {

--- a/active_projects/ode/part1/staging.py
+++ b/active_projects/ode/part1/staging.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part1.shared_constructs import *
 from active_projects.ode.part1.pendulum import Pendulum
 from active_projects.ode.part1.pendulum import ThetaVsTAxes

--- a/active_projects/ode/part1/wordy_scenes.py
+++ b/active_projects/ode/part1/wordy_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part1.shared_constructs import *
 
 

--- a/active_projects/ode/part2/fourier_series.py
+++ b/active_projects/ode/part2/fourier_series.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 # import scipy
 
 

--- a/active_projects/ode/part2/heat_equation.py
+++ b/active_projects/ode/part2/heat_equation.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part2.shared_constructs import *
 
 

--- a/active_projects/ode/part2/pi_scenes.py
+++ b/active_projects/ode/part2/pi_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part2.wordy_scenes import WriteHeatEquationTemplate
 
 

--- a/active_projects/ode/part2/shared_constructs.py
+++ b/active_projects/ode/part2/shared_constructs.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 TIME_COLOR = YELLOW
 X_COLOR = GREEN

--- a/active_projects/ode/part2/staging.py
+++ b/active_projects/ode/part2/staging.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.ode.part1.staging import TourOfDifferentialEquations
 
 

--- a/active_projects/ode/part2/wordy_scenes.py
+++ b/active_projects/ode/part2/wordy_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class WriteHeatEquationTemplate(Scene):

--- a/active_projects/shadows.py
+++ b/active_projects/shadows.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 # Helpers

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 # To watch one of these scenes, run the following:
 # python -m manim example_scenes.py SquareToCircle -pl

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -139,7 +139,7 @@ def parse_cli():
 def get_module(file_name):
     if file_name == "-":
         module = types.ModuleType("input_scenes")
-        code = "from big_ol_pile_of_manim_imports import *\n\n" + sys.stdin.read()
+        code = "from manimlib.imports import *\n\n" + sys.stdin.read()
         try:
             exec(code, module.__dict__)
             return module

--- a/manimlib/imports.py
+++ b/manimlib/imports.py
@@ -5,7 +5,7 @@ of manim available without having to worry about what namespace they come from.
 
 Rather than having a large pile of "from <module> import *" at the top of every such
 script, the intent of this file is to make it so that one can just include
-"from big_ol_pile_of_manim_imports import *".  The effects of adding more modules
+"from manimlib.imports import *".  The effects of adding more modules
 or refactoring the library on current or older scene scripts should be entirely
 addressible by changing this file.
 

--- a/manimlib/stream_starter.py
+++ b/manimlib/stream_starter.py
@@ -49,5 +49,5 @@ def start_livestream(to_twitch=False, twitch_key=None):
     variables.update(locals())
     shell = code.InteractiveConsole(variables)
     shell.push("manim = Manim()")
-    shell.push("from big_ol_pile_of_manim_imports import *")
+    shell.push("from manimlib.imports import *")
     shell.interact(banner=manimlib.constants.STREAMING_CONSOLE_BANNER)

--- a/old_projects/256.py
+++ b/old_projects/256.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from old_projects.crypto import sha256_tex_mob, bit_string_to_mobject, BitcoinLogo
 

--- a/old_projects/WindingNumber.py
+++ b/old_projects/WindingNumber.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 import warnings
 warnings.warn("""

--- a/old_projects/WindingNumber_G.py
+++ b/old_projects/WindingNumber_G.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from old_projects.uncertainty import Flash
 from old_projects.WindingNumber import *

--- a/old_projects/alt_calc.py
+++ b/old_projects/alt_calc.py
@@ -1,5 +1,5 @@
  # -*- coding: utf-8 -*-
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 def apply_function_to_center(point_func, mobject):

--- a/old_projects/basel/basel.py
+++ b/old_projects/basel/basel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from once_useful_constructs.light import *
 

--- a/old_projects/basel/basel2.py
+++ b/old_projects/basel/basel2.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from once_useful_constructs.light import *
 
 import warnings

--- a/old_projects/bell.py
+++ b/old_projects/bell.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from tqdm import tqdm as ProgressDisplay
 

--- a/old_projects/borsuk.py
+++ b/old_projects/borsuk.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from functools import reduce
 
 class Jewel(VMobject):

--- a/old_projects/borsuk_addition.py
+++ b/old_projects/borsuk_addition.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.lost_lecture import GeometryProofLand
 from old_projects.quaternions import SpecialThreeDScene
 from old_projects.uncertainty import Flash

--- a/old_projects/brachistochrone/curves.py
+++ b/old_projects/brachistochrone/curves.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 RANDY_SCALE_FACTOR = 0.3
 

--- a/old_projects/brachistochrone/cycloid.py
+++ b/old_projects/brachistochrone/cycloid.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.brachistochrone.curves import *
 
 class RollAlongVector(Animation):

--- a/old_projects/brachistochrone/drawing_images.py
+++ b/old_projects/brachistochrone/drawing_images.py
@@ -9,7 +9,7 @@ import random
 from scipy.spatial.distance import cdist
 from scipy import ndimage
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 DEFAULT_GAUSS_BLUR_CONFIG = {

--- a/old_projects/brachistochrone/graveyard.py
+++ b/old_projects/brachistochrone/graveyard.py
@@ -1,7 +1,7 @@
 import numpy as np
 import itertools as it
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from old_projects.brachistochrone.curves import Cycloid
 

--- a/old_projects/brachistochrone/light.py
+++ b/old_projects/brachistochrone/light.py
@@ -1,7 +1,7 @@
 import numpy as np
 import itertools as it
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from old_projects.brachistochrone.curves import \
     Cycloid, PathSlidingScene, RANDY_SCALE_FACTOR, TryManyPaths

--- a/old_projects/brachistochrone/misc.py
+++ b/old_projects/brachistochrone/misc.py
@@ -1,7 +1,7 @@
 import numpy as np
 import itertools as it
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.brachistochrone.curves import Cycloid
 
 class PhysicalIntuition(Scene):

--- a/old_projects/brachistochrone/multilayered.py
+++ b/old_projects/brachistochrone/multilayered.py
@@ -1,7 +1,7 @@
 import numpy as np
 import itertools as it
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.brachistochrone.light import PhotonScene
 from old_projects.brachistochrone.curves import *
 

--- a/old_projects/brachistochrone/wordplay.py
+++ b/old_projects/brachistochrone/wordplay.py
@@ -2,7 +2,7 @@ import numpy as np
 import itertools as it
 import os
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.brachistochrone.drawing_images import sort_by_color
 
 class Intro(Scene):

--- a/old_projects/cba.py
+++ b/old_projects/cba.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class EnumerableSaveScene(Scene):

--- a/old_projects/clacks/name_bump.py
+++ b/old_projects/clacks/name_bump.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.clacks.question import BlocksAndWallExample
 
 

--- a/old_projects/clacks/question.py
+++ b/old_projects/clacks/question.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 OUTPUT_DIRECTORY = "clacks/question"

--- a/old_projects/clacks/solution1.py
+++ b/old_projects/clacks/solution1.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.clacks.question import *
 from old_projects.div_curl import ShowTwoPopulations
 

--- a/old_projects/clacks/solution2/block_collision_scenes.py
+++ b/old_projects/clacks/solution2/block_collision_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.clacks.question import BlocksAndWallExample
 
 

--- a/old_projects/clacks/solution2/mirror_scenes.py
+++ b/old_projects/clacks/solution2/mirror_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class MirrorScene(Scene):

--- a/old_projects/clacks/solution2/pi_creature_scenes.py
+++ b/old_projects/clacks/solution2/pi_creature_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class OnAnsweringTwice(TeacherStudentsScene):

--- a/old_projects/clacks/solution2/position_phase_space.py
+++ b/old_projects/clacks/solution2/position_phase_space.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.clacks.question import Block
 from old_projects.clacks.question import Wall
 from old_projects.clacks.question import ClackFlashes

--- a/old_projects/clacks/solution2/simple_scenes.py
+++ b/old_projects/clacks/solution2/simple_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.lost_lecture import ShowWord
 from old_projects.clacks.solution2.mirror_scenes import ReflectWorldThroughMirrorNew
 from old_projects.clacks.question import Thumbnail

--- a/old_projects/clacks/solution2/wordy_scenes.py
+++ b/old_projects/clacks/solution2/wordy_scenes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.clacks.solution2.position_phase_space import ShowMomentumConservation
 
 

--- a/old_projects/complex_multiplication_article.py
+++ b/old_projects/complex_multiplication_article.py
@@ -5,7 +5,7 @@ import itertools as it
 from copy import deepcopy
 import sys
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from functools import reduce
 
 DEFAULT_PLANE_CONFIG = {

--- a/old_projects/counting_in_binary.py
+++ b/old_projects/counting_in_binary.py
@@ -6,7 +6,7 @@ import itertools as it
 from copy import deepcopy
 import sys
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from script_wrapper import command_line_create_scene
 
 MOVIE_PREFIX = "counting_in_binary/"

--- a/old_projects/crypto.py
+++ b/old_projects/crypto.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from hashlib import sha256
 import binascii

--- a/old_projects/dandelin.py
+++ b/old_projects/dandelin.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from old_projects.lost_lecture import Orbiting
 from old_projects.lost_lecture import ShowWord

--- a/old_projects/div_curl.py
+++ b/old_projects/div_curl.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 # Quick note to anyone coming to this file with the

--- a/old_projects/domino_play.py
+++ b/old_projects/domino_play.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class SimpleVelocityGraph(GraphScene):

--- a/old_projects/efvgt.py
+++ b/old_projects/efvgt.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 ADDER_COLOR = GREEN
 MULTIPLIER_COLOR = YELLOW

--- a/old_projects/eoc/chapter1.py
+++ b/old_projects/eoc/chapter1.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eoc.chapter2 import Car, MoveCar
 
 class CircleScene(PiCreatureScene):

--- a/old_projects/eoc/chapter10.py
+++ b/old_projects/eoc/chapter10.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 def derivative(func, x, n = 1, dx = 0.01):
     samples = [func(x + (k - n/2)*dx) for k in range(n+1)]

--- a/old_projects/eoc/chapter2.py
+++ b/old_projects/eoc/chapter2.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 DISTANCE_COLOR = BLUE
 TIME_COLOR = YELLOW

--- a/old_projects/eoc/chapter3.py
+++ b/old_projects/eoc/chapter3.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eoc.chapter2 import DISTANCE_COLOR, TIME_COLOR, \
     VELOCITY_COLOR, Car, MoveCar
 

--- a/old_projects/eoc/chapter4.py
+++ b/old_projects/eoc/chapter4.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 SINE_COLOR = BLUE
 X_SQUARED_COLOR = GREEN

--- a/old_projects/eoc/chapter5.py
+++ b/old_projects/eoc/chapter5.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eoc.chapter4 import ThreeLinesChainRule
 
 class ExpFootnoteOpeningQuote(OpeningQuote):

--- a/old_projects/eoc/chapter6.py
+++ b/old_projects/eoc/chapter6.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 SPACE_UNIT_TO_PLANE_UNIT = 0.75
 

--- a/old_projects/eoc/chapter7.py
+++ b/old_projects/eoc/chapter7.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Chapter7OpeningQuote(OpeningQuote):
     CONFIG = {

--- a/old_projects/eoc/chapter8.py
+++ b/old_projects/eoc/chapter8.py
@@ -1,5 +1,5 @@
 import scipy
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eoc.chapter1 import Thumbnail as Chapter1Thumbnail
 from old_projects.eoc.chapter2 import Car, MoveCar, ShowSpeedometer, \
     IncrementNumber, GraphCarTrajectory, SecantLineToTangentLine, \

--- a/old_projects/eoc/chapter9.py
+++ b/old_projects/eoc/chapter9.py
@@ -1,7 +1,7 @@
 import scipy
 import fractions
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Chapter9OpeningQuote(OpeningQuote):
     CONFIG = {

--- a/old_projects/eoc/footnote.py
+++ b/old_projects/eoc/footnote.py
@@ -1,7 +1,7 @@
 import scipy
 import math
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eoc.chapter1 import Car, MoveCar
 from old_projects.eoc.chapter10 import derivative
 

--- a/old_projects/eoc/old_chapter1.py
+++ b/old_projects/eoc/old_chapter1.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 #### Warning, scenes here not updated based on most recent GraphScene changes #######

--- a/old_projects/eola/chapter0.py
+++ b/old_projects/eola/chapter0.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from once_useful_constructs import *
 
 EXAMPLE_TRANFORM = [[0, 1], [-1, 1]]

--- a/old_projects/eola/chapter1.py
+++ b/old_projects/eola/chapter1.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter0 import UpcomingSeriesOfVidoes
 
 import random

--- a/old_projects/eola/chapter10.py
+++ b/old_projects/eola/chapter10.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter1 import plane_wave_homotopy
 from old_projects.eola.chapter3 import ColumnsToBasisVectors
 from old_projects.eola.chapter5 import get_det_text

--- a/old_projects/eola/chapter11.py
+++ b/old_projects/eola/chapter11.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter1 import plane_wave_homotopy
 from old_projects.eola.chapter3 import ColumnsToBasisVectors
 from old_projects.eola.chapter5 import NameDeterminant, Blob

--- a/old_projects/eola/chapter2.py
+++ b/old_projects/eola/chapter2.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter1 import plane_wave_homotopy
 
 class OpeningQuote(Scene):

--- a/old_projects/eola/chapter3.py
+++ b/old_projects/eola/chapter3.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 def curvy_squish(point):
     x, y, z = point

--- a/old_projects/eola/chapter4.py
+++ b/old_projects/eola/chapter4.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter3 import MatrixVectorMultiplicationAbstract
 
 

--- a/old_projects/eola/chapter5.py
+++ b/old_projects/eola/chapter5.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter3 import MatrixVectorMultiplicationAbstract
 
 

--- a/old_projects/eola/chapter6.py
+++ b/old_projects/eola/chapter6.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from ka_playgrounds.circuits import Resistor, Source, LongResistor
 
 class OpeningQuote(Scene):

--- a/old_projects/eola/chapter7.py
+++ b/old_projects/eola/chapter7.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.footnote2 import TwoDTo1DTransformWithDots
 
 

--- a/old_projects/eola/chapter8.py
+++ b/old_projects/eola/chapter8.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter5 import get_det_text, RightHandRule
 
 

--- a/old_projects/eola/chapter8p2.py
+++ b/old_projects/eola/chapter8p2.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter5 import get_det_text
 from old_projects.eola.chapter8 import *
 

--- a/old_projects/eola/chapter9.py
+++ b/old_projects/eola/chapter9.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter1 import plane_wave_homotopy
 
 V_COLOR = YELLOW

--- a/old_projects/eola/footnote.py
+++ b/old_projects/eola/footnote.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from functools import reduce
 
 class OpeningQuote(Scene):

--- a/old_projects/eola/footnote2.py
+++ b/old_projects/eola/footnote2.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from ka_playgrounds.circuits import Resistor, Source, LongResistor
 

--- a/old_projects/eola/thumbnails.py
+++ b/old_projects/eola/thumbnails.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.eola.chapter9 import Jennifer, You
 
 class Chapter0(LinearTransformationScene):

--- a/old_projects/fc1.py
+++ b/old_projects/fc1.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.efvgt import get_confetti_animations
 
 

--- a/old_projects/for_flammy.py
+++ b/old_projects/for_flammy.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.sphere_area import *
 
 

--- a/old_projects/fourier.py
+++ b/old_projects/fourier.py
@@ -2,7 +2,7 @@
 from constants import *
 import scipy.integrate
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 USE_ALMOST_FOURIER_BY_DEFAULT = True
 NUM_SAMPLES_FOR_FFT = 1000

--- a/old_projects/fractal_charm.py
+++ b/old_projects/fractal_charm.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class FractalCreation(Scene):
     CONFIG = {

--- a/old_projects/fractal_dimension.py
+++ b/old_projects/fractal_dimension.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from functools import reduce
 
 def break_up(mobject, factor = 1.3):

--- a/old_projects/generate_logo.py
+++ b/old_projects/generate_logo.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 ## Warning, much of what is in this class
 ## likely not supported anymore.

--- a/old_projects/gradient.py
+++ b/old_projects/gradient.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 # Warning, this file uses ContinualChangingDecimal,

--- a/old_projects/hanoi.py
+++ b/old_projects/hanoi.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class CountingScene(Scene):
     CONFIG = {

--- a/old_projects/highD.py
+++ b/old_projects/highD.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 ##########
 #force_skipping

--- a/old_projects/hilbert/fractal_porn.py
+++ b/old_projects/hilbert/fractal_porn.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.hilbert.curves import *
 
 class Intro(TransformOverIncreasingOrders):

--- a/old_projects/hilbert/section1.py
+++ b/old_projects/hilbert/section1.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 import displayer as disp
 

--- a/old_projects/hilbert/section2.py
+++ b/old_projects/hilbert/section2.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 import displayer as disp
 from hilbert.curves import \
     TransformOverIncreasingOrders, FlowSnake, HilbertCurve, \

--- a/old_projects/hilbert/section3.py
+++ b/old_projects/hilbert/section3.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 import displayer as disp
 
 from hilbert.curves import \

--- a/old_projects/inventing_math.py
+++ b/old_projects/inventing_math.py
@@ -7,7 +7,7 @@ import sys
 import operator as op
 from random import sample
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from script_wrapper import command_line_create_scene
 from functools import reduce
 

--- a/old_projects/inventing_math_images.py
+++ b/old_projects/inventing_math_images.py
@@ -6,7 +6,7 @@ import itertools as it
 from copy import deepcopy
 import sys
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from script_wrapper import command_line_create_scene
 from .inventing_math import divergent_sum, draw_you
 

--- a/old_projects/leibniz.py
+++ b/old_projects/leibniz.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from functools import reduce
 
 # revert_to_original_skipping_status

--- a/old_projects/lost_lecture.py
+++ b/old_projects/lost_lecture.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from old_projects.div_curl import VectorField
 from old_projects.div_curl import get_force_field_func

--- a/old_projects/matrix_as_transform_2d.py
+++ b/old_projects/matrix_as_transform_2d.py
@@ -5,7 +5,7 @@ import itertools as it
 from copy import deepcopy
 import sys
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 ARROW_CONFIG = {"stroke_width" : 2*DEFAULT_STROKE_WIDTH}
 LIGHT_RED = RED_E

--- a/old_projects/moser_intro.py
+++ b/old_projects/moser_intro.py
@@ -6,7 +6,7 @@ import itertools as it
 import operator as op
 from copy import deepcopy
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 RADIUS = FRAME_Y_RADIUS - 0.1
 CIRCLE_DENSITY = DEFAULT_POINT_DENSITY_1D*RADIUS

--- a/old_projects/moser_main.py
+++ b/old_projects/moser_main.py
@@ -8,7 +8,7 @@ from random import random, randint
 import sys
 import inspect
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from script_wrapper import command_line_create_scene
 from functools import reduce
 

--- a/old_projects/mug.py
+++ b/old_projects/mug.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.efvgt import ConfettiSpiril
 
 #revert_to_original_skipping_status

--- a/old_projects/music_and_measure.py
+++ b/old_projects/music_and_measure.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import sys
 from fractions import Fraction, gcd
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from .inventing_math import Underbrace
 
 import random

--- a/old_projects/mvcr.py
+++ b/old_projects/mvcr.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class HoldUpMultivariableChainRule(TeacherStudentsScene):

--- a/old_projects/name_animation.py
+++ b/old_projects/name_animation.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 NAME_WITH_SPACES = "Prime Meridian"
 DIAMETER = 3.0

--- a/old_projects/nn/part1.py
+++ b/old_projects/nn/part1.py
@@ -3,7 +3,7 @@ import os.path
 import cv2
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 import warnings
 warnings.warn("""

--- a/old_projects/nn/part2.py
+++ b/old_projects/nn/part2.py
@@ -3,7 +3,7 @@ import sys
 import os.path
 import cv2
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from nn.network import *
 from nn.part1 import *

--- a/old_projects/nn/playground.py
+++ b/old_projects/nn/playground.py
@@ -8,7 +8,7 @@ from functools import reduce
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from constants import *
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from nn.network import *
 from nn.part1 import *

--- a/old_projects/number_line_scene.py
+++ b/old_projects/number_line_scene.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class NumberLineScene(Scene):
     def construct(self, **number_line_config):

--- a/old_projects/patreon.py
+++ b/old_projects/patreon.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class SideGigToFullTime(Scene):

--- a/old_projects/pi_day.py
+++ b/old_projects/pi_day.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 ###### Ben's stuff ########
 

--- a/old_projects/putnam.py
+++ b/old_projects/putnam.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class ShowExampleTest(ExternallyAnimatedScene):
     pass

--- a/old_projects/qa_round_two.py
+++ b/old_projects/qa_round_two.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.efvgt import get_confetti_animations
 
 

--- a/old_projects/quat3d.py
+++ b/old_projects/quat3d.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.quaternions import *
 
 W_COLOR = YELLOW

--- a/old_projects/quaternions.py
+++ b/old_projects/quaternions.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 def q_mult(q1, q2):

--- a/old_projects/sphere_area.py
+++ b/old_projects/sphere_area.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from active_projects.shadows import *
 
 

--- a/old_projects/tattoo.py
+++ b/old_projects/tattoo.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class TrigRepresentationsScene(Scene):

--- a/old_projects/tau_poem.py
+++ b/old_projects/tau_poem.py
@@ -6,7 +6,7 @@ import itertools as it
 from copy import deepcopy
 import sys
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from script_wrapper import command_line_create_scene
 from .generate_logo import LogoGeneration
 

--- a/old_projects/triangle_of_power/end.py
+++ b/old_projects/triangle_of_power/end.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 from old_projects.triangle_of_power.triangle import TOP, OPERATION_COLORS
 

--- a/old_projects/triangle_of_power/intro.py
+++ b/old_projects/triangle_of_power/intro.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class TrigAnimation(Animation):

--- a/old_projects/triangle_of_power/triangle.py
+++ b/old_projects/triangle_of_power/triangle.py
@@ -1,5 +1,5 @@
 import numbers
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from functools import reduce
 
 OPERATION_COLORS = [YELLOW, GREEN, BLUE_B]

--- a/old_projects/triples.py
+++ b/old_projects/triples.py
@@ -1,5 +1,5 @@
 import fractions
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 A_COLOR = BLUE
 B_COLOR = GREEN

--- a/old_projects/turbulence.py
+++ b/old_projects/turbulence.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.div_curl import PureAirfoilFlow
 from old_projects.div_curl import move_submobjects_along_vector_field
 from old_projects.div_curl import move_points_along_vector_field

--- a/old_projects/uncertainty.py
+++ b/old_projects/uncertainty.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import scipy
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from old_projects.fourier import *
 
 import warnings

--- a/old_projects/wallis.py
+++ b/old_projects/wallis.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from once_useful_constructs.light import AmbientLight
 from once_useful_constructs.light import Lighthouse
 from once_useful_constructs.light import SwitchOn

--- a/old_projects/waves.py
+++ b/old_projects/waves.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 import warnings

--- a/old_projects/wcat.py
+++ b/old_projects/wcat.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 
 class ClosedLoopScene(Scene):

--- a/old_projects/zeta.py
+++ b/old_projects/zeta.py
@@ -1,5 +1,5 @@
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 import mpmath
 mpmath.mp.dps = 7

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(name='manim',
          'pycairo',
          'pydub',
       ],
-      scripts=['manim.py', 'stage_scenes.py', 'big_ol_pile_of_manim_imports.py'],
+      scripts=['manim.py', 'stage_scenes.py'],
       package_data={'manimlib': ['*.tex', 'files/**']},
 )


### PR DESCRIPTION
Changing from `big_ol_pile_of_manim_imports.py` to `manimlib.imports` in order to save keystrokes and facilitate the move toward containing manim a single directory.