### PR TITLE
Update scene_file_writer.py

### DIFF
--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -34,6 +34,7 @@ class SceneFileWriter(object):
         # TODO, address this in extract_scene et. al.
         "file_name": None,
         "output_directory": None,
+        "input_file_path": './media/'
     }
 
     def __init__(self, scene, **kwargs):


### PR DESCRIPTION
Added `input_file_path: './media/'` option in `CONFIG` dict

`manim --livestream` was giving the following error:
```
(manimations) [jarwin:~/Documents/envs]$ manim --livestream
Media will be stored in ./media/. You can change this behavior by writing a different directory to media_dir.txt.
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/jarwin/Documents/envs/manimations/lib/python3.7/site-packages/manimlib/stream_starter.py", line 38, in __new__                                                                                                                
    return Scene(**kwargs)
  File "/home/jarwin/Documents/envs/manimations/lib/python3.7/site-packages/manimlib/scene/scene.py", line 37, in __init__                                                                                                                  
    self, **self.file_writer_config,
  File "/home/jarwin/Documents/envs/manimations/lib/python3.7/site-packages/manimlib/scene/scene_file_writer.py", line 43, in __init__                                                                                                      
    self.init_output_directories()
  File "/home/jarwin/Documents/envs/manimations/lib/python3.7/site-packages/manimlib/scene/scene_file_writer.py", line 48, in init_output_directories                                                                                       
    output_directory = self.output_directory or self.get_default_output_directory()
  File "/home/jarwin/Documents/envs/manimations/lib/python3.7/site-packages/manimlib/scene/scene_file_writer.py", line 79, in get_default_output_directory                                                                                  
    filename = os.path.basename(self.input_file_path)
AttributeError: 'SceneFileWriter' object has no attribute 'input_file_path'

Manim is now running in streaming mode. Stream animations by passing
them to manim.play(), e.g.
>>> c = Circle()
>>> manim.play(ShowCreation(c))
 
```
To avoid the AttributeError, `input_file_path` was defined at the `CONFIG` dictionary.
After the changes to the same, no error was observed