### PR TITLE
Converted 0 to 0.0 in sdf() and angle_between_vectors()

### DIFF
--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -51,7 +51,7 @@ float sdf(){
     float sgn = orientation * sign(v2);
     float Fp = (p.x * p.x - p.y);
     if(sgn * Fp < 0){
-        return 0;
+        return 0.0;
     }else{
         return min_dist_to_curve(uv_coords, uv_b2, bezier_degree);
     }

--- a/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
@@ -66,7 +66,7 @@ void flatten_points(in vec3[3] points, out vec2[3] flat_points){
 float angle_between_vectors(vec2 v1, vec2 v2){
     float v1_norm = length(v1);
     float v2_norm = length(v2);
-    if(v1_norm == 0 || v2_norm == 0) return 0;
+    if(v1_norm == 0 || v2_norm == 0) return 0.0;
     float dp = dot(v1, v2) / (v1_norm * v2_norm);
     float angle = acos(clamp(dp, -1.0, 1.0));
     float sn = sign(cross2d(v1, v2));


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
GLSL files viz; geom.glsl and frag.glsl has two functions angle_between_vectors and sdf. Their return type is float but returned 0(int) which caused glsl error in many gpus.

## Proposed changes
<!-- What you changed in those files -->
- Converted the 0 to 0.0 in return statement of angle_between_vectors and sdf
