### PR TITLE
Adding "label_buff" config parameter for Brace

### DIFF
--- a/manimlib/mobject/svg/brace.py
+++ b/manimlib/mobject/svg/brace.py
@@ -88,6 +88,7 @@ class BraceLabel(VMobject):
     CONFIG = {
         "label_constructor": Tex,
         "label_scale": 1,
+        "lable_buff": DEFAULT_MOBJECT_TO_MOBJECT_BUFFER  
     }
 
     def __init__(self, obj, text, brace_direction=DOWN, **kwargs):
@@ -104,7 +105,7 @@ class BraceLabel(VMobject):
         if self.label_scale != 1:
             self.label.scale(self.label_scale)
 
-        self.brace.put_at_tip(self.label)
+        self.brace.put_at_tip(self.label, buff=self.lable_buff)
         self.set_submobjects([self.brace, self.label])
 
     def creation_anim(self, label_anim=FadeIn, brace_anim=GrowFromCenter):

--- a/manimlib/mobject/svg/brace.py
+++ b/manimlib/mobject/svg/brace.py
@@ -1,5 +1,6 @@
 import numpy as np
 import math
+import copy
 
 from manimlib.animation.composition import AnimationGroup
 from manimlib.constants import *

--- a/manimlib/mobject/svg/brace.py
+++ b/manimlib/mobject/svg/brace.py
@@ -88,7 +88,7 @@ class BraceLabel(VMobject):
     CONFIG = {
         "label_constructor": Tex,
         "label_scale": 1,
-        "lable_buff": DEFAULT_MOBJECT_TO_MOBJECT_BUFFER  
+        "label_buff": DEFAULT_MOBJECT_TO_MOBJECT_BUFFER  
     }
 
     def __init__(self, obj, text, brace_direction=DOWN, **kwargs):
@@ -105,7 +105,7 @@ class BraceLabel(VMobject):
         if self.label_scale != 1:
             self.label.scale(self.label_scale)
 
-        self.brace.put_at_tip(self.label, buff=self.lable_buff)
+        self.brace.put_at_tip(self.label, buff=self.label_buff)
         self.set_submobjects([self.brace, self.label])
 
     def creation_anim(self, label_anim=FadeIn, brace_anim=GrowFromCenter):


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
-When adding a Brace Label, I can adjust the label scale and the buff between the brace and the mobject adding to. However, I can not adjust the buff between the label and the brace, which would make the distance disproportional. 

-Directly using ```brace.scale()``` does not work either, as this will change the length of the brace as well.

-Meanwhile, directly passing in the argument ```buff=value``` as keyword argument will set the buff between the target mobject and the brace only. And since both methods (```Brace.CONFIG``` and ```Brace.put_at_tip```) use the ```buff``` keyword argument, therefore, to allow different values can be passed in for "mobject-brace buff" and "brace-label buff", this parameter is clarified as ```label_buff```.
```python
brace1 = BraceLabel(dl1, 'r', UP, label_scale=0.35, font_size=30, buff=0.1)
```
For example, the code above will result in 
![image](https://user-images.githubusercontent.com/86190295/147906016-e18d56ea-20b3-4221-befc-cf2c686bdbe5.png)
Which in this case the small 'r' is clearly too far away from the brace.

## Proposed changes
<!-- What you changed in those files -->
- In file manimlib.mobject.svg.brace.py, class BraceLable, added parameter ```label_buff``` in the CONFIG
- In Line 108, pass in the parameter ```buff=self.label_buff``` for put_at_top method
- Added import copy at the beginning

## Test
<!-- How do you test your changes -->
**Code**:
```python
brace1 = BraceLabel(dl1, 'r', UP, label_scale=0.35, font_size=30, buff=0.1, label_buff=0.1)
```
**Result**:
![image](https://user-images.githubusercontent.com/86190295/147906094-bccc3362-7548-41a1-aaeb-46620a1303a7.png)


In addition, the previous version was missing an importation
*before*
<img width="650" alt="f6cffa48c2608c43789a0e864f0db5d" src="https://user-images.githubusercontent.com/86190295/147912845-84160e52-f9d7-4113-b388-fa87cffb7edc.png">
*after*
![image](https://user-images.githubusercontent.com/86190295/147912827-4b2bc43b-f132-4e54-ab76-8c123affdb51.png)

