### PR TITLE
Fix Vector orientation in 3d

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -636,6 +636,10 @@ class Arrow(Line):
             super().scale(length / self.get_length())
 
         self.rotate(angle_of_vector(vect) - self.get_angle())
+        self.rotate(
+            PI / 2 - np.arccos(normalize(vect)[2]),
+            axis=rotate_vector(self.get_unit_vector(), -PI / 2),
+        )
         self.shift(start - self.get_start())
         self.refresh_triangulation()
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Currently `Vector`s work only in 2d. If the `direction` passed for `Vector` extends into 3d, the resulting vector still lies on the XY plane (It's a vector in the direction given by `direction[:2]`, except for those along z-axis). Same is the case with `Arrow`s.  This happens because angle of the vector above the plane (90 - phi) is not considered currently. 
https://github.com/3b1b/manim/blob/66817c4e2bc56f45f370498c2c93b033c1109951/manimlib/mobject/geometry.py#L638 This accounts only for the angle of vector from x-axis (theta). Angle of the vector from z-axis(phi) is ignored.

## Proposed changes
<!-- What you changed in those files -->

- Rotate `Arrow`s (and thus, also `Vector`s) by an angle `90-phi` above the XY plane to place them correctly in 3d.

## Test
<!-- How do you test your changes -->
**Code**:
```py
class Vectors3DIssue(ThreeDScene):
    def construct(self):
        frame = self.camera.frame
        frame.set_euler_angles(5*DEGREES, 45*DEGREES)

        from itertools import product
        points = [*product([2, -2], repeat=3), 2*OUT]
        vectors = list(map(Vector, points))

        self.add(NumberPlane(), *vectors)
        always(frame.increment_theta, 0.2 * 1 / self.camera.frame_rate)
        self.add(frame)
        self.wait(4)
```
**Result**:
- Before: 

https://user-images.githubusercontent.com/64465542/107124488-3d88f380-68ca-11eb-8717-afeccc4b5363.mp4

- After: 

https://user-images.githubusercontent.com/64465542/107124496-4aa5e280-68ca-11eb-8cfb-35c3cbff17e2.mp4

