### PR TITLE
Remove duplicate usepackage

### DIFF
--- a/manimlib/ctex_template.tex
+++ b/manimlib/ctex_template.tex
@@ -14,7 +14,6 @@
 \usepackage{ragged2e}
 \usepackage{physics}
 \usepackage{xcolor}
-\usepackage{textcomp}
 \usepackage{microtype}
 %\DisableLigatures{encoding = *, family = * }
 \usepackage[UTF8]{ctex}


### PR DESCRIPTION
The textcomp package was imported twice in the ctex template.

See issue #552 