### PR TITLE
manimlib/mobject/mobject: use deepcopy by default

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -34,6 +34,7 @@ class Mobject(Container):
         "name": None,
         "dim": 3,
         "target": None,
+        "use_deepcopy": True,
     }
 
     def __init__(self, **kwargs):
@@ -114,9 +115,9 @@ class Mobject(Container):
         )
 
     def copy(self):
-        # TODO, either justify reason for shallow copy, or
-        # remove this redundancy everywhere
-        # return self.deepcopy()
+
+        if self.use_deepcopy:
+            return self.deepcopy()
 
         copy_mobject = copy.copy(self)
         copy_mobject.points = np.array(self.points)


### PR DESCRIPTION
Using a shallow copy can result in duplicate objects for references in
an mobject that aren't part of the submobjects array, see [1].
Deepcopy fixes this and doesn't seem to have any other adverse
drawbacks.

Use it by default, however add a config value allowing this to be
overwritten for backwards compatibility.

[1]: https://github.com/3b1b/manim/issues/688

This has been tested by compiling most of the built-in scenes.