### PR TITLE
Add input parameters to StreamLines.get_start_points

### DIFF
--- a/manimlib/mobject/vector_field.py
+++ b/manimlib/mobject/vector_field.py
@@ -262,18 +262,37 @@ class StreamLines(VGroup):
             )
             self.color_using_background_image(image_file)
 
-    def get_start_points(self):
-        x_min = self.x_min
-        x_max = self.x_max
-        y_min = self.y_min
-        y_max = self.y_max
-        delta_x = self.delta_x
-        delta_y = self.delta_y
-        n_repeats = self.n_repeats
-        noise_factor = self.noise_factor
-
+    def get_start_points(
+        self,
+        x_min = None,
+        x_max = None,
+        y_min = None,
+        y_max = None,
+        delta_x = None,
+        delta_y = None,
+        n_repeats = None,
+        noise_factor = None
+    ):
+        if x_min is None:
+            x_min = self.x_min
+        if x_max is None:
+            x_max = self.x_max
+        if y_min is None:
+            y_min = self.y_min
+        if y_max is None:
+            y_max = self.y_max
+        if delta_x is None:
+            delta_x = self.delta_x
+        if delta_y is None:
+            delta_y = self.delta_y
+        if n_repeats is None:
+            n_repeats = self.n_repeats
         if noise_factor is None:
-            noise_factor = delta_y / 2
+            if self.noise_factor is not None:
+                noise_factor = self.noise_factor
+            else:
+                noise_factor = delta_y / 2 if delta_y != 0 else 0
+
         return np.array([
             x * RIGHT + y * UP + noise_factor * np.random.random(3)
             for n in range(n_repeats)


### PR DESCRIPTION
As mentioned in https://github.com/3b1b/manim/issues/994, attempting to initialise `StreamLines` with any values set in `"start_points_generator_config"` results in
```
TypeError: get_start_points() got an unexpected keyword argument 'delta_x'
```
A minimal example:
```
from manimlib.mobject.vector_field import StreamLines

stream_line_config = {
    "start_points_generator_config": {
        "delta_x": 0.1
    }
}
sl = StreamLines(lambda x: x, **stream_line_config)
```

The error is due to the initialise method of `StreamLines` attempting to call `get_start_points` with keyword arguments:
https://github.com/3b1b/manim/blob/ca0b7a6b06ff7787d1efab5ad3b28cfb88f67c3f/manimlib/mobject/vector_field.py#L228-L230
However `get_start_points` does not accept any parameters:
https://github.com/3b1b/manim/blob/ca0b7a6b06ff7787d1efab5ad3b28cfb88f67c3f/manimlib/mobject/vector_field.py#L265

 It is unclear if the configuration was handled differently in the past as `"start_points_generator_config"` has been used [in older code](https://github.com/3b1b/manim/blob/master/from_3b1b/old/div_curl.py#L1432-L1455), but no changes are evident in the git history.

This change provides `get_start_points` with parameters that default to the class config properties if no values are passed.