### PR TITLE
Add frame to the scene when initialization

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -50,7 +50,7 @@ class Scene(object):
 
         self.camera = self.camera_class(**self.camera_config)
         self.file_writer = SceneFileWriter(self, **self.file_writer_config)
-        self.mobjects = []
+        self.mobjects = [self.camera.frame]
         self.num_plays = 0
         self.time = 0
         self.skip_time = 0


### PR DESCRIPTION
If we add an updater to the frame of the camera, and have not added the frame into the scene before, the updater will not work. So, I suggest to add the frame to the objects of the scene at the initilization stage.