### PR TITLE
Add missing import to brace.py

### DIFF
--- a/manimlib/mobject/svg/brace.py
+++ b/manimlib/mobject/svg/brace.py
@@ -9,7 +9,7 @@ from manimlib.mobject.svg.tex_mobject import TextMobject
 from manimlib.mobject.types.vectorized_mobject import VMobject
 from manimlib.utils.config_ops import digest_config
 from manimlib.utils.space_ops import get_norm
-
+import copy
 
 class Brace(TexMobject):
     CONFIG = {


### PR DESCRIPTION
Without `import copy` lines 128 to 131 will throw an error. I've tested this edit in my local version of the library and it fixes the bug.