### PR TITLE
Use ManimPango for Text rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ pyreadline; sys_platform == 'win32'
 validators
 ipython
 PyOpenGL
-pycairo
+manimpango>=0.2.0,<0.3.0'


### PR DESCRIPTION
## Motivation
Pango is a lot better at Text Rendering rather than using a Toy API for Cairo. I had discussed this with @3b1b on [Discord.](https://discord.com/channels/581738731934056449/712140817200054294/808055730639863868). This will remove the dependency on pycairo.

It also provides another method to add a font file to Pango search path, whose family name can later be called. This method isn't available for macOS yet.

I couldn't find `Code` here, that would require a small change setting `disable_ligatures`, or else colours would be broken, due to ligatures.

## Proposed changes
- requirements.txt - add manimpango
- text_mobject.py - use manimpango

## Test
Running example scenes should work, no breaking API changes. `register_font` API can be used as
```py
with register_font('roboto.ttf'):
    a=Text("Hello Roboto",font="Roboto")
```
A list of fonts visible to Pango can be got from
```py
>>> import manimpango
>>> manimpango.list_fonts()
[ ... ]
```
More API at https://manimpango.manim.community/en/latest/