### PR TITLE
Fix the bug of rotating camera

### DIFF
--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -66,8 +66,8 @@ class CameraFrame(Mobject):
         curr_rot_T = self.get_inverse_camera_rotation_matrix()
         added_rot_T = rotation_matrix_transpose(angle, axis)
         new_rot_T = np.dot(curr_rot_T, added_rot_T)
-        Fz = clip(new_rot_T[2], -1, 1)
-        phi = np.arccos(Fz[2])
+        Fz = new_rot_T[2]
+        phi = np.arccos(clip(Fz[2], -1, 1))
         theta = angle_of_vector(Fz[:2]) + PI / 2
         partial_rot_T = np.dot(
             rotation_matrix_transpose(phi, RIGHT),


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Problem
<!-- Outline your motivation: In what way do your changes improve the library? -->

I'd like to rotate the camera frame in one scene but something was wrong. It turned out to that the value of `new_rot_T[2]` went beyond [-1,1], which is fatal for the arccos function. The problem was probably caused by loss of precision in float calculation. 

## Proposed changes
<!-- What you changed in those files -->
As a result, `clip` function is called before `Fz` is passed into `acos`. 
