### PR TITLE
Align description to code

### DIFF
--- a/docs/source/getting_started/learning_by_example.rst
+++ b/docs/source/getting_started/learning_by_example.rst
@@ -91,7 +91,7 @@ them.  The call to :meth:`~mobject.mobject.Mobject.flip` flips the
 to a refection across the x-axis.
 
 The call to :meth:`~mobject.mobject.Mobject.rotate` rotates the
-:class:`~mobject.geometry.Square` 3/8ths of a full rotation counterclockwise.
+:class:`~mobject.geometry.Square` 3/8ths of a full rotation clockwise.
 
 The call to :meth:`~mobject.mobject.Mobject.set_fill` sets
 the fill color for the :class:`~mobject.geometry.Circle` to pink, and its opacity to 0.5.


### PR DESCRIPTION
The rotation happens in a clockwise direction, because the sign of the argument is negative.
---
I found it confusing and had to check the video to make sure the square was rotating clockwise.

So I thought to send a change.