### PR TITLE
Typo fix in UpdatersExample

### DIFF
--- a/docs/source/getting_started/example_scenes.rst
+++ b/docs/source/getting_started/example_scenes.rst
@@ -335,7 +335,7 @@ UpdatersExample
             # If the argument itself might change, you can use f_always,
             # for which the arguments following the initial Mobject method
             # should be functions returning arguments to that method.
-            # The following line ensures thst decimal.set_value(square.get_y())
+            # The following line ensures that decimal.set_value(square.get_y())
             # is called every frame
             f_always(number.set_value, square.get_width)
             # You could also write the following equivalent line


### PR DESCRIPTION
## Motivation
Fixed a documentation typo in updatersExample section under Example Scenes section . 

## Proposed changes
The following change was made in example_scenes.rst file . 
- In line 338 , I have fixed a trivial typo which may mislead the readers  (thst -> that).

## Test
No explicit testing was done for a typo fix in  documentation as It'll be reflected as expected without any issues.

**Result**: The typo is fixed for better.