### PR TITLE
Inability to set custom FPS (Frames Per Second) Fixed

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -127,6 +127,14 @@ def parse_cli():
             "--tex_dir",
             help="directory to write tex",
         )
+
+        # edited by SGP
+        parser.add_argument(
+            "-x", "--custom_fps",
+            action="store_true",
+            help="custom frames per second (fps)",
+        )
+        # edited by SGP 
         return parser.parse_args()
     except argparse.ArgumentError as err:
         print(str(err))
@@ -208,15 +216,41 @@ def get_configuration(args):
 
 def get_camera_configuration(args):
     camera_config = {}
-    if args.low_quality:
-        camera_config.update(manimlib.constants.LOW_QUALITY_CAMERA_CONFIG)
-    elif args.medium_quality:
-        camera_config.update(manimlib.constants.MEDIUM_QUALITY_CAMERA_CONFIG)
-    elif args.high_quality:
-        camera_config.update(manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG)
-    else:
-        camera_config.update(manimlib.constants.PRODUCTION_QUALITY_CAMERA_CONFIG)
+    if args.custom_fps:
+        CUSTOM_QUALITY_CONFIG = {
+            "pixel_height": None,
+            "pixel_width": None,
+            "frame_rate": manimlib.constants.CUSTOM_QUALITY_CAMERA_CONFIG["frame_rate"],
+        }
 
+        if args.low_quality:
+            CUSTOM_QUALITY_CONFIG["pixel_height"] = manimlib.constants.LOW_QUALITY_CAMERA_CONFIG["pixel_height"]
+            CUSTOM_QUALITY_CONFIG["pixel_width"] = manimlib.constants.LOW_QUALITY_CAMERA_CONFIG["pixel_width"]
+        elif args.medium_quality:
+            CUSTOM_QUALITY_CONFIG["pixel_height"] = manimlib.constants.MEDIUM_QUALITY_CAMERA_CONFIG["pixel_height"]
+            CUSTOM_QUALITY_CONFIG["pixel_width"] = manimlib.constants.MEDIUM_QUALITY_CAMERA_CONFIG["pixel_width"]
+        elif args.high_quality:
+            CUSTOM_QUALITY_CONFIG["pixel_height"] = manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG["pixel_height"]
+            CUSTOM_QUALITY_CONFIG["pixel_width"] = manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG["pixel_width"]
+        else:
+            CUSTOM_QUALITY_CONFIG["pixel_height"] = manimlib.constants.PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_height"]
+            CUSTOM_QUALITY_CONFIG["pixel_width"] = manimlib.constants.PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_width"]
+
+        if manimlib.constants.CUSTOM_QUALITY_CAMERA_CONFIG["frame_rate"] == None:
+            raise Exception("You need to set custom FPS using set_custom_fps(int-value) to use this parameter.")
+        
+        camera_config.update(CUSTOM_QUALITY_CONFIG)
+
+    if not args.custom_fps:
+        if args.low_quality:
+            camera_config.update(manimlib.constants.LOW_QUALITY_CAMERA_CONFIG)
+        elif args.medium_quality:
+            camera_config.update(manimlib.constants.MEDIUM_QUALITY_CAMERA_CONFIG)
+        elif args.high_quality:
+            camera_config.update(manimlib.constants.HIGH_QUALITY_CAMERA_CONFIG)
+        else:
+            camera_config.update(manimlib.constants.PRODUCTION_QUALITY_CAMERA_CONFIG)
+    
     # If the resolution was passed in via -r
     if args.resolution:
         if "," in args.resolution:

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -127,14 +127,11 @@ def parse_cli():
             "--tex_dir",
             help="directory to write tex",
         )
-
-        # edited by SGP
         parser.add_argument(
             "-x", "--custom_fps",
             action="store_true",
             help="custom frames per second (fps)",
         )
-        # edited by SGP 
         return parser.parse_args()
     except argparse.ArgumentError as err:
         print(str(err))

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -139,6 +139,22 @@ LOW_QUALITY_CAMERA_CONFIG = {
     "frame_rate": 15,
 }
 
+CUSTOM_QUALITY_CAMERA_CONFIG = {
+    "pixel_height": None,
+    "pixel_width": None,
+    "frame_rate": None}
+
+def set_custom_fps(frame_rate):
+    # type filter
+    if type(frame_rate) != int:
+        raise Exception(f"Invlaid value {frame_rate} for custom frame rate. Required value is of type int!")
+
+    # value filter
+    if 0 < frame_rate <= 120:
+        CUSTOM_VIDEO_CONFIG["frame_rate"] = frame_rate
+    else:
+        raise Exception("Custom FPS has to be 0 < integer <= 120!")
+
 DEFAULT_PIXEL_HEIGHT = PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_height"]
 DEFAULT_PIXEL_WIDTH = PRODUCTION_QUALITY_CAMERA_CONFIG["pixel_width"]
 DEFAULT_FRAME_RATE = 60


### PR DESCRIPTION
1. **Rendering at different frames per second becomes integral when working with video inside the animation itself, which is something I am doing with the creation of a new Object called VideoMobject**
2. I have added a **type failsafe and a limit failsafe to the custom frame rate** that can be set, as can be seen below:
```
def set_custom_fps(frame_rate):
    # type filter
    if type(frame_rate) != int:
        raise Exception(f"Invlaid value {frame_rate} for custom frame rate. Required value is of type int!")

    # value filter
    if 0 < frame_rate <= 120:
        CUSTOM_VIDEO_CONFIG["frame_rate"] = frame_rate
    else:
        raise Exception("Custom FPS has to be 0 < integer <= 120!")
```
Furthermore in the config.py file I have placed a failsafe if the parameter -x is added but the function set_custom_fps is not used in the file at all or is not used correctly, as can be seen below:

```
if args.custom_fps:
        _**code not important to this point I am making **_

        if manimlib.constants.CUSTOM_QUALITY_CAMERA_CONFIG["frame_rate"] == None:
            raise Exception("You need to set custom FPS using set_custom_fps(int-value) to use this parameter.")

```

**_if the --custom_fps is passed without a --low_quality or another quality parameter then it will take PRODUCTION_QUALITY as default pixel (height x width). But if they are it will use the custom fps along with the height & width of the quality you mentioned._**

Note:  The --low_quality or another quality parameter's framerate are ignored if you pass in the --custom_fps and correctly set a valid fps in the file using the set_custom_fps(0 < integer_value <= 120).

THIS FEATURE IS EXTREMELY IMPORTANT IF WE WANT THERE TO BE A VIDEOMOBJECT as not all videos have the same fps