### PR TITLE
Fix Livestreaming feature

### DIFF
--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -15,11 +15,11 @@ def initialize_directories(config):
     global TEX_DIR
     global TEXT_DIR
 
-    video_path_specified = config["video_dir"] or config["video_output_dir"]
+    video_path_specified = config.get("video_dir") or config.get("video_output_dir")
 
-    if not (video_path_specified and config["tex_dir"]):
-        if config["media_dir"]:
-            MEDIA_DIR = config["media_dir"]
+    if not (video_path_specified and config.get("tex_dir")):
+        if config.get("media_dir"):
+            MEDIA_DIR = config.get("media_dir")
         else:
             MEDIA_DIR = os.path.join(
                 os.path.expanduser('~'),
@@ -32,21 +32,21 @@ def initialize_directories(config):
             "this behavior with the --media_dir flag."
         )
     else:
-        if config["media_dir"]:
+        if config.get("media_dir"):
             print(
                 "Ignoring --media_dir, since both --tex_dir and a video "
                 "directory were both passed"
             )
 
-    TEX_DIR = config["tex_dir"] or os.path.join(MEDIA_DIR, "Tex")
+    TEX_DIR = config.get("tex_dir") or os.path.join(MEDIA_DIR, "Tex")
     TEXT_DIR = os.path.join(MEDIA_DIR, "texts")
     if not video_path_specified:
         VIDEO_DIR = os.path.join(MEDIA_DIR, "videos")
         VIDEO_OUTPUT_DIR = os.path.join(MEDIA_DIR, "videos")
-    elif config["video_output_dir"]:
-        VIDEO_OUTPUT_DIR = config["video_output_dir"]
+    elif config.get("video_output_dir"):
+        VIDEO_OUTPUT_DIR = config.get("video_output_dir")
     else:
-        VIDEO_DIR = config["video_dir"]
+        VIDEO_DIR = config.get("video_dir")
 
     for folder in [VIDEO_DIR, VIDEO_OUTPUT_DIR, TEX_DIR, TEXT_DIR]:
         if folder != "" and not os.path.exists(folder):

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -28,7 +28,7 @@ def open_file_if_needed(file_writer, **config):
         if config["file_writer_config"]["save_last_frame"]:
             file_paths.append(file_writer.get_image_file_path())
         if config["file_writer_config"]["write_to_movie"]:
-            file_paths.append(file_writer.get_movie_file_path())
+            file_paths.append(file_writer.movie_file_path)
 
         for file_path in file_paths:
             if current_os == "Windows":

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -463,9 +463,6 @@ class Scene(Container):
         self.progress_through_animations(animations)
         self.finish_animations(animations)
 
-    def idle_stream(self):
-        self.file_writer.idle_stream()
-
     def clean_up_animations(self, *animations):
         for animation in animations:
             animation.clean_up_from_scene(self)

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -53,6 +53,10 @@ class Scene(Container):
             self.construct()
         except EndSceneEarlyException:
             pass
+
+        if self.file_writer.livestreaming:
+            return
+
         self.tear_down()
         self.file_writer.finish()
         self.print_end_message()

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -46,13 +46,12 @@ class SceneFileWriter(object):
 
     # Output directories and files
     def init_output_directories(self):
-        module_directory = self.output_directory or self.get_default_module_directory()
         scene_name = self.file_name or self.get_default_scene_name()
         if self.save_last_frame:
             if consts.VIDEO_DIR != "":
                 image_dir = guarantee_existence(os.path.join(
                     consts.VIDEO_DIR,
-                    module_directory,
+                    self.output_directory or self.get_default_module_directory(),
                     "images",
                 ))
             else:
@@ -68,7 +67,7 @@ class SceneFileWriter(object):
             if consts.VIDEO_DIR != "":
                 movie_dir = guarantee_existence(os.path.join(
                     consts.VIDEO_DIR,
-                    module_directory,
+                    self.output_directory or self.get_default_module_directory(),
                     self.get_resolution_directory(),
                 ))
             else:

--- a/manimlib/stream_starter.py
+++ b/manimlib/stream_starter.py
@@ -15,12 +15,13 @@ def start_livestream(to_twitch=False, twitch_key=None):
             "show_file_in_finder": False,
             # By default, write to file
             "file_writer_config": {
-                "write_to_movie": False,
+                "write_to_movie": True,
                 "save_pngs": False,
                 "movie_file_extension": ".mp4",
                 "to_twitch": to_twitch,
                 "twitch_key": twitch_key,
                 "livestreaming": True,
+                "output_directory": "livestream"
             },
             "show_last_frame": False,
             # If -t is passed in (for transparent), this will be RGBA

--- a/manimlib/stream_starter.py
+++ b/manimlib/stream_starter.py
@@ -7,35 +7,36 @@ import subprocess
 from manimlib.scene.scene import Scene
 import manimlib.constants
 
-
 def start_livestream(to_twitch=False, twitch_key=None):
     class Manim():
-
-        def __new__(cls):
-            kwargs = {
-                "scene_name": manimlib.constants.LIVE_STREAM_NAME,
-                "open_video_upon_completion": False,
-                "show_file_in_finder": False,
-                # By default, write to file
-                "write_to_movie": True,
-                "show_last_frame": False,
+        STREAMING_CONFIG = {
+            "scene_name": manimlib.constants.LIVE_STREAM_NAME,
+            "open_video_upon_completion": False,
+            "show_file_in_finder": False,
+            # By default, write to file
+            "file_writer_config": {
+                "write_to_movie": False,
                 "save_pngs": False,
-                # If -t is passed in (for transparent), this will be RGBA
-                "saved_image_mode": "RGB",
                 "movie_file_extension": ".mp4",
-                "quiet": True,
-                "ignore_waits": False,
-                "write_all": False,
-                "name": manimlib.constants.LIVE_STREAM_NAME,
-                "start_at_animation_number": 0,
-                "end_at_animation_number": None,
-                "skip_animations": False,
-                "camera_config": manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG,
-                "livestreaming": True,
                 "to_twitch": to_twitch,
                 "twitch_key": twitch_key,
-            }
-            return Scene(**kwargs)
+                "livestreaming": True,
+            },
+            "show_last_frame": False,
+            # If -t is passed in (for transparent), this will be RGBA
+            "saved_image_mode": "RGB",
+            "quiet": True,
+            "ignore_waits": False,
+            "write_all": False,
+            "name": manimlib.constants.LIVE_STREAM_NAME,
+            "start_at_animation_number": 0,
+            "end_at_animation_number": None,
+            "skip_animations": False,
+            "camera_config": manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG,
+        }
+        def __new__(cls):
+            manimlib.constants.initialize_directories(cls.STREAMING_CONFIG)
+            return Scene(**cls.STREAMING_CONFIG)
 
     if not to_twitch:
         FNULL = open(os.devnull, 'w')


### PR DESCRIPTION
## Motivation
Noticed that the livestreaming option wasn't working as intended, and decided to fix it.
An issue also exists for it to at #753.

## Description
Since the addition of `SceneFileWriter` and the refactoring that came with it, live streaming was broken due to:
- configurations moving from `Scene` to `SceneFileWriter` and the streaming configuration remaining the same
- Streaming operations in `SceneFileWriter` stil referring to functions as if it was begin run as `Scene`
- Directory constants in `constants.py` not being pre-populated (calling `initialize_directories` is required)

So by fixing all of the above, livestreaming works once more!

## Testing
Before my changes, this was the displayed error:
![Screenshot from 2019-11-06 03-35-41](https://user-images.githubusercontent.com/11013166/68281909-a4c05400-0046-11ea-86df-215ad981f197.png)

Below is a demo of sending commands in livestream mode and the resulting behavior:
![manim_stream](https://user-images.githubusercontent.com/11013166/68282483-cd951900-0047-11ea-9359-e59bd874986e.gif)



