### PR TITLE
Remove typographically incorrect punctuation from documentation headings

### DIFF
--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -9,7 +9,7 @@ how ``manim`` is used, but the examples won't run on the latest version of
 .. _a very nice tutorial: https://talkingphysics.wordpress.com/2018/06/11/learning-how-to-animate-videos-using-``manim``-series-a-journey/
 
 .. toctree::
-    :caption: Contents:
+    :caption: Contents
     :maxdepth: 2
 
     learning_by_example

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ a pull request there.
 
 .. toctree::
     :maxdepth: 2
-    :caption: Contents:
+    :caption: Contents
 
     about
     installation/index

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -5,7 +5,7 @@ Instructions on installing Manim
 
 .. toctree::
     :maxdepth: 2
-    :caption: Contents:
+    :caption: Contents
 
     linux
     mac


### PR DESCRIPTION
While reading the documentation, I noticed some headings ending with a colon, namely "Contents:" and some without any punctuation at the end.
The latter is the typographical rule, so I thought we should follow it consistently.