### PR TITLE
Pygments added to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,6 @@ dependencies:
   - pycairo==1.18.0
   - pydub==0.23.0
   - ffmpeg
+  - pygments==2.6.1
   - pip:
-    - pyreadline
+      - pyreadline


### PR DESCRIPTION
1. After installing manim with Anaconda using the environment.yml file and running any script including the example_scenes.py script, one receives an error of "no module pygments installed" (to that effect). This dependency is in the requirements.txt file but not in the environment.yml file, therefore I added it for easier environment installation and setup.
