### PR TITLE
Use generators for any and all calls and comprehensions

### DIFF
--- a/active_projects/eop/reusables/histograms.py
+++ b/active_projects/eop/reusables/histograms.py
@@ -2,11 +2,7 @@ from manimlib.imports import *
 from random import *
 
 def text_range(start,stop,step): # a range as a list of strings
-    numbers = np.arange(start,stop,step)
-    labels = []
-    for x in numbers:
-        labels.append(str(x))
-    return labels
+    return [str(x) for x in np.arange(start,stop,step)]
 
 
 class Histogram(VMobject):
@@ -82,10 +78,7 @@ class Histogram(VMobject):
             self.remove(submob)
 
         def empty_string_array(n):
-            arr = []
-            for i in range(n):
-                arr.append("")
-            return arr
+            return ["" for _ in range(n)]
 
         def num_arr_to_string_arr(arr): # converts number array to string array
             ret_arr = []

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -150,10 +150,10 @@ class Scene(Container):
             mobject.update(dt)
 
     def should_update_mobjects(self):
-        return self.always_update_mobjects or any([
+        return self.always_update_mobjects or any(
             mob.has_time_based_updater()
             for mob in self.get_mobject_family_members()
-        ])
+        )
 
     ###
 

--- a/manimlib/scene/three_d_scene.py
+++ b/manimlib/scene/three_d_scene.py
@@ -75,7 +75,7 @@ class ThreeDScene(Scene):
     def get_moving_mobjects(self, *animations):
         moving_mobjects = Scene.get_moving_mobjects(self, *animations)
         camera_mobjects = self.camera.get_value_trackers()
-        if any([cm in moving_mobjects for cm in camera_mobjects]):
+        if any(cm in moving_mobjects for cm in camera_mobjects):
             return self.mobjects
         return moving_mobjects
 

--- a/manimlib/utils/iterables.py
+++ b/manimlib/utils/iterables.py
@@ -30,7 +30,7 @@ def list_difference_update(l1, l2):
 
 
 def all_elements_are_instances(iterable, Class):
-    return all([isinstance(e, Class) for e in iterable])
+    return all(isinstance(e, Class) for e in iterable)
 
 
 def adjacent_n_tuples(objects, n):

--- a/old_projects/uncertainty.py
+++ b/old_projects/uncertainty.py
@@ -238,7 +238,7 @@ class RadarPulse(ContinualAnimation):
             ps.update_mobject(dt)
 
     def is_finished(self):
-        return all([ps.is_finished() for ps in self.pulse_singletons])
+        return all(ps.is_finished() for ps in self.pulse_singletons)
 
 class MultipleFlashes(Succession):
     CONFIG = {


### PR DESCRIPTION
I just made some small improvements:
In `any` and `all` calls, generators are faster than lists because the loop can break and short cut if the first `True` (in `any`) or `False` (in `all`) is found.
Also some cleaner code with comprehensions :)