### PR TITLE
Update comments in example.py

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -2,7 +2,7 @@ from manimlib import *
 import numpy as np
 
 # To watch one of these scenes, run the following:
-# python -m manim example_scenes.py SquareToCircle
+# manimgl example_scenes.py OpeningManimExample
 # Use -s to skip to the end and just save the final frame
 # Use -w to write the animation to a file
 # Use -o to write it to a file and open it once done


### PR DESCRIPTION
updated the cmd command line to "manimgl example_scenes.py OpeningManimExample" instead of "python -m manim", which the latter one was used for cairo-backend manim version instead of the current manimgl
