### PR TITLE
Update pycairo requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ progressbar==2.5
 scipy==1.1.0
 tqdm==4.24.0
 opencv-python==3.4.2.17
-pycairo==1.17.1
+pycairo>=1.17.1
 pydub==0.23.0


### PR DESCRIPTION
Many issues, such as #535, stem from the odd installation procedure of cairo and pycairo on Windows. By changing the pycairo requirement in requirements.txt, pip will no longer attempt to uninstall the working version. This should have no effect on the functionality of manim, though new installations are likely to default to pycairo 1.18.0 now.