### PR TITLE
add frame_rate command line argument

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -103,6 +103,10 @@ def parse_cli():
             help="Background color",
         )
         parser.add_argument(
+            "--frame_rate",
+            help="Frames per second",
+        )
+        parser.add_argument(
             "--sound",
             action="store_true",
             help="Play a success/failure sound",
@@ -267,6 +271,14 @@ def get_camera_configuration(args):
         except AttributeError as err:
             print("Please use a valid color")
             print(err)
+            sys.exit(2)
+
+    if args.frame_rate:
+        int_frame_rate = int(args.frame_rate)
+        if int_frame_rate > 0:
+            camera_config["frame_rate"] = int_frame_rate
+        else:
+            print("Please provide a positive frame rate")
             sys.exit(2)
 
     # If rendering a transparent image/move, make sure the

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -5,6 +5,7 @@ MEDIA_DIR = ""
 VIDEO_DIR = ""
 VIDEO_OUTPUT_DIR = ""
 TEX_DIR = ""
+FILE_DIR = r"C:\manim-assets"
 
 
 def initialize_directories(config):

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -42,7 +42,13 @@ class SVGMobject(VMobject):
     def __init__(self, file_name=None, **kwargs):
         digest_config(self, kwargs)
         self.file_name = file_name or self.file_name
-        self.ensure_valid_file()
+
+        try:
+            self.ensure_valid_file()
+        except IOError:
+            warnings.warn(f"No svg {self.file_name}, falling back to default")
+            self.file_name = os.path.join(FILE_DIR, "default_svg.svg")
+
         VMobject.__init__(self, **kwargs)
         self.move_into_position()
 

--- a/manimlib/mobject/types/image_mobject.py
+++ b/manimlib/mobject/types/image_mobject.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from PIL import Image
@@ -52,7 +54,12 @@ class ImageMobject(AbstractImageMobject):
     def __init__(self, filename_or_array, **kwargs):
         digest_config(self, kwargs)
         if isinstance(filename_or_array, str):
-            path = get_full_raster_image_path(filename_or_array)
+            try:
+                path = get_full_raster_image_path(filename_or_array)
+            except IOError:
+                warnings.warn(f"No image {filename_or_array}, falling back to default")
+                path = os.path.join(FILE_DIR, "default_image.png")
+
             image = Image.open(path).convert(self.image_mode)
             self.pixel_array = np.array(image)
         else:


### PR DESCRIPTION
There is apparently no way to set fps without editing manim source code. This adds a command-line argument frame_rate. I think this is useful, there are many cases where rendering with 60 fps is wasteful and not fitting with the rest of the project outside manim (we use 24 fps).