### PR TITLE
Fix init of Elbow super class

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -569,7 +569,7 @@ class Elbow(VMobject):
     }
 
     def __init__(self, **kwargs):
-        super().__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.set_points_as_corners([UP, UP + RIGHT, RIGHT])
         self.set_width(self.width, about_point=ORIGIN)
         self.rotate(self.angle, about_point=ORIGIN)


### PR DESCRIPTION
## Motivation
Elbow is unusable in the master

## Proposed changes
Fixed the __init__ of Elbow

## Test
**Code**:
class ElbowExample(Scene):
    def construct(self):
        elbow = Elbow()
        self.add(elbow)
**Result**:
An Elbow is drawn