### PR TITLE
Allow Axes to change the color of coordinate labels

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -186,19 +186,19 @@ class Axes(VGroup, CoordinateSystem):
     def get_axes(self):
         return self.axes
 
-    def get_coordinate_labels(self, x_vals=None, y_vals=None):
+    def get_coordinate_labels(self, x_vals=None, y_vals=None, **kwargs):
         if x_vals is None:
             x_vals = []
         if y_vals is None:
             y_vals = []
-        x_mobs = self.get_x_axis().get_number_mobjects(*x_vals)
-        y_mobs = self.get_y_axis().get_number_mobjects(*y_vals)
+        x_mobs = self.get_x_axis().get_number_mobjects(*x_vals, **kwargs)
+        y_mobs = self.get_y_axis().get_number_mobjects(*y_vals, **kwargs)
 
         self.coordinate_labels = VGroup(x_mobs, y_mobs)
         return self.coordinate_labels
 
-    def add_coordinates(self, x_vals=None, y_vals=None):
-        self.add(self.get_coordinate_labels(x_vals, y_vals))
+    def add_coordinates(self, x_vals=None, y_vals=None, **kwargs):
+        self.add(self.get_coordinate_labels(x_vals, y_vals, **kwargs))
         return self
 
 


### PR DESCRIPTION
Allow Axes to change the color of coordinate labels

__before__ , we can't change the color of the coordinates' color.
```python
class Test(Scene):
    CONFIG = {
        "camera_config": {
            "background_color": WHITE,
        },
    }
    def construct(self):
        plane = NumberPlane(axis_config={"stroke_color": BLACK})
        plane.add_coordinates()
        self.add(plane)
```
![image](https://user-images.githubusercontent.com/44120331/82012179-be9fbb00-96a9-11ea-9ded-99a505b18acb.png)
```python
plane.add_coordinates(number_config={"color": BLACK})
```
![image](https://user-images.githubusercontent.com/44120331/82012248-f149b380-96a9-11ea-95ed-adcc7edc4247.png)

__after__, allow to use `number_config` to change the color:
```python
class Test(Scene):
    CONFIG = {
        "camera_config": {
            "background_color": WHITE,
        },
    }
    def construct(self):
        plane = NumberPlane(axis_config={"stroke_color": BLACK})
        plane.add_coordinates(number_config={"color": BLACK})
        self.add(plane)
```
![image](https://user-images.githubusercontent.com/44120331/82012343-3ff74d80-96aa-11ea-96da-d977abe74542.png)

