### PR TITLE
Revert "Update pycairo requirement"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ progressbar==2.5
 scipy==1.1.0
 tqdm==4.24.0
 opencv-python==3.4.2.17
-pycairo>=1.17.1
+pycairo==1.17.1
 pydub==0.23.0


### PR DESCRIPTION
This reverts commit 17558a4bd516526ec7f7b20adfb9ed489f5d261e.

By using ">=" in requirements, the package can get broken anytime. This has happened - on linux, 1.18.1 will be installed, resulting in this exception when using manim:

```
Traceback (most recent call last):
  File "/home/soeren/anaconda3/envs/manim-gallery/lib/python3.7/site-packages/flask/cli.py", line 236, in locate_app
    __import__(module_name)
  File "/home/soeren/Projects/manim-gallery/src/app.py", line 9, in <module>
    from examples import hello_world
  File "/home/soeren/Projects/manim-gallery/src/examples/hello_world.py", line 1, in <module>
    from manimlib.imports import *
  File "/home/soeren/anaconda3/envs/manim-gallery/lib/python3.7/site-packages/manimlib/__init__.py", line 3, in <module>
    import manimlib.extract_scene
  File "/home/soeren/anaconda3/envs/manim-gallery/lib/python3.7/site-packages/manimlib/extract_scene.py", line 9, in <module>
    from manimlib.scene.scene import Scene
  File "/home/soeren/anaconda3/envs/manim-gallery/lib/python3.7/site-packages/manimlib/scene/scene.py", line 11, in <module>
    from manimlib.camera.camera import Camera
  File "/home/soeren/anaconda3/envs/manim-gallery/lib/python3.7/site-packages/manimlib/camera/camera.py", line 9, in <module>
    import cairo
  File "/home/soeren/anaconda3/envs/manim-gallery/lib/python3.7/site-packages/cairo/__init__.py", line 1, in <module>
    from ._cairo import *  # noqa: F401,F403
ImportError: /home/soeren/anaconda3/envs/manim-gallery/lib/python3.7/site-packages/cairo/_cairo.cpython-37m-x86_64-linux-gnu.so: undefined symbol: cairo_svg_surface_set_document_unit
```