### PR TITLE
New feature: set_row_colors for matrix mobject

### DIFF
--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -125,6 +125,18 @@ class Matrix(VMobject):
             column.set_color(color)
         return self
 
+    def get_rows(self):
+        return VGroup(*[
+            VGroup(*self.mob_matrix[i, :])
+            for i in range(self.mob_matrix.shape[1])
+        ])
+
+    def set_row_colors(self, *colors):
+        rows = self.get_rows()
+        for color, row in zip(colors, rows):
+            row.set_color(color)
+        return self
+
     def add_background_to_entries(self):
         for mob in self.get_entries():
             mob.add_background_rectangle()


### PR DESCRIPTION
This commit allows users to set row colors to a matrix mobject. Local tests were successful.