### PR TITLE
Minor fix for zooming

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -570,7 +570,7 @@ class Scene(object):
         frame = self.camera.frame
         if self.window.is_key_pressed(ord("z")):
             factor = 1 + np.arctan(10 * offset[1])
-            frame.scale(factor, about_point=point)
+            frame.scale(1/factor, about_point=point)
         else:
             transform = frame.get_inverse_camera_rotation_matrix()
             shift = np.dot(np.transpose(transform), offset)


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
It's weird that when you Scroll Up, the interactive shell zooms out, this is generally the other way round for most of the UI's.

## Proposed changes
<!-- What you changed in those files -->
Simply replace factor -> 1 / factor. 
