### PR TITLE
Dashed pattern using pycairo.

### DIFF
--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -396,7 +396,12 @@ class Camera(object):
             # as you zoom in on them.
             (self.get_frame_width() / FRAME_WIDTH)
         )
+        dash_pattern = vmobject.get_stroke_dash_pattern()
+        ctx.save()
+        if None != dash_pattern:
+            ctx.set_dash(dash_pattern)
         ctx.stroke_preserve()
+        ctx.restore()
         return self
 
     def get_stroke_rgbas(self, vmobject, background=False):

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -195,6 +195,9 @@ DEGREES = TAU / 360
 
 FFMPEG_BIN = "ffmpeg"
 
+# Dashes
+DASHED = [.1, .05]
+
 # Colors
 COLOR_MAP = {
     "DARK_BLUE": "#236B8E",

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -35,6 +35,7 @@ class VMobject(Mobject):
         "stroke_color": None,
         "stroke_opacity": 1.0,
         "stroke_width": DEFAULT_STROKE_WIDTH,
+        "dash_pattern": None,
         # The purpose of background stroke is to have
         # something that won't overlap the fill, e.g.
         # For text against some textured background
@@ -312,6 +313,9 @@ class VMobject(Mobject):
         else:
             width = self.stroke_width
         return max(0, width)
+
+    def get_stroke_dash_pattern(self):
+        return self.dash_pattern
 
     def get_stroke_opacity(self, background=False):
         return self.get_stroke_opacities(background)[0]


### PR DESCRIPTION
I have created a dashed stroke pattern.
By now, dashed patterns are made by splitting a curve into many small pieces.
This patch uses pycairos stroke configuration.
DashedLine() should be patched, too.

Using it is very simple:
self.play(
    ShowCreation(Circle(radius=1.0, dash_pattern=DASHED)),
    ShowCreation(Circle(radius=2.0, dash_pattern=[.4, 0.05, 0.1, 0.05])),
)

Reference:
https://www.cairographics.org/samples/dash/

[dashed.py.txt](https://github.com/3b1b/manim/files/4612328/dashed.py.txt)
![Screenshot 2020-05-11 18-59-41](https://user-images.githubusercontent.com/50269481/81616617-332cde00-93ba-11ea-8c04-563d214b0bb8.png)
