### PR TITLE
Updated installation for linux

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -17,6 +17,17 @@ Install manim via pypi::
     # pip3 install manimlib
 
 OR Install manim via the git repository with venv::
+NOTE : Make sure that the python version you are using is python3.7 because manim works only for that version . If not, you will get errors when running the old_projects.If the python3 version is not 3.7 then upgrade your version usimg the following steps:
+     
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt-get update
+sudo apt-get install build-essential libpq-dev libssl-dev openssl libffi-dev zlib1g-dev
+sudo apt-get install python3-pip python3.7-dev
+sudo apt-get install python3.7
+
+Then use python3.7 command for 3.7 version and python3 for pre installed version.
+
 
     $ git clone https://github.com/3b1b/manim
     $ cd manim


### PR DESCRIPTION
The installation guide for linux is half-way. It doesnot give the main thing that python3 version should be 3.7 for the manim software to work . It took almost aday for me figureout that. So,I added some commands to complete the installation guide .