### PR TITLE
update dockerfile, add flag for high quality rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ RUN apt-get update \
     && apt-get install -qqy --no-install-recommends \
         apt-utils \
         ffmpeg \
-        texlive-latex-base \
         texlive-full \
-        texlive-fonts-extra \
         sox \
         libcairo2-dev \
     && rm -rf /var/lib/apt/lists/*
-COPY requirements.txt requirements.txt
-RUN python -m pip install -r requirements.txt && rm requirements.txt
+COPY . /manim
+RUN cd /manim \
+    && python setup.py sdist \
+    && python -m pip install dist/manimlib*
 ENTRYPOINT ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
     image: eulertour/manim:latest
     # uncomment this line to build rather than pull the image
     # build: .
-    volumes:
-      - ${MANIM_PATH:?MANIM_PATH environment variable isn't set}:/opt/manim
-    environment:
-      - PYTHONPATH=/opt/manim
-    working_dir: /opt/manim
     entrypoint:
-      - python
-      - -m
       - manim
+    volumes:
+      - ${INPUT_DIR:?INPUT_DIR environment variable isn't set}:/tmp/input
+      - ${OUTPUT_DIR:?OUTPUT_DIR environment variable isn't set}:/tmp/output
+    environment:
+      - FILE_DIR=/tmp/output
+      - MEDIA_DIR=/tmp/output
+    working_dir: /tmp/input
     network_mode: "none"

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -48,6 +48,11 @@ def parse_cli():
             help="Render at a medium quality",
         ),
         parser.add_argument(
+            "--high_quality",
+            action="store_true",
+            help="Render at a high quality",
+        ),
+        parser.add_argument(
             "-g", "--save_pngs",
             action="store_true",
             help="Save each frame as a png",
@@ -216,6 +221,8 @@ def get_camera_configuration(args):
         camera_config.update(manimlib.constants.LOW_QUALITY_CAMERA_CONFIG)
     elif args.medium_quality:
         camera_config.update(manimlib.constants.MEDIUM_QUALITY_CAMERA_CONFIG)
+    elif args.high_quality:
+        camera_config.update(manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG)
     else:
         camera_config.update(manimlib.constants.PRODUCTION_QUALITY_CAMERA_CONFIG)
 

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -90,7 +90,7 @@ PRODUCTION_QUALITY_CAMERA_CONFIG = {
 HIGH_QUALITY_CAMERA_CONFIG = {
     "pixel_height": 1080,
     "pixel_width": 1920,
-    "frame_rate": 30,
+    "frame_rate": 60,
 }
 
 MEDIUM_QUALITY_CAMERA_CONFIG = {


### PR DESCRIPTION
The dockerfile now installs manim directly into the container, so there is no need to bind mount the library when running it. That said, you will still have to bind mount the places to read the source and write the video.
1080p rendering is now possible by passing the `--high_quality` flag, and I changed the 1080p frame rate from 30fps to 60fps.