### PR TITLE
Comment out SceneFromVideo

### DIFF
--- a/manimlib/imports.py
+++ b/manimlib/imports.py
@@ -78,7 +78,8 @@ from manimlib.scene.reconfigurable_scene import *
 from manimlib.scene.scene import *
 from manimlib.scene.sample_space_scene import *
 from manimlib.scene.graph_scene import *
-from manimlib.scene.scene_from_video import *
+## This doesn't work anymore. To use install opencv
+#from manimlib.scene.scene_from_video import *
 from manimlib.scene.three_d_scene import *
 from manimlib.scene.vector_space_scene import *
 from manimlib.scene.zoomed_scene import *


### PR DESCRIPTION
`SceneFromVideo` apparently doesn't work and also adds the `opencv` dependency unnecessarily. This PR aims to exclude this class from `manimlib.imports` and make the opencv denedency optional.

Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
