### PR TITLE
Allow nested updating suspend/resume.

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -43,7 +43,7 @@ class Mobject(Container):
         if self.name is None:
             self.name = self.__class__.__name__
         self.updaters = []
-        self.updating_suspended = False
+        self.updating_suspended = 0
         self.reset_points()
         self.generate_points()
         self.init_colors()
@@ -146,7 +146,7 @@ class Mobject(Container):
     # Updating
 
     def update(self, dt=0, recursive=True):
-        if self.updating_suspended:
+        if self.updating_suspended > 0:
             return self
         for updater in self.updaters:
             parameters = get_parameters(updater)
@@ -208,14 +208,15 @@ class Mobject(Container):
         return self
 
     def suspend_updating(self, recursive=True):
-        self.updating_suspended = True
+        self.updating_suspended += 1
         if recursive:
             for submob in self.submobjects:
                 submob.suspend_updating(recursive)
         return self
 
     def resume_updating(self, recursive=True):
-        self.updating_suspended = False
+        assert(self.updating_suspended >= 1)
+        self.updating_suspended -= 1
         if recursive:
             for submob in self.submobjects:
                 submob.resume_updating(recursive)

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -215,8 +215,12 @@ class Mobject(Container):
         return self
 
     def resume_updating(self, recursive=True):
-        assert(self.updating_suspended >= 1)
         self.updating_suspended -= 1
+        # It might happen that we where added to a mobject that
+        # was already suspended. Therefore, resume_updating()
+        # would be called even if suspend_updating() was never called.
+        if self.updating_suspended < 0:
+            self.updating_suspended = 0
         if recursive:
             for submob in self.submobjects:
                 submob.resume_updating(recursive)


### PR DESCRIPTION
In the present time, calls to Mobject.suspend_updating cannot be nested. I made nesting possible by substituting the boolean flag by a counter.

I do not see any need to argue about the need/desire to suspend updating when performing some animation. But as I see, updating methods keep the Mobject satisfying some constraint. However, during the animation, probably the object might not satisfy those constraints, so updating should usually be suspended.

But if you do a block of a sequence of animations (even using the Succession animation class), updating is resumed as soon as the first animation finishes. IMO, suspension should be like:

```
mobject.suspend_updating()
# Leave the orbit a bit.
self.play(DoThis(mobject))
self.wait()
# Fly back to its orbit.
self.play(DoThat(mobject))
mobject.resume_updating()
```
However, DoThis calls mobject.resume_updating and causes the animation sequence to be disrupted before DoThat is played. Suspension does not work even if you do:
self.play(Succession(DoThis(mobject), DoThat(mobject))).

Ideally, Succession should call suspend_updating for every mobject involved. But this is not the object of this patch. :-)