### PR TITLE
removed extra 'all' from comments

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -274,7 +274,7 @@ class UpdatersExample(Scene):
         square = Square()
         square.set_fill(BLUE_E, 1)
 
-        # On all all frames, the constructor Brace(square, UP) will
+        # On all frames, the constructor Brace(square, UP) will
         # be called, and the mobject brace will set its data to match
         # that of the newly constructed object
         brace = always_redraw(Brace, square, UP)


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
fixed typo in comments
## Proposed changes
<!-- What you changed in those files -->
- remove an extra 'all'
- 
- 

## Test
<!-- How do you test your changes -->
**Code**:

**Result**: