### PR TITLE
 Overridden add operations for mobjects

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1597,7 +1597,7 @@ class Group(Mobject):
         self.add(*mobjects)
         
     def __add__(self, other : 'Mobject' or 'Group'):
-        assert(isinstance(other(Mobject))
+        assert(isinstance(other, Mobject))
         return self.add(other)
 
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -83,7 +83,7 @@ class Mobject(object):
         return self.__class__.__name__
 
     def __add__(self, other : 'Mobject'):
-        return Group(self, other)
+        return self.get_group_class(self, other)
 
     def __mul__(self, other : 'int'):
         return self.replicate(other)

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -84,7 +84,7 @@ class Mobject(object):
 
     def __add__(self, other : 'Mobject') -> 'Mobject':
         assert(isinstance(other, Mobject))
-        return self.get_group_class(self, other)
+        return self.get_group_class()(self, other)
 
     def __mul__(self, other : 'int') -> 'Mobject':
         assert(isinstance(other, int))

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1596,6 +1596,15 @@ class Group(Mobject):
             raise Exception("All submobjects must be of type Mobject")
         Mobject.__init__(self, **kwargs)
         self.add(*mobjects)
+    def __add__(self, other : 'Mobject' or 'Group'):
+        assert(isinstance(other, Mobject))
+        if other in self:
+            return Group(*self, other.copy())
+        if isinstance(other, (Group, VGroup)):
+            if all([isinstance(i, VMobject) for i in Group(*self, *other)]):
+                return VGroup(*self, *other)
+            return Group(*self, *other)
+        return Group(*self, other)
 
 
 class Point(Mobject):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -87,8 +87,9 @@ class Mobject(object):
         return Group(self, other)
 
     def __mul__(self, other : 'int'):
+        from manimlib.mobject.types.vectorized_mobject import VMobject, VGroup
         if isinstance(self, VMobject):
-            return VGroup(*[mob.copy() for mob in range(other)])
+            return VGroup(*[self.copy() for i in range(other)])
         return Group(*[mob.copy() for mob in range(other)])
 
     def init_data(self):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1594,14 +1594,7 @@ class Group(Mobject):
         Mobject.__init__(self, **kwargs)
         self.add(*mobjects)
     def __add__(self, other : 'Mobject' or 'Group'):
-        assert(isinstance(other, Mobject))
-        if other in self:
-            return Group(*self, other.copy())
-        if isinstance(other, (Group, VGroup)):
-            if all([isinstance(i, VMobject) for i in Group(*self, *other)]):
-                return VGroup(*self, *other)
-            return Group(*self, *other)
-        return Group(*self, other)
+        return self.add(other)
 
 
 class Point(Mobject):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1595,7 +1595,9 @@ class Group(Mobject):
             raise Exception("All submobjects must be of type Mobject")
         Mobject.__init__(self, **kwargs)
         self.add(*mobjects)
+        
     def __add__(self, other : 'Mobject' or 'Group'):
+        assert(isinstance(other(Mobject))
         return self.add(other)
 
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -82,10 +82,12 @@ class Mobject(object):
     def __str__(self):
         return self.__class__.__name__
 
-    def __add__(self, other : 'Mobject'):
+    def __add__(self, other : 'Mobject') -> 'Mobject':
+        assert(isinstance(other, Mobject))
         return self.get_group_class(self, other)
 
-    def __mul__(self, other : 'int'):
+    def __mul__(self, other : 'int') -> 'Mobject':
+        assert(isinstance(other, int))
         return self.replicate(other)
 
     def init_data(self):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -82,6 +82,15 @@ class Mobject(object):
     def __str__(self):
         return self.__class__.__name__
 
+    def __add__(self, other : 'Mobject'):
+        assert(isinstance(other, Mobject))
+        return Group(self, other)
+
+    def __mul__(self, other : 'int'):
+        if isinstance(self, VMobject):
+            return VGroup(*[mob.copy() for mob in range(other)])
+        return Group(*[mob.copy() for mob in range(other)])
+
     def init_data(self):
         self.data = {
             "points": np.zeros((0, 3)),

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -83,14 +83,10 @@ class Mobject(object):
         return self.__class__.__name__
 
     def __add__(self, other : 'Mobject'):
-        assert(isinstance(other, Mobject))
         return Group(self, other)
 
     def __mul__(self, other : 'int'):
-        from manimlib.mobject.types.vectorized_mobject import VMobject, VGroup
-        if isinstance(self, VMobject):
-            return VGroup(*[self.copy() for i in range(other)])
-        return Group(*[mob.copy() for mob in range(other)])
+        return self.replicate(other)
 
     def init_data(self):
         self.data = {

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -993,6 +993,16 @@ class VGroup(VMobject):
             raise Exception("All submobjects must be of type VMobject")
         super().__init__(**kwargs)
         self.add(*vmobjects)
+    
+    def __add__(self:'VGroup', other : 'VMobject' or 'VGroup'):
+        assert(isinstance(other, VMobject))
+        if isinstance(other, VGroup):
+            return VGroup(*self, *other)
+        if isinstance(other, Mobject):
+            return Group(*self) + other
+        if other in self:
+            return self.add(other.copy())
+        return self.add(other)
 
 
 class VectorizedPoint(Point, VMobject):

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -75,6 +75,10 @@ class VMobject(Mobject):
         self.triangulation = np.zeros(0, dtype='i4')
         super().__init__(**kwargs)
         self.refresh_unit_normal()
+        
+    def __add__(self, other : 'VMobject') -> VGroup:
+        assert(isinstance(other, VMobject))
+        return VGroup(self, other)
 
     def get_group_class(self):
         return VGroup

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -75,10 +75,6 @@ class VMobject(Mobject):
         self.triangulation = np.zeros(0, dtype='i4')
         super().__init__(**kwargs)
         self.refresh_unit_normal()
-        
-    def __add__(self, other : 'VMobject') -> 'VGroup':
-        assert(isinstance(other, VMobject))
-        return VGroup(self, other)
 
     def get_group_class(self):
         return VGroup

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -991,6 +991,7 @@ class VGroup(VMobject):
         self.add(*vmobjects)
     
     def __add__(self:'VGroup', other : 'VMobject' or 'VGroup'):
+        assert(isinstance(other, VMobject))
         return self.add(other)
 
 

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -995,13 +995,6 @@ class VGroup(VMobject):
         self.add(*vmobjects)
     
     def __add__(self:'VGroup', other : 'VMobject' or 'VGroup'):
-        assert(isinstance(other, VMobject))
-        if isinstance(other, VGroup):
-            return VGroup(*self, *other)
-        if isinstance(other, Mobject):
-            return Group(*self) + other
-        if other in self:
-            return self.add(other.copy())
         return self.add(other)
 
 

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -76,7 +76,7 @@ class VMobject(Mobject):
         super().__init__(**kwargs)
         self.refresh_unit_normal()
         
-    def __add__(self, other : 'VMobject') -> VGroup:
+    def __add__(self, other : 'VMobject') -> 'VGroup':
         assert(isinstance(other, VMobject))
         return VGroup(self, other)
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
- To make combining mobjects to a Group of mobjects and adding mobjects to a group more convenient. 


## Proposed changes
<!-- What you changed in those files -->
- In file mobject.py, added __add__ function and __mul__ dunder function for Mobject, returning a Group type accordingly
- In file vectorized_mobject,py, added __add__ dunder function
- 

## Test
<!-- How do you test your changes -->
**Code**:
```python
class testscene(Scene):
    def construct(self):
        cir = Circle()
        sq = Square()
        group1 = (cir*6).arrange_in_grid(2, 3)
        print(type(group1))
        self.add(group1)
        group2 = (cir+sq).move_to(DOWN)
        self.add(group2)
        print(type(group2))
```

**Result**:
```
<class 'manimlib.mobject.types.vectorized_mobject.VGroup'>
<class 'manimlib.mobject.types.vectorized_mobject.VGroup'>
```