### PR TITLE
Fix tqdm display problem in windows

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -1,6 +1,7 @@
 import inspect
 import random
 import warnings
+import platform
 
 from tqdm import tqdm as ProgressDisplay
 import numpy as np
@@ -304,6 +305,7 @@ class Scene(Container):
         time_progression = ProgressDisplay(
             times, total=n_iterations,
             leave=self.leave_progress_bars,
+            ascii=False if platform.system() != 'Windows' else True
         )
         return time_progression
 


### PR DESCRIPTION
This is a compromise solution because this problem is caused by windows its own.
You can see this problem in [here](https://github.com/tqdm/tqdm/issues/454).
The problem picture:
<img width="665" alt="problem" src="https://user-images.githubusercontent.com/47266984/61939455-e2ccc700-afc5-11e9-91c0-c5e1c537e0ce.png">
