### PR TITLE
Set the axis tick label numbers to be the same color as the axis.

### DIFF
--- a/manimlib/scene/graph_scene.py
+++ b/manimlib/scene/graph_scene.py
@@ -76,7 +76,8 @@ class GraphScene(Scene):
             tick_frequency=self.x_tick_frequency,
             leftmost_tick=self.x_leftmost_tick,
             numbers_with_elongated_ticks=self.x_labeled_nums,
-            color=self.axes_color
+            color=self.axes_color,
+            decimal_number_config={ 'color': self.axes_color },
         )
         x_axis.shift(self.graph_origin - x_axis.number_to_point(0))
         if len(self.x_labeled_nums) > 0:
@@ -110,6 +111,7 @@ class GraphScene(Scene):
             color=self.axes_color,
             line_to_number_vect=LEFT,
             label_direction=LEFT,
+            decimal_number_config={ 'color': self.axes_color },
         )
         y_axis.shift(self.graph_origin - y_axis.number_to_point(0))
         y_axis.rotate(np.pi / 2, about_point=y_axis.number_to_point(0))


### PR DESCRIPTION
Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)

I changed the color of the GraphScene axis but could not change the color of the tick labels to match.  This is a small change to graph_scene.py to provide the correct information to NumberLine.

2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.

Before and after screenshots:
<img width="628" alt="before" src="https://user-images.githubusercontent.com/1450174/76887507-c59c7f80-6858-11ea-9009-a98f6313bd6e.png">
<img width="697" alt="after" src="https://user-images.githubusercontent.com/1450174/76887510-c6cdac80-6858-11ea-8cdd-b183ef14dabd.png">


