### PR TITLE
Small improvements to Matrix mobject

### DIFF
--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -63,6 +63,8 @@ class Matrix(VMobject):
         "element_to_mobject": TexMobject,
         "element_to_mobject_config": {},
         "element_alignment_corner": DR,
+        "left_bracket": "\\big[",
+        "right_bracket": "\\big]",
     }
 
     def __init__(self, matrix, **kwargs):
@@ -76,7 +78,7 @@ class Matrix(VMobject):
         self.organize_mob_matrix(mob_matrix)
         self.elements = VGroup(*mob_matrix.flatten())
         self.add(self.elements)
-        self.add_brackets()
+        self.add_brackets(self.left_bracket,self.right_bracket)
         self.center()
         self.mob_matrix = mob_matrix
         if self.add_background_rectangles_to_entries:
@@ -100,8 +102,8 @@ class Matrix(VMobject):
                 )
         return self
 
-    def add_brackets(self):
-        bracket_pair = TexMobject("\\big[", "\\big]")
+    def add_brackets(self, left, right):
+        bracket_pair = TexMobject(left, right)
         bracket_pair.scale(2)
         bracket_pair.stretch_to_fit_height(
             self.get_height() + 2 * self.bracket_v_buff

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -125,6 +125,18 @@ class Matrix(VMobject):
             column.set_color(color)
         return self
 
+    def get_rows(self):
+        return VGroup(*[
+            VGroup(*self.mob_matrix[i, :])
+            for i in range(self.mob_matrix.shape[1])
+        ])
+
+    def set_row_colors(self, *colors):
+        rows = self.get_rows()
+        for color, row in zip(colors, rows):
+            row.set_color(color)
+        return self
+
     def add_background_to_entries(self):
         for mob in self.get_entries():
             mob.add_background_rectangle()


### PR DESCRIPTION
The first commit allows users to set row colors to a matrix mobject. Local tests were successful.

The second commit allows easy customization of the left and right bracket of a matrix.

_Re-creating the pull request, because first version was done on branch master by accident._