### PR TITLE
add option -i to save as gif

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -53,6 +53,11 @@ def parse_cli():
             help="Save each frame as a png",
         ),
         parser.add_argument(
+            "-i", "--save_as_gif",
+            action="store_true",
+            help="Save the video as gif",
+        ),
+        parser.add_argument(
             "-f", "--show_file_in_finder",
             action="store_true",
             help="Show the output file in finder",
@@ -161,6 +166,7 @@ def get_configuration(args):
         "write_to_movie": args.write_to_movie or not args.save_last_frame,
         "save_last_frame": args.save_last_frame,
         "save_pngs": args.save_pngs,
+        "save_as_gif": args.save_as_gif,
         # If -t is passed in (for transparent), this will be RGBA
         "png_mode": "RGBA" if args.transparent else "RGB",
         "movie_file_extension": ".mov" if args.transparent else ".mp4",

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -27,6 +27,7 @@ class SceneFileWriter(object):
         "png_mode": "RGBA",
         "save_last_frame": False,
         "movie_file_extension": ".mp4",
+        "gif_file_extension": ".gif",
         "livestreaming": False,
         "to_twitch": False,
         "twitch_key": None,
@@ -67,6 +68,12 @@ class SceneFileWriter(object):
                 movie_dir,
                 add_extension_if_not_present(
                     file_name, self.movie_file_extension
+                )
+            )
+            self.gif_file_path = os.path.join(
+                movie_dir,
+                add_extension_if_not_present(
+                    file_name, self.gif_file_extension
                 )
             )
             self.partial_movie_directory = guarantee_existance(os.path.join(
@@ -299,10 +306,14 @@ class SceneFileWriter(object):
             '-f', 'concat',
             '-safe', '0',
             '-i', file_list,
-            '-c', 'copy',
+            #'-c', 'copy',
             '-loglevel', 'error',
             movie_file_path
         ]
+        if self.save_as_gif:
+            commands +=[
+                self.gif_file_path,
+            ]
         if not self.includes_sound:
             commands.insert(-1, '-an')
 

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -315,9 +315,9 @@ class SceneFileWriter(object):
                 movie_file_path
             ]
         if self.save_as_gif:
+            movie_file_path=self.gif_file_path
             commands +=[
                 movie_file_path,
-                self.gif_file_path,
             ]
         if not self.includes_sound:
             commands.insert(-1, '-an')

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -306,12 +306,17 @@ class SceneFileWriter(object):
             '-f', 'concat',
             '-safe', '0',
             '-i', file_list,
-            #'-c', 'copy',
             '-loglevel', 'error',
-            movie_file_path
+            
         ]
+        if not self.save_as_gif:
+            commands +=[
+                '-c', 'copy',
+                movie_file_path
+            ]
         if self.save_as_gif:
             commands +=[
+                movie_file_path,
                 self.gif_file_path,
             ]
         if not self.includes_sound:


### PR DESCRIPTION
I added the option to save as gif, however the mp4 or mov file still needs to be saved as well. I'll be trying to find a workaround, but despite that it works. When using the -i option a .gif file will be saved to the output directory