### PR TITLE
Improve `Mobject.scale`

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -561,7 +561,7 @@ class Mobject(object):
         )
         return self
 
-    def scale(self, scale_factor, min_scale_factor=1e-8, **kwargs):
+    def scale(self, scale_factor, min_scale_factor=1e-8, about_point=None, about_edge=ORIGIN, recurse=True):
         """
         Default behavior is to scale about the center of the mobject.
         The argument about_edge can be a vector, indicating which side of
@@ -572,11 +572,18 @@ class Mobject(object):
         respect to that point.
         """
         scale_factor = max(scale_factor, min_scale_factor)
-        self.apply_points_function(
-            lambda points: scale_factor * points,
-            works_on_bounding_box=True,
-            **kwargs
-        )
+        if about_point is None and about_edge is not None:
+            about_point = self.get_bounding_box_point(about_edge)
+        if recurse:
+            for submob in self.submobjects:
+                submob.scale(scale_factor, about_point=about_point, recurse=True)
+        if not self.submobjects:
+            self.apply_points_function(
+                lambda points: scale_factor * points,
+                works_on_bounding_box=True,
+                about_point=about_point,
+                about_edge=about_edge
+            )
         return self
 
     def stretch(self, factor, dim, **kwargs):


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Previous `Mobject.scale` method doesn't use overrided method, which causes some problems when scaling a VGroup:

**Code**:
```python
class Code(Scene):
    def construct(self):
        num = VGroup(
            DecimalNumber(1), 
            Text("foo")
        ).scale(4).arrange(RIGHT)
        self.add(num)
        self.play(num[0].animate.set_value(2))
```
**Output**:

https://user-images.githubusercontent.com/44120331/127976196-03ea964f-3cf5-4260-afa0-6da174f4ce28.mp4

Because `DecimalNumber` override `scale` method to change the `font_size` attribute.

This PR is implemented by recursively calling `scale` method on the submobjects of the current mobject.

## Proposed changes
<!-- What you changed in those files -->
- M `manimlib/mobject/mobject.py`: rewrote `scale` method

## Test
<!-- How do you test your changes -->
**Code**:
```python
class Code(Scene):
    def construct(self):
        num = VGroup(
            DecimalNumber(1), 
            Text("foo")
        ).scale(4).arrange(RIGHT)
        self.add(num)
        self.play(num[0].animate.set_value(2))
```
**Result**:

https://user-images.githubusercontent.com/44120331/127976835-cd7c9246-fb4e-4f1b-b9b2-05040d3c88b1.mp4

