### PR TITLE
Fix NumberLine's unit_size

### DIFF
--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -57,6 +57,7 @@ class NumberLine(Line):
         super().__init__(self.x_min * RIGHT, self.x_max * RIGHT, **kwargs)
         if self.width:
             self.set_width(self.width)
+            self.unit_size = self.get_unit_size()
         else:
             self.scale(self.unit_size)
         self.center()
@@ -123,7 +124,7 @@ class NumberLine(Line):
         return self.point_to_number(point)
 
     def get_unit_size(self):
-        return (self.x_max - self.x_min) / self.get_length()
+        return self.get_length() / (self.x_max - self.x_min)
 
     def get_number_mobject(self, x,
                            number_config=None,


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Minor bugs concerning `unit_size` of `NumberLine`. 

1. The `get_unit_size` method 
https://github.com/3b1b/manim/blob/66817c4e2bc56f45f370498c2c93b033c1109951/manimlib/mobject/number_line.py#L125-L126 should return `self.get_length() / (self.x_max - self.x_min)`, not `(self.x_max - self.x_min) / self.get_length()`

2. If `width` is passed as an argument, the `unit_size` attribute (available via `CONFIG`) still remains 1 when it should be reset to appropriate value.
## Proposed changes
<!-- What you changed in those files -->
1. Fix the return value of `get_unit_size` method.
2. Reset the value of `unit_size` attribute if `width` is passed.  
