### PR TITLE
Update requirements.txt to include pyreadline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ opencv-python==3.4.2.17
 pycairo==1.17.1; sys_platform == 'linux'
 pycairo>=1.18.0; sys_platform == 'win32'
 pydub==0.23.0
+pyreadline==2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ opencv-python==3.4.2.17
 pycairo==1.17.1; sys_platform == 'linux'
 pycairo>=1.18.0; sys_platform == 'win32'
 pydub==0.23.0
-pyreadline==2.1
+pyreadline==2.1; sys_platform == 'win32'


### PR DESCRIPTION
This solves #444

I never tested this pull request, but I had this error after installing from pip and running the `manim` script:
`ModuleNotFoundError: No module named 'readline'`

I then ran:
`py -m pip install pyreadline`

And got this:
... `Successfully installed pyreadline-2.1`

And now `manim` prints the help message instead of the above error.