### PR TITLE
latex can't recognize path seperator \\ in windows

### DIFF
--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -1,6 +1,8 @@
 import os
 import hashlib
 
+from pathlib import Path
+
 from manimlib.constants import TEX_TEXT_TO_REPLACE
 from manimlib.constants import TEX_USE_CTEX
 import manimlib.constants as consts
@@ -39,12 +41,15 @@ def generate_tex_file(expression, template_tex_file_body):
 
 def tex_to_dvi(tex_file):
     result = tex_file.replace(".tex", ".dvi" if not TEX_USE_CTEX else ".xdv")
+    result = Path(result).as_posix()
+    tex_file = Path(tex_file).as_posix()
+    tex_dir = Path(consts.TEX_DIR).as_posix()
     if not os.path.exists(result):
         commands = [
             "latex",
             "-interaction=batchmode",
             "-halt-on-error",
-            "-output-directory=\"{}\"".format(consts.TEX_DIR),
+            "-output-directory=\"{}\"".format(tex_dir),
             "\"{}\"".format(tex_file),
             ">",
             os.devnull
@@ -53,7 +58,7 @@ def tex_to_dvi(tex_file):
             "-no-pdf",
             "-interaction=batchmode",
             "-halt-on-error",
-            "-output-directory=\"{}\"".format(consts.TEX_DIR),
+            "-output-directory=\"{}\"".format(tex_dir),
             "\"{}\"".format(tex_file),
             ">",
             os.devnull
@@ -76,6 +81,8 @@ def dvi_to_svg(dvi_file, regen_if_exists=False):
     where in the dvi
     """
     result = dvi_file.replace(".dvi" if not TEX_USE_CTEX else ".xdv", ".svg")
+    result = Path(result).as_posix()
+    dvi_file = Path(dvi_file).as_posix()
     if not os.path.exists(result):
         commands = [
             "dvisvgm",


### PR DESCRIPTION
Modify path as posix style before transport it to system command to fix issue #505 

I ran the example_scenes.py and pass all cases.