### PR TITLE
Conditional requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ progressbar==2.5
 scipy==1.1.0
 tqdm==4.24.0
 opencv-python==3.4.2.17
-pycairo>=1.17.1
+pycairo==1.17.1; sys_platform == 'linux'
+pycairo==1.18.0; sys_platform == 'win32'
 pydub==0.23.0


### PR DESCRIPTION
Choose pycairo version based on platform
#569 and #555 indicate that linux and windows require different versions of pycairo, so install the one needed by the platform.