### PR TITLE
Remove unused parameter in mobject.py

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -250,7 +250,7 @@ class Mobject(Container):
         )
         return self
 
-    def rotate_about_origin(self, angle, axis=OUT, axes=[]):
+    def rotate_about_origin(self, angle, axis=OUT):
         return self.rotate(angle, axis, about_point=ORIGIN)
 
     def rotate(self, angle, axis=OUT, **kwargs):


### PR DESCRIPTION
Hi,

As seen in the source code, the argument 'axes' is never used. There is no point providing it, as the real useful argument 'axis' has been there. This can mislead the users.

This function is provided as an API to users, and it's not used in manimlib itself(I tested via Pycharm's Find usage option). So it's safe to remove it from the source code.

Previous user code that didn't use this argument can be compiled with manim correctly as before. Also, any previous user code that did use this parameter(should be really rare) will not be compiled to generate videos. And that makes sense, because it has nothing meaningful. Using argument 'axis' is the right solution.