### PR TITLE
A solution to xelatex error converting to xdv

### DIFF
--- a/manimlib/ctex_template.tex
+++ b/manimlib/ctex_template.tex
@@ -1,4 +1,5 @@
 \documentclass[preview]{standalone}
+\usepackage[UTF8]{ctex}
 
 \usepackage[english]{babel}
 \usepackage{amsmath}
@@ -16,7 +17,6 @@
 \usepackage{xcolor}
 \usepackage{microtype}
 %\DisableLigatures{encoding = *, family = * }
-\usepackage[UTF8]{ctex}
 \linespread{1}
 
 \begin{document}


### PR DESCRIPTION
This may solve some xelatex errors, like #1055 #1027 etc.

If `\usepackage[UTF8]{ctex}` doesn’t be placed at the top of `ctex_template.tex`, it may cause xelatex error even TexLive or MiKTeX is installed correctly.