### PR TITLE
Make manim support latex package tikz /tikz-circuit.

### DIFF
--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -42,8 +42,9 @@ def tex_to_dvi(tex_file):
     if not os.path.exists(result):
         commands = [
             "latex",
-            "-interaction=batchmode",
-            "-halt-on-error",
+            "-synctex=1",
+            "-interaction=nonstopmode",
+            "-file-line-error",
             "-output-directory=\"{}\"".format(consts.TEX_DIR),
             "\"{}\"".format(tex_file),
             ">",


### PR DESCRIPTION
By changing the configuration of `text_file_writing.py`, manim can compile the latex code invoking package tikz /tikz-circuit. And it needs adding `\usepackage[options]{tikz}` or `\usepackage[options]{circuitikz}`. Writing the code of the MObeject in the way like `TikzMobject=(r"……") is convenient.

Write:
`class TikzMobject(TextMobject):
    CONFIG = {
        "stroke_width": 3,
        "fill_opacity": 1,
        "stroke_opacity": 1,
    }`
to make the SVG show normally.

![ExampleTikz](https://user-images.githubusercontent.com/50192406/74147007-4dc9ac80-4c3d-11ea-9eac-06e3a5de81b0.gif)


The modification of the `text_file_writing.py` won't affect other `TextMobject` or `TexMobject` codes to compile(up to now). But I don't know why it compiles twice when invoking cirtcuitikz. Invoking tikz complies once!

If setting like this, it won't support Xelatex(it needs some time to mix).

Inspired by https://github.com/Elteoremadebeethoven/AnimationsWithManim/blob/master/English/extra/faqs/tikz.py.

BTW: there is a better way to compile the TextMobject or TexMobject and support more languages directly.
Complying the tex code with `xelatex`, and use `dvisvgm`  convert the `pdf` into `svg` by `divisvgm --pdf file.pdf` which won't thorough the `.dvi` file.
If using the latex package `xeCJK`, it will support Chinese, Japanese and Korean, as well as English at the same time.

Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
