### PR TITLE
fix issue #1509

### DIFF
--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -15,7 +15,7 @@ class Window(PygletWindow):
     cursor = True
 
     def __init__(self, scene, size=(1280, 720), **kwargs):
-        super().__init__()
+        super().__init__(size=size)
         digest_config(self, kwargs)
 
         self.scene = scene


### PR DESCRIPTION
https://github.com/3b1b/manim/issues/1509 is caused by Camera.pixel_coords_to_space_coords using the default pyglet window size (1280x720) instead of the actual window size. Fixed by passing the window size to the constructor of PygletWindow.