### PR TITLE
Replace redundant CONFIG key in NumberLine

### DIFF
--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -37,7 +37,7 @@ class NumberLine(Line):
             "num_decimal_places": 0,
             "height": 0.25,
         },
-        "exclude_zero_from_default_numbers": False,
+        "numbers_to_exclude": None
     }
 
     def __init__(self, x_range=None, **kwargs):
@@ -70,7 +70,7 @@ class NumberLine(Line):
         if self.include_ticks:
             self.add_ticks()
         if self.include_numbers:
-            self.add_numbers()
+            self.add_numbers(excluding=self.numbers_to_exclude)
 
     def get_tick_range(self):
         if self.include_tip:


### PR DESCRIPTION

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Currently the key `exclude_zero_from_default_numbers` of `NumberLine` is redundant since its value is not used anywhere else (including `coordinate_systems.py`) https://github.com/3b1b/manim/blob/fe85d4e02f6935c49fb0b88eebbd492dfff2d324/manimlib/mobject/number_line.py#L40 So, passing it as an argument to `NumberLine` won't produce the desired result. This PR removes the redundancy by replacing the key `exclude_zero_from_default_numbers` with `numbers_to_exclude` (defaults to `None`), which is passed as an argument to the method `add_numbers` at this line:
https://github.com/3b1b/manim/blob/fe85d4e02f6935c49fb0b88eebbd492dfff2d324/manimlib/mobject/number_line.py#L73 So `self.add_numbers()` becomes `self.add_numbers(excluding=self.numbers_to_exclude)`
## Proposed changes

1. Replace the redundant `CONFIG` key `exclude_zero_from_default_numbers` with `numbers_to_exclude`.
2. Pass the value of replaced key `numbers_to_exclude` to the method `add_numbers` 

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
Before: 
```py
class NumberLineExcludeFail(Scene):
    def construct(self):
        self.add(
            NumberLine(
                include_numbers = True,
                exclude_zero_from_default_numbers = True
                )
            )
```
![Test](https://user-images.githubusercontent.com/64465542/106432907-6a39a700-6495-11eb-90f1-5b54cd1b28dd.png)
After:
```py
class NumberLineExcludePass(Scene):
    def construct(self):
        self.add(
            NumberLine(
                include_numbers = True,
                numbers_to_exclude = [0]
                )
            )
```

![Test](https://user-images.githubusercontent.com/64465542/106433212-e0d6a480-6495-11eb-97b9-ddc780c23471.png)
