### PR TITLE
Specify pycairo version less than 1.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ progressbar
 scipy
 tqdm
 opencv-python
-pycairo==1.19.1
+pycairo<1.20.0
 pydub
 pygments
 pyreadline; sys_platform == 'win32'


### PR DESCRIPTION
This is the second fix for pr [#1264 ](https://github.com/3b1b/manim/pull/1264).

Some interpreter may cause a warning for pycairo not satisfied 1.19.1 (especially for old users). Now any installed version that is less than 1.20.0 is fine, and will not cause the ci  to fail (see more infomation in [#1264](https://github.com/3b1b/manim/pull/1264)).