### PR TITLE
zip to list

### DIFF
--- a/from_3b1b/old/nn/network.py
+++ b/from_3b1b/old/nn/network.py
@@ -73,7 +73,7 @@ class Network(object):
         if n_layers is None:
             n_layers = self.num_layers
         activations = [input_a.reshape((input_a.size, 1))]
-        for bias, weight in zip(self.biases, self.weights)[:n_layers]:
+        for bias, weight in list(zip(self.biases, self.weights))[:n_layers]:
             last_a = activations[-1]
             new_a = self.non_linearity(np.dot(weight, last_a) + bias)
             new_a = new_a.reshape((new_a.size, 1))


### PR DESCRIPTION
https://stackoverflow.com/questions/27431390/typeerror-zip-object-is-not-subscriptable: In Python3 zip returns an iterable and thus cannot be sliced. It can be converted to a list, then sliced, however

Thanks for contributing to manim!

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.
