### PR TITLE
fixed deprecation warning: tostring -> tobytes

### DIFF
--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -333,7 +333,7 @@ class SceneFileWriter(object):
             Pixel array of the frame.
         """
         if self.write_to_movie:
-            self.writing_process.stdin.write(frame.tostring())
+            self.writing_process.stdin.write(frame.tobytes())
 
     def save_final_image(self, image):
         """


### PR DESCRIPTION
Fixed the following deprecation warning caused by numpy:
`/manim/manimlib/scene/scene_file_writer.py:336: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.`
Tested on: python 3.8.1 ; numpy 1.19.1