### PR TITLE
Add simple table drawing functionality.

### DIFF
--- a/manimlib/imports.py
+++ b/manimlib/imports.py
@@ -58,6 +58,7 @@ from manimlib.mobject.types.vectorized_mobject import *
 from manimlib.mobject.mobject_update_utils import *
 from manimlib.mobject.value_tracker import *
 from manimlib.mobject.vector_field import *
+from manimlib.mobject.tables import *
 
 from manimlib.for_3b1b_videos.common_scenes import *
 from manimlib.for_3b1b_videos.pi_creature import *

--- a/manimlib/mobject/tables.py
+++ b/manimlib/mobject/tables.py
@@ -1,0 +1,95 @@
+from manimlib.mobject.types.vectorized_mobject import VGroup
+from manimlib.mobject.svg.tex_mobject import TexMobject
+from manimlib.mobject.geometry import Line
+from manimlib.constants import *
+class Table(VGroup):
+#TODO : Add proper length checking to avoid smaller than useful vertical lines when dealing with TeX
+# Use CONFIG instead of directly passing parameters to function?
+
+    def get_table(tabledict:dict,buff_length=0.3,line_color=WHITE,text_color=WHITE):
+        
+        def flatten(inlist):
+            outlist=[]
+            for element in inlist:
+                for sub_element in element:
+                    outlist.append(sub_element)
+            return outlist
+        
+        table=VGroup() #The table is a VGroup with all the fields, records and separators.
+        
+        fields=list(tabledict.keys()) #Since the data is recieved as a dict, the keys will be the fields
+
+        cell_length=TexMobject(max(fields + flatten(tabledict.values()), key=len)).get_width()+2*buff_length #The length of a record/field of max length is the base cell size
+        cell_height=TexMobject(max(fields + flatten(tabledict.values()), key=len)).get_height()+2*buff_length
+       
+        #The first position is set like so.
+        field_position=[ (cell_length-TexMobject(fields[0]).get_width())/2 + TexMobject(fields[0]).get_width()/2, 0,0 ] #The initial position of the first field. This is 
+        #NOTE: Coordinates of TexMobjects in Manim are taken from centre, not top-right. Adjustments have been made.
+        
+        total_table_width=(cell_length-TexMobject(fields[0]).get_width())/2
+
+        total_table_height=cell_height*(len(tabledict[max(tabledict.keys(),key=len)])+1)
+
+        for n in range(len(fields)):
+            
+            field=TexMobject(fields[n])
+            
+            field_length=field.get_width() #This is the length that the actual field name will take up on-screen
+            
+            if n+1<len(fields): #This gets the nxt field if it exists and chooses an empty TexMobject if it doesn't
+                next_field=TexMobject(fields[n+1])
+            else:
+                next_field=TexMobject("")
+            
+            next_field_length=next_field.get_width() #Gets the next fields length
+            
+            
+            field.move_to(field_position)
+            
+            
+            space_to_right_of_field=(cell_length-field_length)/2
+            
+            space_to_left_of_next_field=(cell_length-next_field_length)/2
+            
+            space_to_leave= space_to_right_of_field + space_to_left_of_next_field + next_field_length/2
+            
+            #next_field_length/2 is added to account for the fact that coordinates are taken from centre and not left edges.
+
+            total_table_width+=field_length+space_to_leave/2
+            table.add(field)
+            field_position=field.get_right()+(space_to_leave,0,0)
+        
+        for keynum in range(len(tabledict.keys())):
+            key=list(tabledict.keys())[keynum] #gets the actual key
+            recordlist=tabledict[key] #selects the list with the records for 
+            
+            if recordlist!=[]:
+
+                record_position=[table[keynum].get_center()[0], -((cell_height-TexMobject(fields[keynum]).get_height())/2 + TexMobject(fields[keynum]).get_height()/2 + cell_height ),0]
+                
+                #the record position is set to be the [center of the field it belongs to, buffer space above the record + centered height of the record, 0  ]
+
+                for recordnum in range(len(recordlist)):    # for each record for
+                    record=TexMobject(recordlist[recordnum]) # the selected field
+                 
+                    
+                    if recordnum+1<len(recordlist): #This gets the nxt record if it exists and chooses an empty TexMobject if it doesn't
+                        next_record=TexMobject(recordlist[recordnum+1])
+                    else:
+                        next_record=TexMobject("")
+                
+
+                    record.move_to(record_position)
+                    record_position=record.get_center()+(0,-cell_height,0)
+                    table.add(record)
+            else:
+                pass
+                
+        line_hor=Line(start=(0,-2*cell_height/3,0),end=(total_table_width,-2*cell_height/3,0),color=line_color)
+        table.add(line_hor)
+        
+        for l in range (len(fields)-1):
+            line=Line( start=(table[l].get_center()+ (cell_length/2,cell_height/2,0)), end =(table[l].get_center()+ (cell_length/2,-total_table_height,0)))
+            table.add(line)
+
+        return table


### PR DESCRIPTION
## Motivation
Tables are really useful for displaying data concisely, which is really useful when making animations on topics such as statistics and science. Currently, Manim can only generate Tables easily through LaTeX, which results in difficulty when generating tables programmatically.

## Results Obtained
With this addition, tables can be made by calling `Table.get_table(<dictionary>)`, where the main, required parameter is a dictionary with the Keys as the field names and Values per Key are the corresponding records.

```python
from manimlib.imports import *
class Tables(Scene):
    def construct(self):
        tabledict={
            "Vowels":["\\alpha","\\epsilon","\\iota","\\omega","a","e","i","o"],
            "Consonants":["\\beta","\\gamma","\\delta","\\phi","\\eta","\\kappa","\\lambda","\\mu","\\nu","\\pi","\\chi","\\zeta"],
            "Words":["Must","add","proper","length","checking","for","use","with","LaTeX.","(No","wraparound","currently.)"],
        }
        table=Table.get_table(tabledict)
        table.scale(0.50)
        table.move_to((0,0,0))
        self.play(Write(table))
        self.wait(2)

```
The code above generates the following table:

![Tables](https://user-images.githubusercontent.com/33193764/71505891-e8944480-28a4-11ea-9f55-789b515c1e00.gif)


Further customisations can be made by passing a `line_color` and `text_color` in the same function like so: `Table.get_table(tabledict,line_color=GREEN,text_color=BLUE)`
Both of these values default to WHITE.

## Changes Made:

A single file named `tables.py` has been added to `manimlib/mobjects`. This file contains the entirety of the logic used.

`manimlib.imports` has been edited to import the aforementioned file.

Future plans for this feature include a wraparound for text and ~~better length measuring of LaTeX strings to ensure proper table column widths, as well as~~ better table element retrieval, since you can only retrieve elements by indexing the resultant VGroup() as of now.

EDIT: I'm closing this PR, since I feel this would work better as an addon to Manim rather than as a core feature. I added support for Text(), TexMobjects(), TextMobjects() and strings. Those interested can find it [here](https://github.com/Aathish04/sanim/tree/master/anim_tools). An example on how to use all its features are [here](https://gitlab.com/aathish04/manim-projects/tree/master/CustomFeatureExamples).
