### PR TITLE
Fixed typo in class name in example_scenes.py

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -111,7 +111,7 @@ class WriteStuff(Scene):
         self.wait()
 
 
-class UdatersExample(Scene):
+class UpdatersExample(Scene):
     def construct(self):
         decimal = DecimalNumber(
             0,


### PR DESCRIPTION
Changed `UdatersExample` to `UpdatersExample`.
