### PR TITLE
Changed manim downloads location from default to custom_default config

### DIFF
--- a/manimlib/utils/directories.py
+++ b/manimlib/utils/directories.py
@@ -23,6 +23,9 @@ def get_text_dir():
 def get_mobject_data_dir():
     return guarantee_existence(os.path.join(get_temp_dir(), "mobject_data"))
 
+def get_downloads_dir():
+    return guarantee_existence(os.path.join(get_temp_dir(), "manim_downloads"))
+
 
 def get_output_dir():
     return guarantee_existence(get_directories()["output"])

--- a/manimlib/utils/file_ops.py
+++ b/manimlib/utils/file_ops.py
@@ -3,7 +3,6 @@ import numpy as np
 
 import validators
 import urllib.request
-import tempfile
 
 
 def add_extension_if_not_present(file_name, extension):
@@ -24,10 +23,9 @@ def find_file(file_name, directories=None, extensions=None):
     # Check if this is a file online first, and if so, download
     # it to a temporary directory
     if validators.url(file_name):
+        from manimlib.utils.directories import get_downloads_dir
         stem, name = os.path.split(file_name)
-        folder = guarantee_existence(
-            os.path.join(tempfile.gettempdir(), "manim_downloads")
-        )
+        folder = get_downloads_dir()
         path = os.path.join(folder, name)
         urllib.request.urlretrieve(file_name, path)
         return path


### PR DESCRIPTION
# Motivation
Just a minor fix!
I had configured default temporary location storage in custom_defaults.yml.
After running SurfaceExample from example_scenes.py, the earth textures were downloaded at the default system temp location rather than what was configured.

# Files Changed
1. manimlib/utils/directories.py
> Added get_downloads_dir method
2. manimlib/utils/file_ops.py
> Changed downloads folder from tempfile.gettempdir() to get_downloads_dir

# Result
Now, the SurfaceExample Scene is downloading textures in the folder configured in custom_defaults.yml rather than system default temp dir.