### PR TITLE
Add better discontinuity functionality.

### DIFF
--- a/manimlib/mobject/functions.py
+++ b/manimlib/mobject/functions.py
@@ -19,7 +19,6 @@ class ParametricFunction(VMobject):
         self.function = function or self.function
         VMobject.__init__(self, **kwargs)
 
-
     def get_function(self):
         return self.function
 
@@ -96,7 +95,6 @@ class ParametricFunction(VMobject):
         ]
         boundary_times.sort()
         for t1, t2 in zip(boundary_times[0::2], boundary_times[1::2]):
-            print(f"{t1} {t2}")
             t_range = list(np.arange(t1, t2, self.get_step_size(t1)))
             if t_range[-1] != t2:
                 t_range.append(t2)

--- a/manimlib/mobject/functions.py
+++ b/manimlib/mobject/functions.py
@@ -81,7 +81,6 @@ class ParametricFunction(VMobject):
                 disconts.append(t)
                 continue
 
-            ##TODO: Add break discontinuity functionality
             ss1 = self.get_step_size(t)
             ss2 = ss1/2
             ss3 = ss1/10

--- a/manimlib/scene/graph_scene.py
+++ b/manimlib/scene/graph_scene.py
@@ -158,16 +158,11 @@ class GraphScene(Scene):
         if x_max is None:
             x_max = self.x_max
 
-        def parameterized_function(alpha):
-            x = interpolate(x_min, x_max, alpha)
-            y = func(x)
-            if not np.isfinite(y):
-                y = self.y_max
-            return self.coords_to_point(x, y)
-
         graph = ParametricFunction(
-            parameterized_function,
+            lambda x: np.array([x, func(x), 0]),
             color=color,
+            t_min=x_min,
+            t_max=x_max,
             **kwargs
         )
         graph.underlying_function = func


### PR DESCRIPTION
1. The motivation for making this change (or link the relevant issues)
 I made this change because I wanted to work with some algebraic curves that have multiple infinite discontinuities and, with the current version of manim, animating them lead to very ugly artifacts appearing on the curve. This fundamentally boils down to the `discontinuities` array appearing in the ParametricFunction class that we needed to "be smarter about." While this isn't a perfect solution (as there are still 'double-tangent' artifacts present in all the examples (without and with the new discontinuities function), this is a little bit smarter.
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
 The image below demonstrates the issue I was attempting to solve.
![ParametricFunctionScene_With_Old_Discont](https://user-images.githubusercontent.com/13473097/70874319-3f318280-1f77-11ea-8ce0-b409493edbe9.png)
 With the new `get_discontinuities` function I coded, the image becomes
![ParametricFunctionScene_With_New_Discont](https://user-images.githubusercontent.com/13473097/70874341-52dce900-1f77-11ea-87d1-6d25a7aa818f.png)
 And, to test both infinite discontinuities and break discontinuities, I just drew a hyperbola with a step function at the tail end, which looked like:
![ParametricFunctionScene_Inf_And_Break_Discont](https://user-images.githubusercontent.com/13473097/70874365-6c7e3080-1f77-11ea-9de1-58c2e648519a.png)
So the issue is solved, and everything should _still_ work.



