### PR TITLE
Fix ControlsExample Scene

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -660,7 +660,9 @@ class ControlsExample(Scene):
                 )
             else:
                 new_text.set_opacity(0)
+            old_text.suspend_updating(recurse=False)
             old_text.become(new_text)
+            old_text.resume_updating(recurse=False, call_updater=False)
 
         text.add_updater(text_updater)
 

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -646,7 +646,7 @@ class ControlsExample(Scene):
         self.add(self.panel)
 
     def construct(self):
-        text = Text("", size=2)
+        text = Text("text", size=2)
 
         def text_updater(old_text):
             assert(isinstance(old_text, Text))

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -660,9 +660,7 @@ class ControlsExample(Scene):
                 )
             else:
                 new_text.set_opacity(0)
-            old_text.suspend_updating(recurse=False)
             old_text.become(new_text)
-            old_text.resume_updating(recurse=False, call_updater=False)
 
         text.add_updater(text_updater)
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -56,9 +56,7 @@ class Mobject(object):
         # Must match in attributes of vert shader
         "shader_dtype": [
             ('point', np.float32, (3,)),
-        ],
-        # Event listener
-        "listen_to_events": False
+        ]
     }
 
     def __init__(self, **kwargs):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -514,7 +514,6 @@ class Mobject(object):
         return self
 
     def clear_updaters(self, recurse=True):
-        self.suspend_updating(recurse)
         self.time_based_updaters = []
         self.non_time_updaters = []
         self.refresh_has_updater_status()

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -516,6 +516,7 @@ class Mobject(object):
         return self
 
     def clear_updaters(self, recurse=True):
+        self.suspend_updating(recurse)
         self.time_based_updaters = []
         self.non_time_updaters = []
         self.refresh_has_updater_status()


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Fixes https://github.com/3b1b/manim/issues/1385 issue (ControlsExample Scene)

## Proposed changes
<!-- What you changed in those files -->
1. Add `self.suspend_updating(recurse)` line back to `Mobject.clear_updaters` function
(This was removed back in https://github.com/3b1b/manim/commit/d7f3f5ad24b22ed7bc85ee27df03319498fa863f commit which fixed https://github.com/3b1b/manim/issues/1378 issue)
2. Unrelated to ControlsExample Scene, Remove unused `listen_to_events` `CONFIG` of `Mobject` which I added during Interactive Mobjects development but never used it! (https://github.com/3b1b/manim/pull/1323, https://github.com/3b1b/manim/pull/1326, https://github.com/3b1b/manim/pull/1335)

## Comments
I am not sure of the consequences of the first change. Since it was intentionally removed before to fix the https://github.com/3b1b/manim/issues/1378 issue, please check whether it is the right way of solving this issue.