### PR TITLE
Add option to add ticks on x-axis in BarChart()

### DIFF
--- a/manimlib/mobject/probability.py
+++ b/manimlib/mobject/probability.py
@@ -8,6 +8,7 @@ from manimlib.mobject.svg.tex_mobject import TexText
 from manimlib.mobject.types.vectorized_mobject import VGroup
 from manimlib.utils.color import color_gradient
 from manimlib.utils.iterables import listify
+from numpy import ndarray
 
 EPSILON = 0.0001
 
@@ -149,7 +150,9 @@ class BarChart(VGroup):
         "height": 4,
         "width": 6,
         "n_ticks": 4,
+        "include_x_ticks": False,
         "tick_width": 0.2,
+        "tick_width_x": 0.15,
         "label_y_axis": True,
         "y_axis_label_height": 0.25,
         "max_value": 1,
@@ -165,6 +168,7 @@ class BarChart(VGroup):
         if self.max_value is None:
             self.max_value = max(values)
 
+        self.n_ticks_x = len(values)
         self.add_axes()
         self.add_bars(values)
         self.center()
@@ -182,6 +186,17 @@ class BarChart(VGroup):
             ticks.add(tick)
         y_axis.add(ticks)
 
+        if self.include_x_ticks == True:
+            ticks1 = VGroup()
+            widths = np.linspace(0, self.width, self.n_ticks_x + 1)
+            label_values = np.linspace(0, len(self.bar_names), self.n_ticks_x + 1)
+            for x, value in zip(widths, label_values):
+                tick1 = Line(UP*0.05, DOWN*0.05)
+                tick1.set_width(self.tick_width_x)
+                tick1.move_to(x * RIGHT)
+                ticks.add(tick1)
+            x_axis.add(ticks1)
+
         self.add(x_axis, y_axis)
         self.x_axis, self.y_axis = x_axis, y_axis
 
@@ -196,7 +211,7 @@ class BarChart(VGroup):
             self.add(labels)
 
     def add_bars(self, values):
-        buff = float(self.width) / (2 * len(values) + 1)
+        buff = float(self.width) / (2 * len(values))
         bars = VGroup()
         for i, value in enumerate(values):
             bar = Rectangle(
@@ -205,7 +220,7 @@ class BarChart(VGroup):
                 stroke_width=self.bar_stroke_width,
                 fill_opacity=self.bar_fill_opacity,
             )
-            bar.move_to((2 * i + 1) * buff * RIGHT, DOWN + LEFT)
+            bar.move_to((2 * i + 0.5) * buff * RIGHT, DOWN + LEFT * 5)
             bars.add(bar)
         bars.set_color_by_gradient(*self.bar_colors)
 

--- a/manimlib/mobject/probability.py
+++ b/manimlib/mobject/probability.py
@@ -175,35 +175,36 @@ class BarChart(VGroup):
     def add_axes(self):
         x_axis = Line(self.tick_width * LEFT / 2, self.width * RIGHT)
         y_axis = Line(MED_LARGE_BUFF * DOWN, self.height * UP)
-        ticks = VGroup()
+        y_ticks = VGroup()
         heights = np.linspace(0, self.height, self.n_ticks + 1)
         values = np.linspace(0, self.max_value, self.n_ticks + 1)
         for y, value in zip(heights, values):
-            tick = Line(LEFT, RIGHT)
-            tick.set_width(self.tick_width)
-            tick.move_to(y * UP)
-            ticks.add(tick)
-        y_axis.add(ticks)
+            y_tick = Line(LEFT, RIGHT)
+            y_tick.set_width(self.tick_width)
+            y_tick.move_to(y * UP)
+            y_ticks.add(y_tick)
+        y_axis.add(y_ticks)
 
         if self.include_x_ticks == True:
+            x_ticks = VGroup()
             widths = np.linspace(0, self.width, self.n_ticks_x + 1)
             label_values = np.linspace(0, len(self.bar_names), self.n_ticks_x + 1)
             for x, value in zip(widths, label_values):
-                tick1 = Line(UP, DOWN)
-                tick1.set_height(self.tick_height)
-                tick1.move_to(x * RIGHT)
-                ticks.add(tick)
-            x_axis.add(ticks)
+                x_tick = Line(UP, DOWN)
+                x_tick.set_height(self.tick_height)
+                x_tick.move_to(x * RIGHT)
+                x_ticks.add(x_tick)
+            x_axis.add(x_ticks)
 
         self.add(x_axis, y_axis)
         self.x_axis, self.y_axis = x_axis, y_axis
 
         if self.label_y_axis:
             labels = VGroup()
-            for tick, value in zip(ticks, values):
+            for y_tick, value in zip(y_ticks, values):
                 label = Tex(str(np.round(value, 2)))
                 label.set_height(self.y_axis_label_height)
-                label.next_to(tick, LEFT, SMALL_BUFF)
+                label.next_to(y_tick, LEFT, SMALL_BUFF)
                 labels.add(label)
             self.y_axis_labels = labels
             self.add(labels)

--- a/manimlib/mobject/probability.py
+++ b/manimlib/mobject/probability.py
@@ -8,7 +8,6 @@ from manimlib.mobject.svg.tex_mobject import TexText
 from manimlib.mobject.types.vectorized_mobject import VGroup
 from manimlib.utils.color import color_gradient
 from manimlib.utils.iterables import listify
-from numpy import ndarray
 
 EPSILON = 0.0001
 
@@ -152,7 +151,7 @@ class BarChart(VGroup):
         "n_ticks": 4,
         "include_x_ticks": False,
         "tick_width": 0.2,
-        "tick_width_x": 0.15,
+        "tick_height": 0.15,
         "label_y_axis": True,
         "y_axis_label_height": 0.25,
         "max_value": 1,
@@ -187,15 +186,14 @@ class BarChart(VGroup):
         y_axis.add(ticks)
 
         if self.include_x_ticks == True:
-            ticks1 = VGroup()
             widths = np.linspace(0, self.width, self.n_ticks_x + 1)
             label_values = np.linspace(0, len(self.bar_names), self.n_ticks_x + 1)
             for x, value in zip(widths, label_values):
-                tick1 = Line(UP*0.05, DOWN*0.05)
-                tick1.set_width(self.tick_width_x)
+                tick1 = Line(UP, DOWN)
+                tick1.set_height(self.tick_height)
                 tick1.move_to(x * RIGHT)
-                ticks.add(tick1)
-            x_axis.add(ticks1)
+                ticks.add(tick)
+            x_axis.add(ticks)
 
         self.add(x_axis, y_axis)
         self.x_axis, self.y_axis = x_axis, y_axis


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
It's only a minor change. I found out that BarChart() doesn't have an option to add ticks on x-axis. I know it's because the x-axis is usually for names or labels and not values, but I think it's nice to add an option to add ticks to seperate bars for better visualization.

## Proposed changes
<!-- What you changed in those files -->
- I looked up at how manim add ticks on y-axis and created an option for people to also add ticks to the x-axis
- I added a config parameter "include-x-ticks"
- The number of ticks divided is also the number of values

## Test
<!-- How do you test your changes -->
**Code**:
```py 
from manimlib import *

class Test(Scene):
    def construct(self):
        global chart
        bar_value = [50]*10
        chart = BarChart(
            bar_value,
            label_y_axis = True,
            n_ticks = 10,
            max_value = 100,
            bar_label_scale_val = 0.5,
            include_x_ticks = True
        )
        self.add(chart)
```

**Result**
![Test](https://user-images.githubusercontent.com/88956865/146397175-b2e688ba-2f03-423d-85c5-b8e5c73ed8d8.png)
: