### PR TITLE
Fix GraphScene and NumberLine

### DIFF
--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -99,7 +99,7 @@ class NumberLine(Line):
         return result
 
     def get_tick_marks(self):
-        return self.tick_marks
+        return self.ticks
 
     def number_to_point(self, number):
         alpha = float(number - self.x_min) / (self.x_max - self.x_min)

--- a/manimlib/scene/graph_scene.py
+++ b/manimlib/scene/graph_scene.py
@@ -82,7 +82,7 @@ class GraphScene(Scene):
         if len(self.x_labeled_nums) > 0:
             if self.exclude_zero_label:
                 self.x_labeled_nums = [x for x in self.x_labeled_nums if x != 0]
-            x_axis.add_numbers(*self.x_labeled_nums)
+            x_axis.add_numbers(self.x_labeled_nums)
         if self.x_axis_label:
             x_label = TexText(self.x_axis_label)
             x_label.next_to(
@@ -116,7 +116,7 @@ class GraphScene(Scene):
         if len(self.y_labeled_nums) > 0:
             if self.exclude_zero_label:
                 self.y_labeled_nums = [y for y in self.y_labeled_nums if y != 0]
-            y_axis.add_numbers(*self.y_labeled_nums)
+            y_axis.add_numbers(self.y_labeled_nums)
         if self.y_axis_label:
             y_label = TexText(self.y_axis_label)
             y_label.next_to(


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Fixed #1354.
Temporarily fix the problem that occurs when `GraphScene` calls `NumberLine`. 
But I am not sure if it is necessary to continue to support `GraphScene`. If needed, then more adaptive changes should be made to `GraphScene`; if not, then it should be deleted.
## Proposed changes
<!-- What you changed in those files -->
- Change `self.tick_marks` to `self.ticks`
- Do not unpack when passing the value to `add_numbers()`

## Test
<!-- How do you test your changes -->
**Code**: The code in #1354 
```python
class Plot2yLabelNumbers(GraphScene):
    CONFIG = {
        "y_min": 0,
        "y_max": 100,
        "y_axis_config": {"tick_frequency": 10},
        "y_labeled_nums": np.arange(0, 100, 10)
    }
    def construct(self):
        self.setup_axes()
        dot = Dot().move_to(self.coords_to_point(PI / 2, 20))
        func_graph = self.get_graph(lambda x: 20 * np.sin(x))
        self.add(dot,func_graph)
```
**Result**:
![Plot2yLabelNumbers](https://user-images.githubusercontent.com/44120331/106996095-38894e80-67bb-11eb-8b1e-8ffa947ab386.png)
