### PR TITLE
Add --video_output_dir flag

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -116,8 +116,13 @@ def parse_cli():
             "--media_dir",
             help="directory to write media",
         )
-        parser.add_argument(
+        video_group = parser.add_mutually_exclusive_group()
+        video_group.add_argument(
             "--video_dir",
+            help="directory to write file tree for video",
+        )
+        video_group.add_argument(
+            "--video_output_dir",
             help="directory to write video",
         )
         parser.add_argument(
@@ -207,6 +212,7 @@ def get_configuration(args):
         "leave_progress_bars": args.leave_progress_bars,
         "media_dir": args.media_dir,
         "video_dir": args.video_dir,
+        "video_output_dir": args.video_output_dir,
         "tex_dir": args.tex_dir,
     }
 

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -3,13 +3,26 @@ import os
 
 MEDIA_DIR = ""
 VIDEO_DIR = ""
+VIDEO_OUTPUT_DIR = ""
 TEX_DIR = ""
 
 def initialize_directories(config):
     global MEDIA_DIR
     global VIDEO_DIR
+    global VIDEO_OUTPUT_DIR
     global TEX_DIR
-    if not (config["video_dir"] and config["tex_dir"]):
+
+    video_path_specified = config["video_dir"] or config["video_output_dir"]
+    if not video_path_specified:
+        VIDEO_DIR = os.path.join(MEDIA_DIR, "videos")
+    elif config["video_output_dir"]:
+        VIDEO_OUTPUT_DIR = config["video_output_dir"]
+    else:
+        VIDEO_DIR = config["video_dir"]
+
+    TEX_DIR = config["tex_dir"] or os.path.join(MEDIA_DIR, "Tex")
+
+    if not (video_path_specified and config["tex_dir"]):
         if config["media_dir"]:
             MEDIA_DIR = config["media_dir"]
         else:
@@ -26,14 +39,12 @@ def initialize_directories(config):
     else:
         if config["media_dir"]:
             print(
-                "Ignoring --media_dir, since --video_dir and --tex_dir were "
-                "both passed"
+                "Ignoring --media_dir, since both --tex_dir and a video "
+                "directory were both passed"
             )
-    VIDEO_DIR  = config["video_dir"] or os.path.join(MEDIA_DIR, "videos")
-    TEX_DIR    = config["tex_dir"] or os.path.join(MEDIA_DIR, "Tex")
 
-    for folder in [VIDEO_DIR, TEX_DIR]:
-        if not os.path.exists(folder):
+    for folder in [VIDEO_DIR, VIDEO_OUTPUT_DIR, TEX_DIR]:
+        if folder != "" and not os.path.exists(folder):
             os.makedirs(folder)
 
 TEX_USE_CTEX = False

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -49,21 +49,30 @@ class SceneFileWriter(object):
         module_directory = self.output_directory or self.get_default_module_directory()
         scene_name = self.file_name or self.get_default_scene_name()
         if self.save_last_frame:
-            image_dir = guarantee_existence(os.path.join(
-                consts.VIDEO_DIR,
-                module_directory,
-                "images",
-            ))
+            if consts.VIDEO_DIR != "":
+                image_dir = guarantee_existence(os.path.join(
+                    consts.VIDEO_DIR,
+                    module_directory,
+                    "images",
+                ))
+            else:
+                image_dir = guarantee_existence(os.path.join(
+                    consts.VIDEO_OUTPUT_DIR,
+                    "images",
+                ))
             self.image_file_path = os.path.join(
                 image_dir,
                 add_extension_if_not_present(scene_name, ".png")
             )
         if self.write_to_movie:
-            movie_dir = guarantee_existence(os.path.join(
-                consts.VIDEO_DIR,
-                module_directory,
-                self.get_resolution_directory(),
-            ))
+            if consts.VIDEO_DIR != "":
+                movie_dir = guarantee_existence(os.path.join(
+                    consts.VIDEO_DIR,
+                    module_directory,
+                    self.get_resolution_directory(),
+                ))
+            else:
+                movie_dir = guarantee_existence(consts.VIDEO_OUTPUT_DIR)
             self.movie_file_path = os.path.join(
                 movie_dir,
                 add_extension_if_not_present(


### PR DESCRIPTION
Video is currently written to a directory named after the input module, which can lead to collisions if modules with the same name are used in a single project. This option allows specifying a video directory manually rather than using the default.