### PR TITLE
Fixing a broken stroke width for ZoomedScene

### DIFF
--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -390,12 +390,7 @@ class Camera(object):
             self.get_stroke_rgbas(vmobject, background=background),
             vmobject
         )
-        ctx.set_line_width(
-            width * self.cairo_line_width_multiple *
-            # This ensures lines have constant width
-            # as you zoom in on them.
-            (self.get_frame_width() / FRAME_WIDTH)
-        )
+        ctx.set_line_width(width * self.cairo_line_width_multiple)
         ctx.stroke_preserve()
         return self
 


### PR DESCRIPTION
When using ZoomedScene, incorrect stroke width behavior is observed. 

I found that a special multiplier `self.get_frame_width() / FRAME_WIDTH` was added, which is supposed to keep the right stroke width. In fact, it introduces an incorrect behavior. See the example below:

![before](https://user-images.githubusercontent.com/5459767/82075120-6fc34700-96e4-11ea-9302-fa2707308d5b.png)
![after](https://user-images.githubusercontent.com/5459767/82075128-7356ce00-96e4-11ea-8f52-31e361804af1.png)

Reproducible example:
```python
class Test(ZoomedScene):
    CONFIG = {
        "zoom_factor": 0.4,
        "zoomed_display_height": 5,
        "zoomed_display_width": 5
    }

    def construct(self):
        zoomed_camera = self.zoomed_camera
        zoomed_display = self.zoomed_display

        title = TextMobject("Before").scale(2.5).to_corner(LEFT + UP)

        zoomed_display.display_frame.set_color(BLUE)
        zoomed_display.to_corner(RIGHT + UP, buff=0)

        circle1 = Circle(stroke_width=6).scale(0.5)
        circle2 = Circle(stroke_width=3, color=BLUE).scale(0.25)
        rect = Rectangle(height=1.25, width=2.0, color=YELLOW, stroke_width=2).next_to(circle2, LEFT, buff=0)
        dot = Dot(fill_color=BLUE, color=WHITE, stroke_width=4).scale(2).next_to(circle1, LEFT, buff=0)
        zoomed_camera.frame.next_to(rect, LEFT)

        self.add(circle1, circle2, rect, dot, title)
        self.activate_zooming()
        self.play(self.get_zoomed_display_pop_out_animation())

        zoomed_camera.frame.generate_target().move_to(circle1)
        self.play(
            MoveToTarget(zoomed_camera.frame),
            run_time=6
        )
        self.wait(2)
```

I understand that the author of this code fragment originally wanted to keep the thickness of the lines in ZoomedScene the same as in the original scene. First of all, I think that this is an unexpected behavior as it is normal to expect a thickening of lines when zooming objects. Secondly, the originally proposed hack does not work, because the width and height of the scenes in pixels are different, so simple multiplication by `self.get_frame_width() / FRAME_WIDTH` does not restore the original stroke width. If someone wants to keep this behavior, it should be made optional.