### PR TITLE
Allow one to refer to submobjects by id.

### DIFF
--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -62,9 +62,13 @@ class SVGMobject(VMobject):
         raise IOError("No file matching %s in image directory" %
                       self.file_name)
 
+    def get_mobject_by_id(self, id):
+        return self.mobject_id_dict[id]
+
     def generate_points(self):
         doc = minidom.parse(self.file_path)
         self.ref_to_element = {}
+        self.mobject_id_dict = {}
         for svg in doc.getElementsByTagName("svg"):
             mobjects = self.get_mobjects_from(svg)
             if self.unpack_groups:
@@ -107,6 +111,11 @@ class SVGMobject(VMobject):
         self.handle_transforms(element, VGroup(*result))
         if len(result) > 1 and not self.unpack_groups:
             result = [VGroup(*result)]
+
+        if len(result) == 1:
+            id = element.getAttribute('id')
+            if id != '':
+                self.mobject_id_dict[id] = result[0]
 
         return result
 


### PR DESCRIPTION
This is so one can get submobjects of an SVGMobject by referring to them by their xml id.

In the same spirit of TexMobject:get_parts_by_tex, with this patch you can get a submobject by its id. You just type something like:
`        left_eye = svg_mobject.get_mobject_by_id('left_eye')
`
I have attached a minimal working example. I just added an id for each eye on PiCreatures_plain.svg.

```
from manimlib.imports import *

class SVGById(Scene):
    def construct(self):
        svg_mobject = SVGMobject(file_name="PiCreatures_plain", fill_color=RED)
        self.add(svg_mobject)
        self.wait()

        left_eye = svg_mobject.get_mobject_by_id('left_eye')
        right_eye = svg_mobject.get_mobject_by_id('right_eye')

        self.play(
            Swap(left_eye, right_eye),
        )

```

![SVGById](https://user-images.githubusercontent.com/50269481/85182937-853a0c80-b260-11ea-9307-fddcc07cb859.gif)
[minimal_working_example.zip](https://github.com/3b1b/manim/files/4806872/svg_id.zip)
