### PR TITLE
explicitly specify the interpreter used by manim.py to be Python3

### DIFF
--- a/manim.py
+++ b/manim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import manimlib
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. The motivation for making this change (or link the relevant issues)
Because my OS is macOS and I found that when using manim.py directly(through `./manim.py`), it will trigger an error, because the default interpreter on macOS invoked by python is Python 2 rather than Python 3, and by changing the first line of manim.py, after specifying explicitly to use `/usr/bin/env python3` as the interpreter rather than `/usr/bin/env python`, the error is gone.
I think this change is very important for macOS users
2. How you tested the new behavior.
Simply execute manim.py again in terminal after modifying the file and it works as expected.