### PR TITLE
Change Ubuntu version to bionic in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+dist: bionic
 python: "3.7"
 cache: pip
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ progressbar
 scipy
 tqdm
 opencv-python
-pycairo==1.19.1
+pycairo
 pydub
 pygments
 pyreadline; sys_platform == 'win32'


### PR DESCRIPTION
This is the second fix to pr #1264. 

The original travis-ci build environment is Ubuntu xenial, which is version 16.04 (see this information on travis-ci [document page](https://docs.travis-ci.com/user/reference/linux)), and the newest cairo version on it is 1.14, which caused problem with the newset pycairo 1.20.0. See the previous travis-ci [error message](https://travis-ci.org/github/3b1b/manim/jobs/737736332#L372).

Ubuntu bionic will not cause the problem, and redundant pycairo version can be removed.