### PR TITLE
Update graph_scene.py: Add an argument to setup the axes without displaying them on screen.

### DIFF
--- a/manimlib/scene/graph_scene.py
+++ b/manimlib/scene/graph_scene.py
@@ -65,7 +65,7 @@ class GraphScene(Scene):
         self.right_T_label = VGroup()
         self.right_v_line = VGroup()
 
-    def setup_axes(self, animate=False):
+    def setup_axes(self, animate=False, hideaxes=False):
         """
         This method sets up the axes of the graph.
 
@@ -141,6 +141,8 @@ class GraphScene(Scene):
 
         if animate:
             self.play(Write(VGroup(x_axis, y_axis)))
+        elif hideaxes:
+            pass
         else:
             self.add(x_axis, y_axis)
         self.x_axis, self.y_axis = self.axes = VGroup(x_axis, y_axis)


### PR DESCRIPTION
1. The aim / objective is to actually have a GraphScene and corresponding graphs, but not displaying the axes beforehand.

Current problem:

    You cannot add a graph without self.setup_axes()
    self.setup_axes() displays the axes by default.

For example, I want to first display some text, FadeOut the TextMobject and then FadeIn the axes, I cannot FadeIn(self.axes) unless first setting up the axes via self.setup_axes().

Hence this patch.

2. Attached is a GIF using my patch.
![hideaxes_trial](https://user-images.githubusercontent.com/42336020/83947833-18be1700-a837-11ea-9fa0-d118ad209a14.gif)
