### PR TITLE
Fix three bugs(shaders/stroke/size) of Text Class (text_mobject.py) 

### DIFF
--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -50,6 +50,7 @@ class Text(SVGMobject):
         self.lsh = self.size if self.lsh == -1 else self.lsh
 
         file_name = self.text2svg()
+        self.remove_last_M(file_name)
         SVGMobject.__init__(self, file_name, **config)
 
         if self.t2c:
@@ -61,6 +62,13 @@ class Text(SVGMobject):
 
         # anti-aliasing
         self.scale(0.1)
+
+    def remove_last_M(self, file_name):
+        with open(file_name, 'r') as fpr:
+            content = fpr.read()
+        content = re.sub(r'Z M [^[A-Za-z]*? "\/>', 'Z "/>', content)
+        with open(file_name, 'w') as fpw:
+            fpw.write(content)
 
     def find_indexes(self, word):
         m = re.match(r'\[([0-9\-]{0,}):([0-9\-]{0,})\]', word)

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -9,6 +9,9 @@ from manimlib.mobject.svg.svg_mobject import SVGMobject
 from manimlib.utils.config_ops import digest_config
 
 
+TEXT_MOB_SCALE_FACTOR = 0.05
+
+
 class TextSetting(object):
     def __init__(self, start, end, font, slant, weight, line_num=-1):
         self.start = start
@@ -76,7 +79,7 @@ class Text(SVGMobject):
             self.set_color_by_t2g()
 
         # anti-aliasing
-        self.scale(0.1)
+        self.scale(TEXT_MOB_SCALE_FACTOR)
 
     def remove_last_M(self, file_name):
         with open(file_name, 'r') as fpr:

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -56,6 +56,7 @@ class Text(SVGMobject):
         nppc = self.n_points_per_cubic_curve
         for each in self:
             if len(each.points) == 0:
+                self.remove(each)
                 continue
             points = each.points
             last = points[0]

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -53,6 +53,20 @@ class Text(SVGMobject):
         self.remove_last_M(file_name)
         SVGMobject.__init__(self, file_name, **config)
 
+        nppc = self.n_points_per_cubic_curve
+        for each in self:
+            if len(each.points) == 0:
+                continue
+            points = each.points
+            last = points[0]
+            each.clear_points()
+            for index, point in enumerate(points):
+                each.append_points([point])
+                if index != len(points) - 1 and (index + 1) % nppc == 0 and any(point != points[index+1]):
+                    each.add_line_to(last)
+                    last = points[index + 1]
+            each.add_line_to(last)
+
         if self.t2c:
             self.set_color_by_t2c()
         if self.gradient:

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -59,7 +59,6 @@ class Text(SVGMobject):
         nppc = self.n_points_per_cubic_curve
         for each in self:
             if len(each.points) == 0:
-                self.remove(each)
                 continue
             points = each.points
             last = points[0]


### PR DESCRIPTION
There were three bugs in the Text Class, and I fixed them, please merge it if possible.

## Bug 1.
The Text Class won't work __in the 'shaders' branch__, and it throws errors as follows:
![](https://tony031218.github.io/images/text_bug1.png)
Then I fixed this bug by __removing the last "M" command in the svg path strings__ which cairo generated automatically. After doing that, it run perfectly in the 'shaders' branch.

## Bug 2.
When display Text's __stroke__, it won't work as expected. Because the svg paths cairo made are not closed.
If I display the index of the points on the svg paths, it just likes follow:
![](https://tony031218.github.io/images/text_bug2_before.png)
Then I fixed this bug by __making the svg paths closed manually__.
After doing that, the stroke of Text display as we expected:
![](https://tony031218.github.io/images/text_bug2_after.png)

## Bug 3.
This is not a bug, just make the Text's __default size__ the __same__ as TextMobject, so we can easily change TextMobject to Text and have a good control of Text's size.
![](https://tony031218.github.io/images/text_bug4.png)