### PR TITLE
Fix typo in example_scenes.py

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -584,7 +584,7 @@ class SurfaceExample(Scene):
         self.wait()
 
 
-class InteractiveDevlopment(Scene):
+class InteractiveDevelopment(Scene):
     def construct(self):
         circle = Circle()
         circle.set_fill(BLUE, opacity=0.5)


### PR DESCRIPTION
## Motivation
My motivation was to make the ease of use better because the class would be properly named.

## Proposed changes
- The spelling of "Development"