### PR TITLE
Scale Text Correctly

### DIFF
--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -19,7 +19,7 @@ from manimpango import PangoUtils
 from manimpango import TextSetting
 
 TEXT_MOB_SCALE_FACTOR = 1/100
-
+DEFAULT_LINE_SPACING_SCALE = 0.3
 
 class Text(SVGMobject):
     CONFIG = {
@@ -55,7 +55,7 @@ class Text(SVGMobject):
             )
             self.font_size = self.size
         if self.lsh == -1:
-            self.lsh = self.font_size + self.font_size * 0.3
+            self.lsh = self.font_size + self.font_size * DEFAULT_LINE_SPACING_SCALE
         else:
             self.lsh = self.font_size + self.font_size * self.lsh
         text_without_tabs = text

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 import re
 import typing
+import warnings
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -17,7 +18,7 @@ from manimlib.utils.directories import get_downloads_dir, get_text_dir
 from manimpango import PangoUtils
 from manimpango import TextSetting
 
-TEXT_MOB_SCALE_FACTOR = 0.001048
+TEXT_MOB_SCALE_FACTOR = 1/100
 
 
 class Text(SVGMobject):
@@ -30,7 +31,7 @@ class Text(SVGMobject):
         "font": '',
         "gradient": None,
         "lsh": -1,
-        "size": 1,
+        "size": None,
         "font_size": 48,
         "tab_width": 4,
         "slant": NORMAL,
@@ -46,7 +47,17 @@ class Text(SVGMobject):
     def __init__(self, text, **config):
         self.full2short(config)
         digest_config(self, config)
-        self.lsh = self.size if self.lsh == -1 else self.lsh
+        if self.size:
+            warnings.warn(
+                "self.size has been deprecated and will "
+                "be removed in future.",
+                DeprecationWarning
+            )
+            self.font_size = self.size
+        if self.lsh == -1:
+            self.lsh = self.font_size + self.font_size * 0.3
+        else:
+            self.lsh = self.font_size + self.font_size * self.lsh
         text_without_tabs = text
         if text.find('\t') != -1:
             text_without_tabs = text.replace('\t', ' ' * self.tab_width)
@@ -67,7 +78,7 @@ class Text(SVGMobject):
 
         # anti-aliasing
         if self.height is None:
-            self.scale(TEXT_MOB_SCALE_FACTOR * self.font_size)
+            self.scale(TEXT_MOB_SCALE_FACTOR)
 
     def remove_empty_path(self, file_name):
         with open(file_name, 'r') as fpr:
@@ -144,7 +155,7 @@ class Text(SVGMobject):
     def text2hash(self):
         settings = self.font + self.slant + self.weight
         settings += str(self.t2f) + str(self.t2s) + str(self.t2w)
-        settings += str(self.lsh) + str(self.size)
+        settings += str(self.lsh) + str(self.font_size)
         id_str = self.text + settings
         hasher = hashlib.sha256()
         hasher.update(id_str.encode())
@@ -198,8 +209,8 @@ class Text(SVGMobject):
 
     def text2svg(self):
         # anti-aliasing
-        size = self.size * 10
-        lsh = self.lsh * 10
+        size = self.font_size
+        lsh = self.lsh
 
         if self.font == '':
             self.font = get_customization()['style']['font']
@@ -210,8 +221,8 @@ class Text(SVGMobject):
         if os.path.exists(file_name):
             return file_name
         settings = self.text2settings()
-        width = 600
-        height = 400
+        width = DEFAULT_PIXEL_WIDTH
+        height = DEFAULT_PIXEL_HEIGHT
         disable_liga = self.disable_ligatures
         return manimpango.text2svg(
             settings,


### PR DESCRIPTION
## Motivation
`Text` wasn't scaled correctly previous with https://github.com/3b1b/manim/pull/1383

Closes #1497.
Closes #1533.

## Proposed changes
Change `TEXT_MOB_SCALE_FACTOR` value
Also deprecate `size` parameter

Also, now text isn't scaled when increasing font size
instead it is passed to the underlying enging
for handling. Though always a Text object is scaled
with a default value so that it fits the screen.

## Test

Locally I get the following with this scene. It would nice if others test this.
**Code**:
```py
from manimlib import *

ipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
class TextExample(Scene):
    def fade_out_in(self, m , m1):
        self.play(FadeOut(m),FadeIn(m1),run_time=3)
    def construct(self):
        t = Text("Hello World")
        t1 = Text("Hello World \n new line")
        t2 = Text("Hello Cursive", font="Cursive")
        t3 = Text("Hello Cursive", font="Cursive", t2c = {'Hello':RED})
        t4 = Text("Hello Cursive", font="Cursive", t2c = {'Hello':RED,'Cursive':BLUE})
        t5 = Text("Hello Cursive", font="Cursive", t2c = {'Hello':RED,'Cursive':BLUE}, font_size=60)        
        t6 = Text(ipsum, font_size=30).scale(.7)
        self.add(t)
        self.fade_out_in(t,t1)
        self.fade_out_in(t1,t2)
        self.fade_out_in(t2,t3)
        self.fade_out_in(t3,t4)
        self.fade_out_in(t4,t5)
        self.fade_out_in(t5,t6)
```

**Result**:

https://user-images.githubusercontent.com/49693820/122561514-95e1b600-d05f-11eb-8367-54530dbe8abc.mp4

