### PR TITLE
Fixed execution of counting.py

### DIFF
--- a/manimlib/once_useful_constructs/counting.py
+++ b/manimlib/once_useful_constructs/counting.py
@@ -10,6 +10,7 @@ from manimlib.mobject.svg.tex_mobject import TexMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
 from manimlib.scene.scene import Scene
 
+import itertools as it
 
 class CountingScene(Scene):
     CONFIG = {
@@ -219,7 +220,7 @@ class CountInTernary(PowerCounter):
     def construct(self):
         self.count(27)
 
-    # def get_template_configuration(self):
+    # def get_template_configuration(self, place):
     #     return [ORIGIN, UP]
 
 
@@ -233,7 +234,7 @@ class CountInBinaryTo256(PowerCounter):
     def construct(self):
         self.count(128, 0.3)
 
-    def get_template_configuration(self):
+    def get_template_configuration(self, place):
         return [ORIGIN, UP]
 
 


### PR DESCRIPTION
Hi,
This is my first attempt at a pull request for manim.

It fixes some runtime errors when generating counting.py (no issue found on the subject).

```
    for point in self.get_template_configuration(place)
TypeError: get_template_configuration() takes 1 positional argument but 2 were given

    it.cycle(new_template)
NameError: name 'it' is not defined
```

These errors do not appear anymore after fix.
[![Build Status](https://travis-ci.org/Lalourche/manim.svg?branch=fix-counting)](https://travis-ci.org/Lalourche/manim)

Cheers
Lalourche