### PR TITLE
Update link to Todd Zimmerman tutorial

### DIFF
--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -2,9 +2,9 @@ Getting Started
 ===============
 
 Todd Zimmerman put together `a very nice tutorial`_ on getting started with
-``manim``, but is unfortunately outdated. It's still useful for understanding
-how ``manim`` is used, but the examples won't run on the latest version of
-``manim``.
+``manim``, which has been updated to run on python 3.7. Note that you'll want
+to change `from big_ol_pile_of_manim_imports import *` to `from
+manimlib.imports import *` to work with the current codebase.
 
 .. _a very nice tutorial: https://talkingphysics.wordpress.com/2019/01/08/getting-started-animating-with-manim-and-python-3-7/
 

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -6,7 +6,7 @@ Todd Zimmerman put together `a very nice tutorial`_ on getting started with
 how ``manim`` is used, but the examples won't run on the latest version of
 ``manim``.
 
-.. _a very nice tutorial: https://talkingphysics.wordpress.com/2018/06/11/learning-how-to-animate-videos-using-``manim``-series-a-journey/
+.. _a very nice tutorial: https://talkingphysics.wordpress.com/2019/01/08/getting-started-animating-with-manim-and-python-3-7/
 
 .. toctree::
     :caption: Contents


### PR DESCRIPTION
This pull request intends to update the docs. The link to Todd Zimmerman's tutorial is broken, this PR fixes that broken link.

Note that this PR is likely not ready to merge. Reading the updated tutorial it seems to have comprehensive changes, but I can't find the previous tutorial so I can't say what changed and I don't know what's up to date and what's become outdated since the January 2019 publication. I'm not confident the text describing this tutorial is still accurate, but I'm not sure how to correctly change that description.

>Todd Zimmerman put together [a very nice tutorial](https://talkingphysics.wordpress.com/2018/06/11/learning-how-to-animate-videos-using-%60%60manim%60%60-series-a-journey/) on getting started with `manim`, but is unfortunately outdated. It’s still useful for understanding how `manim` is used, but the examples won’t run on the latest version of `manim`.

Testing: I haven't tested this as I'm not sure how to build the docs locally.