### PR TITLE
Added multithreading support

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -101,6 +101,11 @@ def parse_cli():
             help="Background color",
         )
         parser.add_argument(
+            "-j", "--threads", type=int,
+            default=1,
+            help="Sets the amount of concurrent threads to use",
+        )
+        parser.add_argument(
             "--sound",
             action="store_true",
             help="Play a success/failure sound",
@@ -184,6 +189,7 @@ def get_configuration(args):
         "video_dir": args.video_dir,
         "video_output_dir": args.video_output_dir,
         "tex_dir": args.tex_dir,
+        "threads": args.threads 
     }
 
     # Camera configuration


### PR DESCRIPTION
**Reason for adding**
1. To enable faster rendering of scenes on cpu's with a high amount of cores vs single core speed.
2. Allow users to opt in using the new "-j" or "--threads" flag followed by the integer number of threads to use (note that -j is picked because -t is taken and the syntax of gcc is -j4 for 4 cores).

**Working Example**
1. My CPU does not benefit massively from it, but using 2 threads gave me a roughly 10-20% speed boost (measured using the time command).
2. Too many cores slow down processing, base it off your cpu architecture.
3. Threads can only work on seperate scenes, so enabling extra threads when processing one scene will do nothing.
4. Makes use of the inbuilt threading library, so there is no need to add more dependencies.