### PR TITLE
fix typo docstring in scene_file_writer.py

### DIFF
--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -427,7 +427,7 @@ class SceneFileWriter(object):
     def close_movie_pipe(self):
         """
         Used internally by Manim to gracefully stop writing to FFMPEG's
-        input buffer, and move the temporary files into their permananant
+        input buffer, and move the temporary files into their permanent
         locations
         """
         self.writing_process.stdin.close()


### PR DESCRIPTION
I accidentally found this "word", and I'm pretty sure there's no such word 'permananant'. I think @Aathish04 means the word 'permanent'.