### PR TITLE
handle_play_like_call decorator to use functools.wraps

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -3,6 +3,7 @@ import itertools as it
 import random
 import sys
 import moderngl
+from functools import wraps
 
 import numpy as np
 
@@ -1287,6 +1288,7 @@ class Mobject(object):
     # Operations touching shader uniforms
 
     def affects_shader_info_id(func):
+        @wraps(func)
         def wrapper(self):
             for mob in self.get_family():
                 func(mob)

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -2,7 +2,7 @@ import itertools as it
 import operator as op
 import moderngl
 
-from functools import reduce
+from functools import reduce, wraps
 
 from manimlib.constants import *
 from manimlib.mobject.mobject import Mobject
@@ -807,6 +807,7 @@ class VMobject(Mobject):
         return tri_indices
 
     def triggers_refreshed_triangulation(func):
+        @wraps(func)
         def wrapper(self, *args, **kwargs):
             old_points = self.get_points()
             func(self, *args, **kwargs)

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -3,6 +3,7 @@ import random
 import platform
 import itertools as it
 import logging
+from functools import wraps
 
 from tqdm import tqdm as ProgressDisplay
 import numpy as np
@@ -372,6 +373,7 @@ class Scene(object):
         return animations
 
     def handle_play_like_call(func):
+        @wraps(func)
         def wrapper(self, *args, **kwargs):
             self.update_skipping_status()
             should_write = not self.skip_animations


### PR DESCRIPTION
this is a remake of https://github.com/3b1b/manim/pull/1204 on the current master

this way, decorated methods - typically Scene.play - have a decent docstring
so first-time users can use help()


<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->
