### PR TITLE
Remove pycairo install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,11 @@ python3 ./manim.py example_scenes.py SquareToCircle -pl
 
 ### Directly (Windows)
 1. [Install FFmpeg](https://www.wikihow.com/Install-FFmpeg-on-Windows).
-2. [Install Cairo](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo). For most users, ``pycairo‑1.18.0‑cp37‑cp37m‑win32.whl`` will do fine (you can download it or other versions from [here](https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo)).
-    ```sh
-    pip3 install C:\path\to\wheel\pycairo‑1.18.0‑cp37‑cp37m‑win32.whl
-    ```
-3. Install a LaTeX distribution. [MiKTeX](https://miktex.org/download) is recommended.
+2. Install a LaTeX distribution. [MiKTeX](https://miktex.org/download) is recommended.
 
-4. [Install SoX](https://sourceforge.net/projects/sox/files/sox/).
+3. [Install SoX](https://sourceforge.net/projects/sox/files/sox/).
 
-5. Install the remaining Python packages.
+4. Install the remaining Python packages.
     ```sh
     git clone https://github.com/3b1b/manim.git
     cd manim

--- a/docs/source/installation/windows.rst
+++ b/docs/source/installation/windows.rst
@@ -41,9 +41,6 @@ Installing python packages and manim
 Make sure you can start pip using ``pip`` in your commandline. Then do
 ``pip install pyreadline`` for the ``readline`` package.
 
-Grab the pycairo wheel binary ``pycairo‑1.18.0‑cp37‑cp37m‑win32.whl`` from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo
-and install it via ``python -m pip install C:\absolute\path\to\the\whl\file``
-
 clone the manim repository if you have git ``git clone https://github.com/3b1b/manim`` or download the zip file from
 the repository page with ``Clone or download`` button and unzip it.
 


### PR DESCRIPTION
Pycairo now has wheels published to PyPi for Windows. So users no need to the these. 
Ref:
https://github.com/pygobject/pycairo/pull/191
https://github.com/ManimCommunity/manim/pull/517