### PR TITLE
fix iteration through a dictionary

### DIFF
--- a/manimlib/for_3b1b_videos/common_scenes.py
+++ b/manimlib/for_3b1b_videos/common_scenes.py
@@ -74,7 +74,7 @@ class OpeningQuote(Scene):
             if self.quote_arg_separator == " ":
                 quote[0].shift(0.2 * RIGHT)
                 quote[-1].shift(0.2 * LEFT)
-        for term, color in self.highlighted_quote_terms:
+        for term, color in self.highlighted_quote_terms.items():
             quote.set_color_by_tex(term, color)
         quote.to_edge(UP, buff=self.top_buff)
         if quote.get_width() > max_width:


### PR DESCRIPTION
I fix a small bug in the OpeningQuote scene. This scene has an attribute `highlighted_quote_terms` that is a dictionary. 
In method `get_quote`, it was iterating only through the dictionary keys.

1.In Python 3.x the way iterate through a dictionary has changed, hence it was incompatible with new Python versions.

2. I tested with my videos.
