### PR TITLE
Correctly return get_unit_size

### DIFF
--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -131,7 +131,7 @@ class NumberLine(Line):
         return self.point_to_number(point)
 
     def get_unit_size(self):
-        return (self.x_max - self.x_min) / self.get_length()
+        return self.get_length() / (self.x_max - self.x_min)
 
     def default_numbers_to_display(self):
         if self.numbers_to_show is not None:


### PR DESCRIPTION
A very simple fix for `mobject.number_line.get_number_line()`

Closes https://github.com/3b1b/manim/issues/997

> In `manimlib/mobject/number_line.py` the method `get_unit_size()` is defined thus
> 
> ```python
> def get_unit_size(self):
>     return (self.x_max - self.x_min) / self.get_length()
> ```
> 
> However, the dividend should be flipped with the divisor:
> 
> ```python
> def get_unit_size(self):
>     return self.get_length() / (self.x_max - self.x_min)
> ```
