### PR TITLE
Typo in super() 77acc99

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -284,7 +284,7 @@ class NumberPlane(Axes):
     }
 
     def __init__(self, **kwargs):
-        super.__init__(**kwargs)
+        super().__init__(**kwargs)
         self.init_background_lines()
 
     def init_background_lines(self):


### PR DESCRIPTION
Hello, I believe there was a typo in commit 77acc99.
Changing this allows to run the following example from Todd Zimmerman's tutorial.
```python
class SimpleField(Scene):
    CONFIG = {
    "plane_kwargs" : {
        "color" : RED
        },
    }
    def construct(self):
        plane = NumberPlane(**self.plane_kwargs)
        plane.add(plane.get_axis_labels())
        self.add(plane)

        points = [x*RIGHT+y*UP
            for x in np.arange(-5,5,1)
            for y in np.arange(-5,5,1)
            ]

        vec_field = []
        for point in points:
            field = 0.5*RIGHT + 0.5*UP
            result = Vector(field).shift(point)
            vec_field.append(result)

        draw_field = VGroup(*vec_field)


        self.play(ShowCreation(draw_field))

```