### PR TITLE
Change fill color and stroke color independently

### DIFF
--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -234,9 +234,9 @@ class VMobject(Mobject):
                 sm1.match_style(sm2)
         return self
 
-    def set_color(self, color, family=True):
-        self.set_fill(color, family=family)
-        self.set_stroke(color, family=family)
+    def set_color(self, fill_color, stroke_color=None, family=True):
+        self.set_fill(fill_color, family=family)
+        self.set_stroke(stroke_color, family=family)
         return self
 
     def set_opacity(self, opacity, family=True):


### PR DESCRIPTION
Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)

Motivation: using the `set_color` function would change both the stroke and fill color, which is not always convenient (one may wish to change one but not the other).

2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.

In this case, if an argument is not provided, the color is simply not updated.