### PR TITLE
Add Windows installation documentation

### DIFF
--- a/docs/source/installation/windows.rst
+++ b/docs/source/installation/windows.rst
@@ -1,4 +1,60 @@
 Windows
 =======
 
-A stub for windows installation
+Install System Libraries
+------------------------
+
+Make sure you have *Python 3* for Windows installed first:
+
+https://www.python.org/downloads/windows/
+
+Install ffmpeg:
+
+https://ffmpeg.org/download.html#build-windows
+
+Install sox:
+
+http://sox.sourceforge.net/Main/HomePage
+
+Install a latex distribution. On Windows MikTex is commonly used:
+
+https://miktex.org/howto/install-miktex
+
+Path configuration
+------------------
+
+To invoke commandline without supplying path to the binary
+the PATH environment needs to be configured. Below are template examples, please change
+the path according to your username and specific python version. Assuming all the
+softwares are installed with no alteration to the installation paths::
+
+  C:\Users\$username\AppData\local\Programs\Python\Python$version\
+  C:\Users\$username\AppData\local\Programs\Python\Python$version\Scripts\
+  C:\MikTex\miktex\bin\x64\
+  C:\ffmpeg\bin\
+
+The path entries should be separated by semicolon.
+
+Installing python packages and manim
+------------------------------------
+
+Make sure you can start pip using ``pip`` in your commandline. Then do
+``pip install pyreadline`` for the ``readline`` package.
+
+Grab the pycairo wheel binary ``pycairo‑1.18.0‑cp37‑cp37m‑win32.whl`` from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo
+and install it via ``pip C:\absolute\path\to\the\whl\file``
+
+clone the manim repository if you have git ``git clone https://github.com/3b1b/manim`` or download the zip file from
+the repository page with ``Clone or download`` button and unzip it.
+
+Open the commandline within the manim directory with ``Shift + Right click`` on an empty space in the folder and select ``open command window here``
+
+Install manim python dependencies with ``pip install -r requirement.txt``
+
+Test the installation
+---------------------
+
+Type in ``python -m manim -h`` and if nothing went wrong during the installtion process you should see the help text.
+
+Use ``python -m manim example_scene.py SquareToCircle -pl`` to render the example scene and the file should play after rendering. The movie file should be
+in ``media/videos/example_scenes/480p15``


### PR DESCRIPTION
The installation is done with a Windows8 machine,
further testing are needed for windows10.

for example ``python`` will launch just fine, while doing so would result in a command not found in cmd.exe

Also I omitted the pypi installtion, for some reasons the pycairo whl install will be removed and force a recompile which #555 is supposed to fix? or just that pypi hasn't get updated yet ?

Installing collected packages: pycairo, manimlib
  Found existing installation: pycairo 1.18.0
    Uninstalling pycairo-1.18.0:
      Successfully uninstalled pycairo-1.18.0
  Running setup.py install for pycairo ... error
    ERROR: Complete output from command 'c:\users\k\appdata\local\programs\python\python37-32\python.exe' -u -c 'import
setuptools, tokenize;__file__='"'"'C:\\Users\\K\\AppData\\Local\\Temp\\pip-install-302sb5sa\\pycairo\\setup.py'"'"';f=ge
tattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compi
le(code, __file__, '"'"'exec'"'"'))' install --record 'C:\Users\K\AppData\Local\Temp\pip-record-6iskt02e\install-record.
txt' --single-version-externally-managed --compile:
    ERROR: running install
    running build
    running build_py
    creating build
    creating build\lib.win32-3.7
    creating build\lib.win32-3.7\cairo
    copying cairo\__init__.py -> build\lib.win32-3.7\cairo
    copying cairo\__init__.pyi -> build\lib.win32-3.7\cairo
    copying cairo\py.typed -> build\lib.win32-3.7\cairo
    running build_ext
    building 'cairo._cairo' extension
    error: Microsoft Visual C++ 14.0 is required. Get it with "Microsoft Visual C++ Build Tools": https://visualstudio.m
icrosoft.com/downloads/


And the buildtool is quite large. manim runs fine using the repo though.
 