### PR TITLE
typo in example_scenes.py comments

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -5,7 +5,7 @@ from manimlib.imports import *
 # To watch one of these scenes, run the following:
 # python -m manim example_scenes.py SquareToCircle -pl
 #
-# Use the flat -l for a faster rendering at a lower
+# Use the flag -l for a faster rendering at a lower
 # quality.
 # Use -s to skip to the end and just save the final frame
 # Use the -p to have the animation (or image, if -s was


### PR DESCRIPTION
Typo "flat" to "flag"
