### PR TITLE
Add default stroke width for the svg mobjects

### DIFF
--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -34,7 +34,7 @@ class SVGMobject(VMobject):
         # Must be filled in in a subclass, or when called
         "file_name": None,
         "unpack_groups": True,  # if False, creates a hierarchy of VGroups
-        "stroke_width": 0,
+        "stroke_width": DEFAULT_STROKE_WIDTH,
         "fill_opacity": 1.0,
         # "fill_color" : LIGHT_GREY,
     }


### PR DESCRIPTION
Closes: #747

I've created a separate scene with SVG mobject and after the fix the pins are there.
I'm not sure whether there are scenes depending on the stroke lines to not be drawn.
![Screenshot](https://user-images.githubusercontent.com/10159037/66375926-6fbcd500-e9a6-11e9-95d4-37c433e2f002.png)
