### PR TITLE
README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="logo/cropped.png"/>
+![logo](logo/cropped.png)
 
 [![Build Status](https://travis-ci.org/3b1b/manim.svg?branch=master)](https://travis-ci.org/3b1b/manim)
 [![Documentation](https://img.shields.io/badge/docs-EulerTour-blue.svg)](https://www.eulertour.com/learn/manim/)
@@ -9,7 +9,7 @@
 Manim is an animation engine for explanatory math videos. It's used to create precise animations programmatically, as seen in the videos at [3Blue1Brown](https://www.3blue1brown.com/).
 
 ## Installation
-Manim runs on python 3.7. You can install it from PyPI via pip
+Manim runs on Python 3.7. You can install it from PyPI via pip:
 
 ```sh
 pip3 install manimlib
@@ -23,7 +23,7 @@ You can now use it via the `manim` command. For example:
 manim my_project.py MyScene
 ```
 
-For more options, take a look at the “Using manim“ sections further below.
+For more options, take a look at the [Using manim](#using-manim) sections further below.
 
 ### Directly
 
@@ -39,7 +39,7 @@ python3 ./manim.py example_scenes.py SquareToCircle -pl
 
 ### Directly (Windows)
 1. [Install FFmpeg](https://www.wikihow.com/Install-FFmpeg-on-Windows).
-2. Install Cairo. Download the wheel from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo. For most users, ``pycairo‑1.18.0‑cp37‑cp37m‑win32.whl`` will do fine.
+2. [Install Cairo](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo). For most users, ``pycairo‑1.18.0‑cp37‑cp37m‑win32.whl`` will do fine.
     ```sh
     pip3 install C:\path\to\wheel\pycairo‑1.18.0‑cp37‑cp37m‑win32.whl
     ```
@@ -81,7 +81,7 @@ environment variable to the absolute path containing your scene file and the
 
 1. [Install Docker](https://docs.docker.com)
 2. [Install Docker Compose](https://docs.docker.com/compose/install/)
-3. Render an animation
+3. Render an animation:
 ```sh
 INPUT_PATH=/path/to/dir/containing/source/code \
 OUTPUT_PATH=/path/to/output/ \
@@ -91,9 +91,9 @@ The command needs to be run as root if your username is not in the docker group.
 
 You can replace `example.scenes.py` with any relative path from your `INPUT_PATH`.
 
-<img src=./manim_docker_diagram.png/>
+![docker diagram](./manim_docker_diagram.png)
 
-After running the output will say files ready at `/tmp/output/`, which refers to path inside the container. Your OUTPUT_PATH is bind mounted to this `/tmp/output` so any changes made by the container to `/tmp/output` will be mirrored on your OUTPUT_PATH. `/media/` will be created in `OUTPUT_PATH`.
+After running the output will say files ready at `/tmp/output/`, which refers to path inside the container. Your `OUTPUT_PATH` is bind mounted to this `/tmp/output` so any changes made by the container to `/tmp/output` will be mirrored on your `OUTPUT_PATH`. `/media/` will be created in `OUTPUT_PATH`.
 
 `-p` won't work as manim would look for video player in the container system, which it does not have.
 
@@ -108,22 +108,21 @@ python3 -m manim example_scenes.py SquareToCircle -pl
 The `-p` flag in the command above is for previewing, meaning the video file will automatically open when it is done rendering. The `-l` flag is for a faster rendering at a lower quality.
 
 Some other useful flags include:
-
 * `-s` to skip to the end and just show the final frame.
 * `-n <number>` to skip ahead to the `n`'th animation of a scene.
 * `-f` to show the file in finder (for OSX).
 
 Set `MEDIA_DIR` environment variable to specify where the image and animation files will be written.
 
-Look through the `old_projects` folder to see the code for previous 3b1b videos.  Note, however, that developments are often made to the library without considering backwards compatibility with those old projects.  To run an old project with a guarantee that it will work, you will have to go back to the commit which completed that project.
+Look through the `old_projects` folder to see the code for previous 3b1b videos. Note, however, that developments are often made to the library without considering backwards compatibility with those old projects. To run an old project with a guarantee that it will work, you will have to go back to the commit which completed that project.
 
-While developing a scene, the `-sp` flags are helpful to just see what things look like at the end without having to generate the full animation.  It can also be helpful to use the `-n` flag to skip over some number of animations.
+While developing a scene, the `-sp` flags are helpful to just see what things look like at the end without having to generate the full animation. It can also be helpful to use the `-n` flag to skip over some number of animations.
 
 ### Documentation
 Documentation is in progress at [eulertour.com/learn/manim](https://www.eulertour.com/learn/manim/).
 
 ### Walkthrough
-Todd Zimmerman put together a [tutorial](https://talkingphysics.wordpress.com/2019/01/08/getting-started-animating-with-manim-and-python-3-7/) on getting started with manim, which has been updated to run on python 3.7.
+Todd Zimmerman put together a [tutorial](https://talkingphysics.wordpress.com/2019/01/08/getting-started-animating-with-manim-and-python-3-7/) on getting started with manim, which has been updated to run on Python 3.7.
 
 ### Live Streaming
 To live stream your animations, simply run manim with the `--livestream` option.
@@ -141,8 +140,8 @@ them to manim.play(), e.g.
 ```
 
 It is also possible to stream directly to Twitch. To do that simply pass
---livestream and --to-twitch to manim and specify the stream key with
---with-key. Then when you follow the above example the stream will directly
+`--livestream` and `--to-twitch to manim` and specify the stream key with
+`--with-key`. Then when you follow the above example the stream will directly
 start on your Twitch channel (with no audio support).
 
 
@@ -151,6 +150,6 @@ Is always welcome. In particular, there is a dire need for tests and documentati
 
 
 ## License
-All files in the directories active_projects and old_projects, which by and large generate the visuals for 3b1b videos, are copyright 3Blue1Brown.
+All files in the directories `active_projects` and `old_projects`, which by and large generate the visuals for 3b1b videos, are copyright 3Blue1Brown.
 
 The general purpose animation code found in the remainder of the repository, on the other hand, is under the MIT license.


### PR DESCRIPTION
This makes a couple changes to the README with the goal of standardizing a few things (e.g. putting options in code lines, capitalizing Python, single spaces after periods).