### PR TITLE
Improve example scene 'WriteStuff'

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -98,7 +98,7 @@ class WarpSquare(Scene):
 class WriteStuff(Scene):
     def construct(self):
         example_text = TextMobject(
-            "This is a some text",
+            "This is some text",
             tex_to_color_map={"text": YELLOW}
         )
         example_tex = TexMobject(

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -104,6 +104,8 @@ class WriteStuff(Scene):
         example_tex = TexMobject(
             "\\sum_{k=1}^\\infty {1 \\over k^2} = {\\pi^2 \\over 6}",
         )
+        example_tex.set_color_by_gradient(RED, BLUE)
+        
         group = VGroup(example_text, example_tex)
         group.arrange(DOWN)
         group.set_width(FRAME_WIDTH - 2 * LARGE_BUFF)


### PR DESCRIPTION
#Makes it more aesthetically pleasing and the inclusion the gradient coloring lets more people access the feature without having to trudge through the WIP docs.

[Here's a before and after of the command ](https://imgur.com/a/3K5xcak)
`python ./manim.py example_scenes.py WriteStuff -pl`

This is running on Python 3.7.0 and [a straight git clone of the Manim repository as of 5/4/2020](https://github.com/3b1b/manim/tree/af65c9d5d4ecbcffc5e569508053d56d1f7e86eb)

Closes #806  