### PR TITLE
fixed bug for previewing gif files

### DIFF
--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -27,7 +27,9 @@ def open_file_if_needed(file_writer, **config):
 
         if config["file_writer_config"]["save_last_frame"]:
             file_paths.append(file_writer.get_image_file_path())
-        if config["file_writer_config"]["write_to_movie"]:
+        elif config["file_writer_config"]["save_as_gif"]:
+            file_paths.append(file_writer.get_gif_file_path())
+        elif config["file_writer_config"]["write_to_movie"]:
             file_paths.append(file_writer.get_movie_file_path())
 
         for file_path in file_paths:

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -124,6 +124,9 @@ class SceneFileWriter(object):
     def get_movie_file_path(self):
         return self.movie_file_path
 
+    def get_gif_file_path(self):
+        return self.gif_file_path
+
     # Sound
     def init_audio(self):
         self.includes_sound = False


### PR DESCRIPTION

# motivation
when `-i` is used with `-p`, the manim script ignores the gif file and opens `.mp4` with the same name
this pr fixes the bug

# test
[video](https://www.youtube.com/watch?v=K-OSIek7xkY)
