### PR TITLE
Fix "Code is unreachable Pylance" warning for NumberPlane

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import numpy as np
 import numbers
 
@@ -51,13 +52,15 @@ class CoordinateSystem():
     def p2c(self, point):
         """Abbreviation for point_to_coords"""
         return self.point_to_coords(point)
-
+    
     def get_origin(self):
         return self.c2p(*[0] * self.dimension)
-
+    
+    @abstractmethod
     def get_axes(self):
         raise Exception("Not implemented")
 
+    @abstractmethod
     def get_all_ranges(self):
         raise Exception("Not implemented")
 
@@ -333,6 +336,18 @@ class Axes(VGroup, CoordinateSystem):
 
     def get_axes(self):
         return self.axes
+    
+    def get_axis(self, index):
+        return self.get_axes()[index]
+
+    def get_x_axis(self):
+        return self.get_axis(0)
+
+    def get_y_axis(self):
+        return self.get_axis(1)
+
+    def get_z_axis(self):
+        return self.get_axis(2)
 
     def get_all_ranges(self):
         return [self.x_range, self.y_range]


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

- After initializing a ```NumberPlane``` object, the code area below will be marked as "unreachable" by Pylance
- This grey out the code and disables syntax highlighting
<img width="482" alt="8df6ec7f74f4c701fa4e3b5e3058afa" src="https://user-images.githubusercontent.com/86190295/149770151-9f5968ab-cd5f-4209-b865-c074a7449371.png">

(When I was writing the code)

![T$X{NC77UQ6E_@N2TFNWI8C](https://user-images.githubusercontent.com/86190295/149769895-6c32b26f-88ae-41b9-9b8b-f6b93a16d4c9.jpg)
(In the source code)

- Meanwhile, when clicking "show definition" for ```get_x_axis()``` or ```get_y_axis```, it will jumps to abstract methods under ```CoordinateSystem```

- https://github.com/microsoft/pylance-release/issues/248 (Reference) 
  This warning was due to 
```python 
def get_axes(self):
    raise Exception("Not implemented")
``` 
however without adding an abstract class decorator
```python 
@absrtactclass
def get_axes(self):
    raise Exception("Not implemented")
``` 
(Jumping was due to the fact that ```get_x_axis()``` and ```get_y_axis``` are not overrode again under ```Axes``` class)

This pull request aims to improve the structure and make it convenient especially for Pylance user writing and tracking codes

## Proposed changes
<!-- What you changed in those files -->

- added ```@abstractclass``` for two abstract methods
- overrides ```get_axis```, ```get_x_axis```, ```get_y_axis```, ```get_z_axis``` so that when using these/writing these methods, Pylance and users can track back to re-implemented methods under ```Axes``` class instead of ```CoordinateSystem``` where they will find nothing but a raise Exception

## Test
<!-- How do you test your changes -->
![image](https://user-images.githubusercontent.com/86190295/149772860-5d790d85-5af2-45ed-b79a-a74d1ba3b8f0.png)

Tested by initializing a Numberline object and no error occurred.