### PR TITLE
Remove superfluous line.

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -701,7 +701,6 @@ class Mobject(Container):
                 result, submob.get_merged_array(array_attr),
                 axis=0
             )
-            submob.get_merged_array(array_attr)
         return result
 
     def get_all_points(self):


### PR DESCRIPTION
The line removed was probably accidentally left behind.

The line calls a function with no side-effects, but its return value is not used at all.