### PR TITLE
conda environment bug fix with pyreadline package, closes #662

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.7
   - cairo
-  - ffmpeg 
+  - ffmpeg
   - colour==0.1.5
   - numpy==1.15.0
   - pillow==5.2.0
@@ -14,5 +14,6 @@ dependencies:
   - opencv==3.4.2
   - pycairo==1.18.0
   - pydub==0.23.0
+  - ffmpeg
   - pip:
     - pyreadline

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,5 @@ dependencies:
   - opencv==3.4.2
   - pycairo==1.18.0
   - pydub==0.23.0
-  - pyreadline
+  - pip:
+    - pyreadline


### PR DESCRIPTION
Simple fix for no longer available `pyreadline` package. Installed via `pip`.
