### PR TITLE
Interactive Mobjects Performance Improvements

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -497,7 +497,8 @@ class ControlsExample(Scene):
         self.add(MotionMobject(text))
 
         self.textbox.set_value("Manim")
-        self.embed()
+        # self.wait(60)
+        # self.embed()
 
 
 # See https://github.com/3b1b/videos for many, many more

--- a/manimlib/mobject/interactive.py
+++ b/manimlib/mobject/interactive.py
@@ -57,7 +57,7 @@ class Button(Mobject):
 
 # Controls
 
-class ContolMobject(ValueTracker):
+class ControlMobject(ValueTracker):
     CONFIG = {
         "listen_to_events": True
     }
@@ -84,7 +84,7 @@ class ContolMobject(ValueTracker):
         pass
 
 
-class EnableDisableButton(ContolMobject):
+class EnableDisableButton(ControlMobject):
     CONFIG = {
         "value_type": np.dtype(bool),
         "rect_kwargs": {
@@ -118,7 +118,7 @@ class EnableDisableButton(ContolMobject):
         return False
 
 
-class Checkbox(ContolMobject):
+class Checkbox(ControlMobject):
     CONFIG = {
         "value_type": np.dtype(bool),
         "rect_kwargs": {
@@ -187,7 +187,7 @@ class Checkbox(ContolMobject):
         return cross
 
 
-class LinearNumberSlider(ContolMobject):
+class LinearNumberSlider(ControlMobject):
     CONFIG = {
         # Since, only slider circle listnes to drag event
         "listen_to_events": False,
@@ -349,7 +349,7 @@ class ColorSliders(Group):
         return rgba[3]
 
 
-class Textbox(ContolMobject):
+class Textbox(ControlMobject):
     CONFIG = {
         "value_type": np.dtype(object),
 

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -58,6 +58,9 @@ class Scene(object):
         self.mouse_point = Point()
         self.mouse_drag_point = Point()
 
+        self.mob_listners = []
+        self.mobjects_to_drag = []
+
         # Much nicer to work with deterministic scenes
         if self.random_seed is not None:
             random.seed(self.random_seed)
@@ -205,6 +208,9 @@ class Scene(object):
         """
         self.remove(*new_mobjects)
         self.mobjects += new_mobjects
+        for new_mob in new_mobjects:
+            for mob_listner in filter(lambda mob: mob.listen_to_events, reversed(new_mob.get_family())):
+                self.mob_listners.insert(0, mob_listner)
         return self
 
     def add_mobjects_among(self, values):
@@ -232,6 +238,9 @@ class Scene(object):
     def bring_to_back(self, *mobjects):
         self.remove(*mobjects)
         self.mobjects = list(mobjects) + self.mobjects
+        for new_mob in reversed(mobjects):
+            for mob_listner in filter(lambda mob: mob.listen_to_events, reversed(new_mob.get_family())):
+                self.mob_listners.append(mob_listner)
         return self
 
     def clear(self):
@@ -519,10 +528,7 @@ class Scene(object):
             in reversed order. So the top most mobject's event is called first.
             This helps in event bubbling.
         """
-        return filter(
-            lambda mob: mob.listen_to_events,
-            reversed(self.get_mobject_family_members())
-        )
+        return self.mob_listners
 
     def on_mouse_motion(self, point, d_point):
         self.mouse_point.move_to(point)
@@ -548,13 +554,16 @@ class Scene(object):
     def on_mouse_drag(self, point, d_point, buttons, modifiers):
         self.mouse_drag_point.move_to(point)
 
-        for mob_listener in self.get_event_listeners_mobjects():
-            if mob_listener.is_point_touching(point):
-                propagate_event = mob_listener.on_mouse_drag(point, d_point, buttons, modifiers)
-                if propagate_event is not None and propagate_event is False:
-                    return
+        for mob_listener in self.mobjects_to_drag:
+            propagate_event = mob_listener.on_mouse_drag(point, d_point, buttons, modifiers)
+            if propagate_event is not None and propagate_event is False:
+                return
 
     def on_mouse_press(self, point, button, mods):
+        for mob_listener in self.get_event_listeners_mobjects():
+            if mob_listener.is_point_touching(point):
+                self.mobjects_to_drag.append(mob_listener)
+
         for mob_listener in self.get_event_listeners_mobjects():
             if mob_listener.is_point_touching(point):
                 propagate_event = mob_listener.on_mouse_press(point, button, mods)
@@ -562,6 +571,8 @@ class Scene(object):
                     return
 
     def on_mouse_release(self, point, button, mods):
+        self.mobjects_to_drag = []
+
         for mob_listener in self.get_event_listeners_mobjects():
             if mob_listener.is_point_touching(point):
                 propagate_event = mob_listener.on_mouse_release(point, button, mods)


### PR DESCRIPTION
# Motivation
As mentioned in https://github.com/3b1b/manim/pull/1323#issuecomment-769350572, interactive mobjects were a bit laggy.

So, to improve interactively mobjects performance, the following changes are made.
1. Maintain a separate list of mobject listeners instead of filtering mobjects on every frame.
>   This significantly improved the performance on all events except the on_mouse_drag event. So to improve it the 2nd change was made.
2.  Changed the way drag events are handled.
> This improved the performance of on_mouse_drag event.

# Files Changed
1. manimlib/scene/scene.py
> To store a separate list of mob_listners rather than checking it on every frame and changed the on_mouse_drag event handling. 
2. manimlib/mobject/interactive.py
> To adapt to the changes made in the way event handling works
3. example_scenes.py
> Commented out "self.embed()"

# Change in how on_mouse_drag works
If mouse is being draged, following events are triggered
1. **on_mouse_press** once
2. Then, till the mouse is being dragged, **on_mouse_drag** is called
3. Finally, **on_mouse_release** once

Previously, on_mouse_drag event of mobject was called on every frame if the point is touching the mobject.

So, if in between dragging, the mouse point leaves the mobject radius, on_mouse_drag event of mobject is stopped.

Now, If on_mouse_press is called, all the mobjects near mouse point is stored in array. And when mouse is being dragged,
on_mouse_drag is called on all the mobjects stored earlier regardless of whether mouse point is touching the mobject or not.
And, once on_mouse_release is called, that array is cleared

This has significantly improved the interactivity involving dragging.

# Results
![DraggableMobjectsExample](https://user-images.githubusercontent.com/49190295/106261792-1423f400-6248-11eb-8738-4980cec4b19d.gif)
Now, all the interactive mobjects are responding very quickly to events.