### PR TITLE
Specify pycairo version to 1.19.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ progressbar
 scipy
 tqdm
 opencv-python
-pycairo
+pycairo==1.19.1
 pydub
 pygments
 pyreadline; sys_platform == 'win32'


### PR DESCRIPTION
pip will by default install the newest version of library. The newest pycairo(which manimlib needs) is now version [1.20.0](https://pypi.org/project/pycairo/#history) released on October 6th, 2020. But unfortunately pycairo 1.20.0 uses [PEP 517](https://www.python.org/dev/peps/pep-0517/) to build, which still has problems with virtualenv that travis-ci or other users rely on.

See the current travis-ci output [message](https://travis-ci.org/github/3b1b/manim/jobs/737736332#L377).

The second newest pycairo version on pip now is 1.19.1, and will not cause the ci to fail. In the future, new version of pycairo should always be tested to see if it's working, otherwise it's safer to specify a particular version of pycairo that works.