### PR TITLE
fix issue #1480

### DIFF
--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -181,7 +181,10 @@ class Tex(SingleStringTex):
         pattern = "|".join(patterns)
         pieces = []
         for s in tex_strings:
-            pieces.extend(re.split(pattern, s))
+            if pattern:
+                pieces.extend(re.split(pattern, s))
+            else:
+                pieces.append(s)
         return list(filter(lambda s: s, pieces))
 
     def break_up_by_substrings(self):


### PR DESCRIPTION
When pattern is an empty string, text is splited one by one. If there is a "$" letter, latex will try to find another "$".