### PR TITLE
Add dot_color to BulletedList

### DIFF
--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -257,6 +257,7 @@ class BulletedList(TextMobject):
     CONFIG = {
         "buff": MED_LARGE_BUFF,
         "dot_scale_factor": 2,
+        "dot_color": WHITE,
         # Have to include because of handle_multiple_args implementation
         "template_tex_file_body": TEMPLATE_TEXT_FILE_BODY,
         "alignment": "",
@@ -266,7 +267,7 @@ class BulletedList(TextMobject):
         line_separated_items = [s + "\\\\" for s in items]
         TextMobject.__init__(self, *line_separated_items, **kwargs)
         for part in self:
-            dot = TexMobject("\\cdot").scale(self.dot_scale_factor)
+            dot = TexMobject("\\cdot", color=self.dot_color).scale(self.dot_scale_factor)
             dot.next_to(part[0], LEFT, SMALL_BUFF)
             part.add_to_back(dot)
         self.arrange(


### PR DESCRIPTION
I felt like using only white in BulletedList wasn't visually appealing, so the ability to change the color of the bullet seemed useful.
```python
l = BulletedList("Item 1", "Item 2", "Item 3", dot_color=BLUE)
```
produces
<img width="366" alt="image" src="https://user-images.githubusercontent.com/31397379/83178468-65864d00-a0d5-11ea-8fc2-2cd665def137.png">
