### PR TITLE
Mentioned -r argument in example_scenes comment

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -11,6 +11,8 @@ from manimlib.imports import *
 # Use the -p to have the animation (or image, if -s was
 # used) pop up once done.
 # Use -n <number> to skip ahead to the n'th animation of a scene.
+# Use -r <number> to specify a resolution (for example, -r 1080
+# for a 1920x1080 video)
 
 
 class OpeningManimExample(Scene):


### PR DESCRIPTION
It is a good option to mention because the current default for a high quality 60fps video is 2560x1440.
So, if someone wants a 1920x1080 video, they should pass -r 1080.