### PR TITLE
New function : Rotate 2D plane such that it's normal matches a 3D vector

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -364,6 +364,12 @@ class Mobject(Container):
     def rotate_in_place(self, angle, axis=OUT):
         # redundant with default behavior of rotate now.
         return self.rotate(angle, axis=axis)
+    
+    def rotate_to_match_vector(self, vector):
+        #rotates a 2D plane such that it's normal matches a 3D vector
+        rotation_axis= np.cross(vector, OUT)
+        angle = angle_between_vectors(vector, OUT)
+        self.rotate_in_place(-angle, axis= rotation_axis)
 
     def scale_in_place(self, scale_factor, **kwargs):
         # Redundant with default behavior of scale now.


### PR DESCRIPTION
The function rotate_to_match_vector can be useful when making 3D scenes.
Can be used e.g. like this:
```py
class Test(ThreeDScene):
    def construct(self):
        self.set_camera_orientation(phi=45 * DEGREES)
        self.begin_ambient_camera_rotation(2)
        rect=Rectangle(width= 3,height=3, fill_color= ORANGE, fill_opacity=0.4, stroke_color = BLACK)
        self.add(rect)
        dot_temp = Dot(point=[0,1,3])
        line_to_dot = Line(ORIGIN, dot_temp)
        unit_vector = line_to_dot.get_unit_vector()
        dot = Dot(point=dot_temp.get_center(), radius= 1).set_color(GREEN)
        dot.rotate_to_match_vector(unit_vector)
        self.add(line_to_dot)
        self.add(dot)
        self.wait(5)
```
![output](https://user-images.githubusercontent.com/44469195/80305943-6ec38780-87c0-11ea-8248-3912618839d5.gif)
