### PR TITLE
Transition build method to PEP 517

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,12 +19,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
     
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft manimlib
+recursive-exclude manimlib *.pyc *.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,43 @@
 [metadata]
 name = manimgl
+version = 1.0.1
 author = Grant Sanderson
-author-email= grant@3blue1brown.com
-summary = Animation engine for explanatory math videos
-description-file = README.md
-description-content-type = text/markdown; charset=UTF-8
-home-page = https://github.com/3b1b/manim
+author_email= grant@3blue1brown.com
+description = Animation engine for explanatory math videos
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+home_page = https://github.com/3b1b/manim
 project_urls =
     Bug Tracker = https://github.com/3b1b/manim/issues
     Documentation = https://3b1b.github.io/manim/
     Source Code = https://github.com/3b1b/manim
 license = MIT
 
-[files]
-packages = manimlib
-extra_files = requirements.txt
+[options]
+packages = find:
+include_package_data=True
+install_requires = 
+    argparse
+    colour
+    numpy
+    Pillow
+    scipy
+    sympy
+    tqdm
+    mapbox-earcut
+    matplotlib
+    moderngl
+    moderngl_window
+    pydub
+    pyyaml
+    screeninfo
+    pyreadline; sys_platform == 'win32'
+    validators
+    ipython
+    PyOpenGL
+    manimpango>=0.2.0,<0.4.0
 
-[entry_points]
+[options.entry_points]
 console_scripts =
     manimgl = manimlib.__main__:main
     manim-render = manimlib.__main__:main

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-
-from setuptools import setup
-
-setup(
-    setup_requires=['pbr'],
-    pbr=True,
-)


### PR DESCRIPTION
## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Because manim always use `pbr` for setup, which needs to automatically obtain the version from the `.git/` folder. This leads to the issues of #1390 #1403 that cannot be installed from the `.zip` file.
So I transitioned to the method of using `pyproject.toml` and `setup.cfg` to build, which is also recommended by `setuptools`.

## Proposed changes
<!-- What you changed in those files -->
- D `setup.py`
- M `setup.cfg`
- N `pyproject.toml`
- N `MANIFEST.in`

## Test
<!-- How do you test your changes -->
https://test.pypi.org/project/manimgl/