### PR TITLE
Parse and generate style for SVG

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -608,8 +608,8 @@ class Arrow(Line):
         self.insert_tip_anchor()
         return self
 
-    def init_colors(self):
-        super().init_colors()
+    def init_colors(self, override=True):
+        super().init_colors(override)
         self.create_tip_with_stroke_width()
 
     def get_arc_length(self):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -109,8 +109,8 @@ class Mobject(object):
             "reflectiveness": self.reflectiveness,
         }
 
-    def init_colors(self):
-        self.set_color(self.color, self.opacity)
+    def init_colors(self, override=True):
+        self.set_color(self.color, self.opacity, override)
 
     def init_points(self):
         # Typically implemented in subclass, unlpess purposefully left blank

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -25,16 +25,6 @@ from manimlib.utils.simple_functions import clip
 from manimlib.logger import log
 
 
-def string_to_numbers(num_string):
-    num_string = num_string.replace("-", ",-")
-    num_string = num_string.replace("e,-", "e-")
-    return [
-        float(s)
-        for s in re.split("[ ,]", num_string)
-        if s != ""
-    ]
-
-
 class SVGMobject(VMobject):
     CONFIG = {
         "should_center": True,
@@ -117,11 +107,6 @@ class SVGMobject(VMobject):
             result = [VGroup(*result)]
 
         return result
-
-    def g_to_mobjects(self, g_element):
-        mob = VGroup(*self.get_mobjects_from(g_element))
-        self.handle_transforms(g_element, mob)
-        return mob.submobjects
 
     def path_string_to_mobject(self, path_string):
         return VMobjectFromSVGPathstring(
@@ -429,7 +414,6 @@ class VMobjectFromSVGPathstring(VMobject):
                     )))
                 func(*args)
                 relative_point = self.get_last_point()
-
 
     def add_elliptical_arc_to(self, rx, ry, x_axis_rotation, large_arc_flag, sweep_flag, point):
         def close_to_zero(a, threshold=1e-5):

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -9,8 +9,6 @@ from xml.dom import minidom
 
 from manimlib.constants import DEFAULT_STROKE_WIDTH
 from manimlib.constants import ORIGIN, UP, DOWN, LEFT, RIGHT, IN
-from manimlib.constants import BLACK
-from manimlib.constants import WHITE
 from manimlib.constants import DEGREES, PI
 
 from manimlib.mobject.geometry import Circle
@@ -112,7 +110,6 @@ class SVGMobject(VMobject):
         # Must be filled in in a subclass, or when called
         "file_name": None,
         "unpack_groups": True,  # if False, creates a hierarchy of VGroups
-        # TODO, style components should be read in, not defaulted
         "stroke_width": DEFAULT_STROKE_WIDTH,
         "fill_opacity": 1.0,
         "path_string_config": {}

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -472,6 +472,7 @@ class VMobjectFromSVGPathstring(VMobject):
             upper_command = command.upper()
             if upper_command == "Z":
                 func()  # `close_path` takes no arguments
+                relative_point = self.get_last_point()
                 continue
 
             number_types = np.array(list(number_types_str))

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -480,7 +480,7 @@ class VMobjectFromSVGPathstring(VMobject):
             number_list = _PathStringParser(coord_string, number_types_str).args
             number_groups = np.array(number_list).reshape((-1, n_numbers))
 
-            for numbers in number_groups:
+            for ind, numbers in enumerate(number_groups):
                 if command.islower():
                     # Treat it as a relative command
                     numbers[number_types == "x"] += relative_point[0]
@@ -496,6 +496,9 @@ class VMobjectFromSVGPathstring(VMobject):
                     args = list(np.hstack((
                         numbers.reshape((-1, 2)), np.zeros((n_numbers // 2, 1))
                     )))
+                if upper_command == "M" and ind != 0:
+                    # M x1 y1 x2 y2  is equal to  M x1 y1 L x2 y2
+                    func, _ = self.command_to_function("L")
                 func(*args)
                 relative_point = self.get_last_point()
 

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -42,6 +42,7 @@ class SingleStringTex(VMobject):
                 svg_mob = SVGMobject(
                     filename,
                     height=None,
+                    color=self.color,
                     stroke_width=self.stroke_width,
                     path_string_config={
                         "should_subdivide_sharp_curves": True,

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -16,7 +16,7 @@ from manimlib.utils.tex_file_writing import display_during_execution
 SCALE_FACTOR_PER_FONT_POINT = 0.001
 
 
-tex_string_to_mob_map = {}
+tex_string_with_color_to_mob_map = {}
 
 
 class SingleStringTex(VMobject):
@@ -35,7 +35,7 @@ class SingleStringTex(VMobject):
         super().__init__(**kwargs)
         assert(isinstance(tex_string, str))
         self.tex_string = tex_string
-        if tex_string not in tex_string_to_mob_map:
+        if tex_string not in tex_string_with_color_to_mob_map:
             with display_during_execution(f" Writing \"{tex_string}\""):
                 full_tex = self.get_tex_file_body(tex_string)
                 filename = tex_to_svg_file(full_tex)
@@ -49,10 +49,10 @@ class SingleStringTex(VMobject):
                         "should_remove_null_curves": True,
                     }
                 )
-                tex_string_to_mob_map[tex_string] = svg_mob
+                tex_string_with_color_to_mob_map[(self.color, tex_string)] = svg_mob
         self.add(*(
             sm.copy()
-            for sm in tex_string_to_mob_map[tex_string]
+            for sm in tex_string_with_color_to_mob_map[(self.color, tex_string)]
         ))
         self.init_colors(override=False)
 

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -42,6 +42,7 @@ class SingleStringTex(VMobject):
                 svg_mob = SVGMobject(
                     filename,
                     height=None,
+                    stroke_width=self.stroke_width,
                     path_string_config={
                         "should_subdivide_sharp_curves": True,
                         "should_remove_null_curves": True,
@@ -52,7 +53,7 @@ class SingleStringTex(VMobject):
             sm.copy()
             for sm in tex_string_to_mob_map[tex_string]
         ))
-        self.init_colors()
+        self.init_colors(override=False)
 
         if self.height is None:
             self.scale(SCALE_FACTOR_PER_FONT_POINT * self.font_size)

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -3,7 +3,6 @@ import os
 import re
 import io
 import typing
-import warnings
 import xml.etree.ElementTree as ET
 import functools
 import pygments
@@ -14,6 +13,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import manimpango
+from manimlib.logger import log
 from manimlib.constants import *
 from manimlib.mobject.geometry import Dot
 from manimlib.mobject.svg.svg_mobject import SVGMobject
@@ -54,10 +54,9 @@ class Text(SVGMobject):
         self.full2short(kwargs)
         digest_config(self, kwargs)
         if self.size:
-            warnings.warn(
-                "self.size has been deprecated and will "
+            log.warning(
+                "`self.size` has been deprecated and will "
                 "be removed in future.",
-                DeprecationWarning
             )
             self.font_size = self.size
         if self.lsh == -1:

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -260,7 +260,7 @@ class TexturedSurface(Surface):
         super().init_uniforms()
         self.uniforms["num_textures"] = self.num_textures
 
-    def init_colors(self):
+    def init_colors(self, override=True):
         self.data["opacity"] = np.array([self.uv_surface.data["rgbas"][:, 3]])
 
     def set_opacity(self, opacity, recurse=True):

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -389,7 +389,6 @@ class VMobject(Mobject):
             new_handle = self.get_points()[-1]
         else:
             new_handle = self.get_reflection_of_last_handle()
-        print(new_handle, handle, point)
         self.add_cubic_bezier_curve_to(new_handle, handle, point)
 
     def has_new_path_started(self):

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -90,7 +90,7 @@ class VMobject(Mobject):
         })
 
     # Colors
-    def init_colors(self):
+    def init_colors(self, override=True):
         self.set_fill(
             color=self.fill_color or self.color,
             opacity=self.fill_opacity,
@@ -103,6 +103,9 @@ class VMobject(Mobject):
         )
         self.set_gloss(self.gloss)
         self.set_flat_stroke(self.flat_stroke)
+        if not override:
+            for submobjects in self.submobjects:
+                submobjects.init_colors(override=False)
         return self
 
     def set_rgba_array(self, rgba_array, name=None, recurse=False):
@@ -386,6 +389,7 @@ class VMobject(Mobject):
             new_handle = self.get_points()[-1]
         else:
             new_handle = self.get_reflection_of_last_handle()
+        print(new_handle, handle, point)
         self.add_cubic_bezier_curve_to(new_handle, handle, point)
 
     def has_new_path_started(self):


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Before, `SVGMobject` will remove all styles from a svg file.
This pull request parse the style for SVG by refering to [ManimCommunity/manim](https://github.com/ManimCommunity/manim).
In order to prevent the style generated layer by layer in `init_points` from being globally overwritten by the `init_colors` after it. I added a parameter `override` to `init_colors`, which is set to `True` by default (that is, consistent with the original performance), but when `override = False`, it will recurse layer by layer and set the color to the currently generated color.

## Proposed changes
<!-- What you changed in those files -->
- M `manimlib/mobject/svg/svg_mobject.py`: add SVG style parser and fix some bugs of path string
- M `manimlib/mobject/types/vectorized_mobject.py`: add `override` parameter to `init_colors`
- M `manimlib/mobject/mobject.py`: synchronously update the parameters of `init_colors`
- M `manimlib/mobject/geometry.py`: synchronously update the parameters of `init_colors`
- M `manimlib/mobject/types/surface.py`: synchronously update the parameters of `init_colors`
- M `manimlib/mobject/svg/tex_mobject.py`: synchronously update the parameters of `init_colors` and synchronize `SingleStringTex`'s `stroke_width` to `SVGMobject`
- M `manimlib/mobject/svg/tex_mobject.py`: cache color in `tex_string_to_mob_map` together with tex_string
- M `manimlib/mobject/svg/text_mobject.py`: replace `warnings.warn` with `log.warning`

## Test
<!-- How do you test your changes -->
I tested all the svg files used in ManimCE for testing and each file renders correctly with color and stroke.
And `Tex` `TexText` can correctly generate texts with color according to the corresponding LaTeX expression (`\color{}`)


**Code**:
```python
class Code(Scene):
    def construct(self):
        svg = VGroup(
            TexText(r"test {\color{red}and} {\color{blue}test}").set_width(10),
            TexText(r"test {\color{red}and} {\color{blue}test}").set_width(10).set_color(WHITE),
            TexText(r"test {\color{red}and} {\color{blue}test}", color=BLACK).set_width(10),
        ).arrange(DOWN)
        self.add(svg)
```
**Result**:
![image](https://user-images.githubusercontent.com/44120331/151164308-7ba0da16-3d1e-4885-b78e-aee061eed808.png)
As can be seen from the above example, the color parameter is only the default color, and this color will be overwritten as long as a color is included in the SVG. If you want to ignore the color in SVG, you can directly `.set_color` again.
