### PR TITLE
help(Scene.play)

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -2,6 +2,7 @@ import inspect
 import random
 import warnings
 import platform
+from functools import wraps
 
 from tqdm import tqdm as ProgressDisplay
 import numpy as np
@@ -841,6 +842,7 @@ class Scene(Container):
             The play() like function that can now write
             to the video file stream.
         """
+        @wraps(func)
         def wrapper(self, *args, **kwargs):
             self.update_skipping_status()
             allow_write = not self.skip_animations


### PR DESCRIPTION
1. The motivation for making this change (or link the relevant issues)

trying to get help on `Scene.play` leads to a dead end, because the `handle_play_like_call` decorator fails to take care of its outcome's docstring (and other special attributes like `__name__` I would bet)

the good practice for writing such decorator is to take advantage of `functools.wraps`, this PR exhibits one example; let me know what you think and I could review the code more deeply to account for the other possible places where that change could come in handy

this way, decorated methods - typically `Scene.play` - have a decent docstring
so first-time users can use `help()` on them


2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) This is rather informal at the moment, but
the goal is to show us how you know the pull request works as intended.

well, I'm a first time user, and I've been using this brew of manim for my first steps, and have not met any unexpected result so far, as compared to what the tutorial shows

