### PR TITLE
Fix BrokenPipeError caused by FFmpeg writing to closed stdin

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -2,6 +2,7 @@ import inspect
 import random
 import warnings
 import platform
+from time import sleep
 
 from tqdm import tqdm as ProgressDisplay
 import numpy as np
@@ -402,9 +403,15 @@ class Scene(Container):
         def wrapper(self, *args, **kwargs):
             self.update_skipping_status()
             allow_write = not self.skip_animations
-            self.file_writer.begin_animation(allow_write)
-            func(self, *args, **kwargs)
-            self.file_writer.end_animation(allow_write)
+            while True:
+                try:
+                    self.file_writer.begin_animation(allow_write)
+                    func(self, *args, **kwargs)
+                    self.file_writer.end_animation(allow_write)
+                    break
+                except:
+                    self.file_writer.writing_process.wait(1)
+                    sleep(1)
             self.num_plays += 1
         return wrapper
 


### PR DESCRIPTION
When working with relatively large images in manim on my Mac, a BrokenPipeError occurs when FFmpeg tries to write to `file_writer` after stdin is closed.

The error shows up at seemingly random times, even with the same input. For instance, the output below shows that the error occurs at 3 different locations with the exact same input.
<img width="1243" alt="Screenshot 2019-12-31 19 03 09" src="https://user-images.githubusercontent.com/28768645/71637103-bc5c2900-2c00-11ea-84e7-23a1da851bbd.png">
<img width="1204" alt="Screenshot 2019-12-31 19 02 54" src="https://user-images.githubusercontent.com/28768645/71637104-bc5c2900-2c00-11ea-9df9-b37b8bff3343.png">
<img width="1138" alt="Screenshot 2019-12-31 19 02 42" src="https://user-images.githubusercontent.com/28768645/71637105-bc5c2900-2c00-11ea-9ea6-6c25fcde6080.png">

**With my commit, everything works fine, even when a BrokenPipeError is raised.** This can be shown by printing the exceptions that occur at the end of the run, and showing that all the animations still play. In the figure below, it printed [Errno 32] Broken pipe once, however, that error now does not damage the video.
![image](https://user-images.githubusercontent.com/28768645/71637123-24127400-2c01-11ea-9dfa-77a4be6b6d42.png)



Notes:
- If this error **never occurred** on some people's machines, this commit will **not change anything**, since it is simply catching the exception when an error is caused.
- Using `wait(1)` is mostly an arbitrary decision and seems to work well.
- If `sleep` is not called after `wait`, some animations do not show up on the screen.
- The changes in this commit **do not print** all the [Errno 32] Broken pipe exceptions that occur, which was done in the final figure.

This error also corresponds to the issue #845.