### PR TITLE
Allow VMobject to have non-VMobject submobjects.

### DIFF
--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -137,7 +137,8 @@ class VMobject(Mobject):
     def set_fill(self, color=None, opacity=None, family=True):
         if family:
             for submobject in self.submobjects:
-                submobject.set_fill(color, opacity, family)
+                if hasattr(submobject, 'set_fill'):
+                    submobject.set_fill(color, opacity, family)
         self.update_rgbas_array("fill_rgbas", color, opacity)
         return self
 
@@ -145,9 +146,10 @@ class VMobject(Mobject):
                    background=False, family=True):
         if family:
             for submobject in self.submobjects:
-                submobject.set_stroke(
-                    color, width, opacity, background, family
-                )
+                if hasattr(submobject, 'set_stroke'):
+                    submobject.set_stroke(
+                        color, width, opacity, background, family
+                    )
         if background:
             array_name = "background_stroke_rgbas"
             width_name = "background_stroke_width"

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -714,6 +714,7 @@ class VMobject(Mobject):
         return np.array(list(it.chain(self.get_anchors(), *[
             sm.get_points_defining_boundary()
             for sm in self.get_family()[1:]
+            if self != sm
         ])))
 
     def get_arc_length(self, n_sample_points=None):

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -709,9 +709,9 @@ class VMobject(Mobject):
         ))))
 
     def get_points_defining_boundary(self):
-        return np.array(list(it.chain(*[
-            sm.get_anchors()
-            for sm in self.get_family()
+        return np.array(list(it.chain(self.get_anchors(), *[
+            sm.get_points_defining_boundary()
+            for sm in self.get_family()[1:]
         ])))
 
     def get_arc_length(self, n_sample_points=None):


### PR DESCRIPTION
Fixes #1122.

Rationale for this patch can be found on Issue #1122.

Calls to Mobject.move_to(), for example, end up in a call to self.get_points_defining_boundary(). However, if a VMobject contains a non-VMobject submobject, we gen an error indicating that submobject.get_anchors() is not implemented.

The method VMobject.get_points_defining_boundary() is a recursive method inherited from VMobject and reimplemented. Since get_anchors() is not implemented in Mobject, instead of calling submobject.get_anchors() for all sobmobjects, it should call get_anchors() just for self, and get_points_defining_boundary() for all submobjects.

One problem in this patch is that this implementation relies on:
1. The fact that self is the first Mobject returned by Mobject.get_family().
2. The fact that self is NOT in Mobject.get_family()[1:]