### PR TITLE
CI: install pango so that manimpango install

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install sphinx and manim env
       run: |
         pip3 install --upgrade pip
-        sudo apt install python3-setuptools
+        sudo apt install python3-setuptools libpango1.0-dev
         pip3 install -r docs/requirements.txt
         pip3 install -r requirements.txt
     


### PR DESCRIPTION
https://github.com/ManimCommunity/ManimPango/issues/53
## Motivation
Install Pango before installing ManimPango, so that docs build.