### PR TITLE
Improve Text's handling of non-display characters in shaders and Add a feature

### DIFF
--- a/custom_defaults.yml
+++ b/custom_defaults.yml
@@ -29,6 +29,10 @@ universal_import_line: "from manimlib.imports import *"
 style:
   font: "Consolas"
   background_color: "#333333"
+# Set the position of preview window, you can use directions, e.g. UL/DR/OL/OO/...
+# also, you can also specify the position(pixel) of the upper left corner of 
+# the window on the monitor, e.g. "960,540"
+window_position: UR
 camera_qualities:
   low:
     resolution: "854x480"

--- a/environment.yml
+++ b/environment.yml
@@ -24,4 +24,5 @@ dependencies:
     - pyyaml
     - validators
     - ipython
+    - PyOpenGL
 

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -125,6 +125,7 @@ class TextExample(Scene):
 
         fonts = Text(
             "And you can also set the font according to different words",
+            font="Arial",
             t2f={"font": "Consolas", "words": "Consolas"},
             t2c={"font": BLUE, "words": GREEN}
         )

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -203,7 +203,23 @@ def get_configuration(args):
     else:
         window_width = monitor.width / 2
     window_height = window_width * 9 / 16
-    window_position = (int(monitor.width - window_width), 0)
+    custom_position = custom_defaults["window_position"]
+    if "," in custom_position:
+        posx, posy = map(int, custom_position.split(","))
+    else:
+        if custom_position[1] == "L":
+            posx = 0
+        elif custom_position[1] == "O":
+            posx = int((monitor.width - window_width) / 2)
+        elif custom_position[1] == "R":
+            posx = int(monitor.width - window_width)
+        if custom_position[0] == "U":
+            posy = 0
+        elif custom_position[0] == "O":
+            posy = int((monitor.height - window_height) / 2)
+        elif custom_position[0] == "D":
+            posy = int(monitor.height - window_height)
+    window_position = (posx, posy)
     config["window_config"] = {
         "size": (window_width, window_height),
         "position": window_position,

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -61,24 +61,12 @@ JOINT_TYPE_MAP = {
 }
 
 # Related to Text
-NOT_SETTING_FONT_MSG = '''
-Warning:
-You haven't set font.
-If you are not using English, this may cause text rendering problem.
-You set font like:
-text = Text('your text', font='your font')
-or:
-class MyText(Text):
-    CONFIG = {
-        'font': 'My Font'
-    }
-'''
 START_X = 30
 START_Y = 20
-NORMAL = 'NORMAL'
-ITALIC = 'ITALIC'
-OBLIQUE = 'OBLIQUE'
-BOLD = 'BOLD'
+NORMAL = "NORMAL"
+ITALIC = "ITALIC"
+OBLIQUE = "OBLIQUE"
+BOLD = "BOLD"
 
 DEFAULT_STROKE_WIDTH = 4
 

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -73,14 +73,17 @@ class Text(SVGMobject):
             self.scale(TEXT_MOB_SCALE_FACTOR * self.font_size)
 
     def apply_space_chars(self):
+        submobs = self.submobjects.copy()
         for char_index in range(self.text.__len__()):
             if self.text[char_index] == " " or self.text[char_index] == "\t" or self.text[char_index] == "\n":
-                space = Dot(redius=0, fill_opacity=0, stroke_opacity=0)
+                space = Dot(radius=0, fill_opacity=0, stroke_opacity=0)
                 if char_index == 0:
-                    space.move_to(self.submobjects[char_index].get_center())
+                    space.move_to(submobs[char_index].get_center())
                 else:
-                    space.move_to(self.submobjects[char_index - 1].get_center())
-                self.submobjects.insert(char_index, space)
+                    space.move_to(submobs[char_index - 1].get_center())
+                # self.submobjects.insert(char_index, space)
+                submobs.insert(char_index, space)
+        self.set_submobjects(submobs)
 
     def remove_last_M(self, file_name):
         with open(file_name, 'r') as fpr:

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -27,23 +27,23 @@ class TextSetting(object):
 class Text(SVGMobject):
     CONFIG = {
         # Mobject
-        'color': WHITE,
-        'height': None,
-        'stroke_width': 0,
+        "color": WHITE,
+        "height": None,
+        "stroke_width": 0,
         # Text
-        'font': '',
-        'gradient': None,
-        'lsh': -1,
-        'size': 1,
-        'font_size': 48,
-        'tab_width': 4,
-        'slant': NORMAL,
-        'weight': NORMAL,
-        't2c': {},
-        't2f': {},
-        't2g': {},
-        't2s': {},
-        't2w': {},
+        "font": '',
+        "gradient": None,
+        "lsh": -1,
+        "size": 1,
+        "font_size": 48,
+        "tab_width": 4,
+        "slant": NORMAL,
+        "weight": NORMAL,
+        "t2c": {},
+        "t2f": {},
+        "t2g": {},
+        "t2s": {},
+        "t2w": {},
     }
 
     def __init__(self, text, **config):

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -81,7 +81,6 @@ class Text(SVGMobject):
                     space.move_to(submobs[char_index].get_center())
                 else:
                     space.move_to(submobs[char_index - 1].get_center())
-                # self.submobjects.insert(char_index, space)
                 submobs.insert(char_index, space)
         self.set_submobjects(submobs)
 

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -539,9 +539,14 @@ class Scene(object):
         pass
 
     def on_key_press(self, symbol, modifiers):
-        if chr(symbol) == "r":
+        try:
+            char = chr(symbol)
+        except OverflowError:
+            print(" Warning: The value of the pressed key is too large.")
+            return
+        if char == "r":
             self.camera.frame.to_default_state()
-        elif chr(symbol) == "q":
+        elif char == "q":
             self.quit_interaction = True
 
     def on_resize(self, width: int, height: int):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ screeninfo
 pyreadline; sys_platform == 'win32'
 validators
 ipython
+PyOpenGL


### PR DESCRIPTION
Continued https://github.com/3b1b/manim/pull/1315#issuecomment-761285165
Although `Text` can be colored properly in some cases, the position of non-display characters is not very good, and tabs are not processed. Because the #1035 of the master is not synchronized to the shaders. So I added them (https://github.com/3b1b/manim/commit/5f6b653803e3b138a2c9337c4a22dead375299c8) and made some changes (https://github.com/3b1b/manim/commit/3d118a5bb6d0dd55111dc8bc496db07d010f26d9) to fit the shaders branch.
And for this part (↓), if modify `SVGMobject` as in #1035, it may cause some problems for SVG, so I only modified the generated svg file in `Text` and deleted the empty path.
https://github.com/3b1b/manim/blob/5f6b653803e3b138a2c9337c4a22dead375299c8/manimlib/mobject/svg/text_mobject.py#L92-L97
Now, even **tabs**, **newlines**, and different amounts of **whitespaces** will not affect the coloring:
```python
text = Text(
    """Here is a tab ->\t, and a newline ->\nand even the number of whitespaces    doesn't influence coloring""",
    t2c={"tab": BLUE, "newline": BLUE, "number": BLUE, "coloring": ORANGE}
).set_width(FRAME_WIDTH - 1)
self.add(text)
index = index_labels(text, 0.05)
self.add(index)
```
![E88({N`~C0M9{ 0VZD8J3WH](https://user-images.githubusercontent.com/44120331/104795825-26377880-57ec-11eb-9958-2d8d9e6d1e8e.png)

And one of the differences between `Text` and `TextMobject` is that the index of `Text` completely obeys the incoming string, that is, tabs are reserved (each occupies a position), and whitespaces (each occupies a position) are also reserved. I think this may be convenient for using `Text`.

---

- For this commit https://github.com/3b1b/manim/commit/f6b5edede29a972c2a1b08d035b37119a0a9d2c0, if don't modify it in this way, the computer will automatically select the Chinese input method when I (in China) focus on the window, resulting in the following annoying errors repeatedly. After the modification, only one sentence is prompted, which may be more friendly.
```text
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 232, in 'calling callback function'
  File "...\Anaconda3\envs\manim\lib\site-packages\pyglet\window\win32\__init__.py", line 668, in f
    result = event_handler(msg, wParam, lParam)
  File "...\Anaconda3\envs\manim\lib\site-packages\pyglet\window\win32\__init__.py", line 739, in _event_key
    self.dispatch_event(ev, symbol, modifiers)
  File "...\Anaconda3\envs\manim\lib\site-packages\pyglet\window\__init__.py", line 1327, in dispatch_event
    if EventDispatcher.dispatch_event(self, *args) != False:
  File "...\Anaconda3\envs\manim\lib\site-packages\pyglet\event.py", line 408, in dispatch_event
    if handler(*args):
  File "...\manimlib\window.py", line 66, in on_key_press
    self.scene.on_key_press(symbol, modifiers)
  File "...\manimlib\scene\scene.py", line 542, in on_key_press
    if chr(symbol) == "r":
OverflowError: Python int too large to convert to C long
```

- For this commit https://github.com/3b1b/manim/commit/b7bd40a6f6af9ec56237529ba954935c62b51d12, I added an option to change the position of the window in `custom_default.yml`. You can use the relative position on the screen (the first character means upper(U) / middle(O) / lower(D), the second character means left(L) / middle(O) / right(R)), and you can also use the pixels on the screen in the upper left corner of the window (separated by a comma) for positioning.

---
Btw, you have gave me the permission to directly push into the shaders branch, but in order not to interfere with your work, I did not do this, but opened a pull request and waited for you to read it and merge. 
So now if I find a small problem in codes (like https://github.com/3b1b/manim/pull/1316/commits/cfa8577454c5272ccad3d7103e710e9d17ae1643), I can _directly commit and then push into the shaders branch_, or _open a pull request but merge directly_, or _open the pull request and wait for you to merge_. Which one do you prefer? @3b1b