### PR TITLE
error that it is an `int` not `float`

### DIFF
--- a/manimlib/shaders/quadratic_bezier_fill_frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill_frag.glsl
@@ -38,7 +38,7 @@ bool is_inside_curve(){
 
 
 float sdf(){
-    if(is_inside_curve()) return -1;
+    if(is_inside_curve()) return -1.0;
     return min_dist_to_curve(uv_coords, uv_b2, bezier_degree, false);
 }
 


### PR DESCRIPTION
```
fragment_shader
===============
0:179(24): error: `return' with wrong type int, in function `sdf' returning float
```

Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
