### PR TITLE
Parse style from <style> tag and Add support to <line> tag

### DIFF
--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -43,17 +43,9 @@ def cascade_element_style(element, inherited):
             style[attr] = element.get(attr)
 
     if element.get("style"):
-        for style_spec in element.get("style").split(";"):
-            style_spec = style_spec.strip()
-            try:
-                key, value = style_spec.split(":")
-            except ValueError as e:
-                if not style_spec.strip():
-                    pass
-                else:
-                    raise e
-            else:
-                style[key.strip()] = value.strip()
+        declarations = parse_declaration_list(element.get("style"))
+        for declaration in declarations:
+            style[declaration.name] = css_serialize(declaration.value)
 
     return style
 

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -13,6 +13,7 @@ from tinycss2 import parse_stylesheet, parse_declaration_list
 from manimlib.constants import ORIGIN, UP, DOWN, LEFT, RIGHT, IN
 from manimlib.constants import DEGREES, PI
 
+from manimlib.mobject.geometry import Line
 from manimlib.mobject.geometry import Circle
 from manimlib.mobject.geometry import Rectangle
 from manimlib.mobject.geometry import RoundedRectangle
@@ -174,6 +175,8 @@ class SVGMobject(VMobject):
             ))
         elif tag == 'use':
             result += self.use_to_mobjects(element, style)
+        elif tag == 'line':
+            result.append(self.line_to_mobject(element, style))
         elif tag == 'rect':
             result.append(self.rect_to_mobject(element, style))
         elif tag == 'circle':
@@ -186,8 +189,8 @@ class SVGMobject(VMobject):
             pass
         else:
             log.warning(f"Unsupported element type: {tag}")
-            pass  # TODO, support <line> and <text> tag
-        result = [m.insert_n_curves(0) for m in result if m is not None]
+            pass  # TODO, support <text> tag
+        result = [m for m in result if m is not None]
         self.handle_transforms(element, VGroup(*result))
         if len(result) > 1 and not self.unpack_groups:
             result = [VGroup(*result)]
@@ -314,6 +317,16 @@ class SVGMobject(VMobject):
 
         mob.shift(mob.get_center() - mob.get_corner(UP + LEFT))
         return mob
+    
+    def line_to_mobject(self, line_element, style):
+        x1, y1, x2, y2 = (
+            self.attribute_to_float(line_element.get(key, "0.0"))
+            for key in ("x1", "y1", "x2", "y2")
+        )
+        return Line(
+            [x1, -y1, 0], [x2, -y2, 0], 
+            **parse_style(style, self.generate_default_style())
+        )
 
     def handle_transforms(self, element, mobject):
         x, y = (

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -156,8 +156,8 @@ class SVGMobject(VMobject):
             self.add(*mobjects[0].submobjects)
 
     def get_mobjects_from(self, wrapper, style):
-        element = wrapper.etree_element
         result = []
+        element = wrapper.etree_element
         if not isinstance(element, ElementTree.Element):
             return result
 
@@ -171,8 +171,6 @@ class SVGMobject(VMobject):
         tag = element.tag.split("}")[-1]
         if tag == 'defs':
             self.update_ref_to_element(element, style)
-        elif tag == 'style':
-            pass
         elif tag in ['g', 'svg', 'symbol']:
             result += it.chain(*(
                 self.get_mobjects_from(child, style)
@@ -192,9 +190,11 @@ class SVGMobject(VMobject):
             result.append(self.ellipse_to_mobject(element, style))
         elif tag in ['polygon', 'polyline']:
             result.append(self.polygon_to_mobject(element, style))
+        elif tag == 'style':
+            pass
         else:
             log.warning(f"Unsupported element type: {tag}")
-            pass  # TODO
+            pass  # TODO, support <line> and <text> tag
         result = [m.insert_n_curves(0) for m in result if m is not None]
         self.handle_transforms(element, VGroup(*result))
         if len(result) > 1 and not self.unpack_groups:
@@ -246,9 +246,7 @@ class SVGMobject(VMobject):
         def_element, def_style = self.ref_to_element[ref]
         style = local_style.copy()
         style.update(def_style)
-        return self.get_mobjects_from(
-            def_element, style
-        )
+        return self.get_mobjects_from(def_element, style)
 
     def attribute_to_float(self, attr):
         stripped_attr = "".join([
@@ -341,7 +339,7 @@ class SVGMobject(VMobject):
         ]
         transform_pattern = re.compile("|".join([x + r"[^)]*\)" for x in transform_names]))
         number_pattern = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
-        transforms = transform_pattern.findall(element.get('transform', ''))[::-1]
+        transforms = transform_pattern.findall(element.get("transform", ""))[::-1]
 
         for transform in transforms:
             op_name, op_args = transform.split("(")

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -4,10 +4,12 @@ import string
 import os
 import hashlib
 
+import cssselect2
 from colour import web2hex
-from xml.dom import minidom
+from xml.etree import ElementTree
+from tinycss2 import serialize as css_serialize
+from tinycss2 import parse_stylesheet, parse_declaration_list
 
-from manimlib.constants import DEFAULT_STROKE_WIDTH
 from manimlib.constants import ORIGIN, UP, DOWN, LEFT, RIGHT, IN
 from manimlib.constants import DEGREES, PI
 
@@ -37,11 +39,11 @@ def cascade_element_style(element, inherited):
     style = inherited.copy()
 
     for attr in DEFAULT_STYLE:
-        if element.hasAttribute(attr):
-            style[attr] = element.getAttribute(attr)
+        if element.get(attr):
+            style[attr] = element.get(attr)
 
-    if element.hasAttribute("style"):
-        for style_spec in element.getAttribute("style").split(";"):
+    if element.get("style"):
+        for style_spec in element.get("style").split(";"):
             style_spec = style_spec.strip()
             try:
                 key, value = style_spec.split(":")
@@ -110,7 +112,7 @@ class SVGMobject(VMobject):
         # Must be filled in in a subclass, or when called
         "file_name": None,
         "unpack_groups": True,  # if False, creates a hierarchy of VGroups
-        "stroke_width": DEFAULT_STROKE_WIDTH,
+        "stroke_width": 0.0,
         "fill_opacity": 1.0,
         "path_string_config": {}
     }
@@ -137,52 +139,61 @@ class SVGMobject(VMobject):
         super().init_colors(override=override)
 
     def init_points(self):
-        doc = minidom.parse(self.file_path)
+        etree = ElementTree.parse(self.file_path)
+        wrapper = cssselect2.ElementWrapper.from_xml_root(etree)
+        svg = etree.getroot()
+        namespace = svg.tag.split("}")[0][1:]
         self.ref_to_element = {}
+        self.css_matcher = cssselect2.Matcher()
 
-        for child in doc.childNodes:
-            if not isinstance(child, minidom.Element):
-                continue
-            if child.tagName != 'svg':
-                continue
-            mobjects = self.get_mobjects_from(child, dict())
-            if self.unpack_groups:
-                self.add(*mobjects)
-            else:
-                self.add(*mobjects[0].submobjects)
-        doc.unlink()
+        for style in etree.findall(f"{{{namespace}}}style"):
+            self.parse_css_style(style.text)
 
-    def get_mobjects_from(self, element, style):
+        mobjects = self.get_mobjects_from(wrapper, dict())
+        if self.unpack_groups:
+            self.add(*mobjects)
+        else:
+            self.add(*mobjects[0].submobjects)
+
+    def get_mobjects_from(self, wrapper, style):
+        element = wrapper.etree_element
         result = []
-        if not isinstance(element, minidom.Element):
+        if not isinstance(element, ElementTree.Element):
             return result
+
+        matches = self.css_matcher.match(wrapper)
+        if matches:
+            for match in matches:
+                _, _, _, css_style = match
+                style.update(css_style)
         style = cascade_element_style(element, style)
 
-        if element.tagName == 'defs':
+        tag = element.tag.split("}")[-1]
+        if tag == 'defs':
             self.update_ref_to_element(element, style)
-        elif element.tagName == 'style':
-            pass  # TODO, handle style
-        elif element.tagName in ['g', 'svg', 'symbol']:
+        elif tag == 'style':
+            pass
+        elif tag in ['g', 'svg', 'symbol']:
             result += it.chain(*(
                 self.get_mobjects_from(child, style)
-                for child in element.childNodes
+                for child in wrapper.iter_children()
             ))
-        elif element.tagName == 'path':
+        elif tag == 'path':
             result.append(self.path_string_to_mobject(
-                element.getAttribute('d'), style
+                element.get('d'), style
             ))
-        elif element.tagName == 'use':
+        elif tag == 'use':
             result += self.use_to_mobjects(element, style)
-        elif element.tagName == 'rect':
+        elif tag == 'rect':
             result.append(self.rect_to_mobject(element, style))
-        elif element.tagName == 'circle':
+        elif tag == 'circle':
             result.append(self.circle_to_mobject(element, style))
-        elif element.tagName == 'ellipse':
+        elif tag == 'ellipse':
             result.append(self.ellipse_to_mobject(element, style))
-        elif element.tagName in ['polygon', 'polyline']:
+        elif tag in ['polygon', 'polyline']:
             result.append(self.polygon_to_mobject(element, style))
         else:
-            log.warning(f"Unsupported element type: {element.tagName}")
+            log.warning(f"Unsupported element type: {tag}")
             pass  # TODO
         result = [m.insert_n_curves(0) for m in result if m is not None]
         self.handle_transforms(element, VGroup(*result))
@@ -204,6 +215,20 @@ class SVGMobject(VMobject):
         if self.stroke_color:
             style["stroke"] = self.stroke_color
         return style
+    
+    def parse_css_style(self, css):
+        rules = parse_stylesheet(css, True, True)
+        for rule in rules:
+            selectors = cssselect2.compile_selector_list(rule.prelude)
+            declarations = parse_declaration_list(rule.content)
+            style = {
+                declaration.name: css_serialize(declaration.value)
+                for declaration in declarations
+                if declaration.name in DEFAULT_STYLE
+            }
+            payload = style
+            for selector in selectors:
+                self.css_matcher.add_selector(selector, payload)
 
     def path_string_to_mobject(self, path_string, style):
         return VMobjectFromSVGPathstring(
@@ -214,7 +239,7 @@ class SVGMobject(VMobject):
 
     def use_to_mobjects(self, use_element, local_style):
         # Remove initial "#" character
-        ref = use_element.getAttribute("xlink:href")[1:]
+        ref = use_element.get("xlink:href")[1:]
         if ref not in self.ref_to_element:
             log.warning(f"{ref} not recognized")
             return VGroup()
@@ -233,7 +258,7 @@ class SVGMobject(VMobject):
         return float(stripped_attr)
 
     def polygon_to_mobject(self, polygon_element, style):
-        path_string = polygon_element.getAttribute("points")
+        path_string = polygon_element.get("points")
         for digit in string.digits:
             path_string = path_string.replace(f" {digit}", f"L {digit}")
         path_string = path_string.replace("L", "M", 1)
@@ -241,11 +266,7 @@ class SVGMobject(VMobject):
 
     def circle_to_mobject(self, circle_element, style):
         x, y, r = (
-            self.attribute_to_float(
-                circle_element.getAttribute(key)
-            )
-            if circle_element.hasAttribute(key)
-            else 0.0
+            self.attribute_to_float(circle_element.get(key, "0.0"))
             for key in ("cx", "cy", "r")
         )
         return Circle(
@@ -255,11 +276,7 @@ class SVGMobject(VMobject):
 
     def ellipse_to_mobject(self, circle_element, style):
         x, y, rx, ry = (
-            self.attribute_to_float(
-                circle_element.getAttribute(key)
-            )
-            if circle_element.hasAttribute(key)
-            else 0.0
+            self.attribute_to_float(circle_element.get(key, "0.0"))
             for key in ("cx", "cy", "rx", "ry")
         )
         result = Circle(**parse_style(style, self.generate_default_style()))
@@ -269,8 +286,8 @@ class SVGMobject(VMobject):
         return result
 
     def rect_to_mobject(self, rect_element, style):
-        stroke_width = rect_element.getAttribute("stroke-width")
-        corner_radius = rect_element.getAttribute("rx")
+        stroke_width = rect_element.get("stroke-width", "")
+        corner_radius = rect_element.get("rx", "")
 
         if stroke_width in ["", "none", "0"]:
             stroke_width = 0
@@ -286,20 +303,20 @@ class SVGMobject(VMobject):
         if corner_radius == 0:
             mob = Rectangle(
                 width=self.attribute_to_float(
-                    rect_element.getAttribute("width")
+                    rect_element.get("width", "")
                 ),
                 height=self.attribute_to_float(
-                    rect_element.getAttribute("height")
+                    rect_element.get("height", "")
                 ),
                 **parsed_style,
             )
         else:
             mob = RoundedRectangle(
                 width=self.attribute_to_float(
-                    rect_element.getAttribute("width")
+                    rect_element.get("width", "")
                 ),
                 height=self.attribute_to_float(
-                    rect_element.getAttribute("height")
+                    rect_element.get("height", "")
                 ),
                 corner_radius=corner_radius,
                 **parsed_style
@@ -310,9 +327,7 @@ class SVGMobject(VMobject):
 
     def handle_transforms(self, element, mobject):
         x, y = (
-            self.attribute_to_float(element.getAttribute(key))
-            if element.hasAttribute(key)
-            else 0.0
+            self.attribute_to_float(element.get(key, "0.0"))
             for key in ("x", "y")
         )
         mobject.shift(x * RIGHT + y * DOWN)
@@ -326,7 +341,7 @@ class SVGMobject(VMobject):
         ]
         transform_pattern = re.compile("|".join([x + r"[^)]*\)" for x in transform_names]))
         number_pattern = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
-        transforms = transform_pattern.findall(element.getAttribute('transform'))[::-1]
+        transforms = transform_pattern.findall(element.get('transform', ''))[::-1]
 
         for transform in transforms:
             op_name, op_args = transform.split("(")
@@ -409,16 +424,16 @@ class SVGMobject(VMobject):
 
     def get_all_childNodes_have_id(self, element):
         all_childNodes_have_id = []
-        if not isinstance(element, minidom.Element):
+        if not isinstance(element, ElementTree.Element):
             return
-        if element.hasAttribute('id'):
+        if element.get('id'):
             return [element]
         for e in element.childNodes:
             all_childNodes_have_id.append(self.get_all_childNodes_have_id(e))
         return self.flatten([e for e in all_childNodes_have_id if e])
 
     def update_ref_to_element(self, defs, style):
-        new_refs = dict([(e.getAttribute('id'), (e, style)) for e in self.get_all_childNodes_have_id(defs)])
+        new_refs = dict([(e.get('id', ''), (e, style)) for e in self.get_all_childNodes_have_id(defs)])
         self.ref_to_element.update(new_refs)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ validators
 ipython
 PyOpenGL
 manimpango>=0.2.0,<0.4.0
+cssselect2

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     ipython
     PyOpenGL
     manimpango>=0.2.0,<0.4.0
+    cssselect2
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
https://github.com/3b1b/manim/pull/1717#issuecomment-1022344306
I solved this issue. Use tinycss2 to parse style (including `<style>` tag and `style` attributes in other tags), and use cssselect2 to choose which tag to apply to based on selector.
And in order to make cssselect2 handle selectors correctly, I replaced `xml.dom.minidom` with `xml.etree` for parsing SVG file, which also has more features.

At the same time, I also implemented the processing of the `<line>` tag by the way.

## Proposed changes
<!-- What you changed in those files -->
- M `manimlib/mobject/svg/svg_mobject.py`: improve style parsing and implement the `<line>` tag
- M `setup.cfg` & `requirements.txt`: add dependency of `cssselect2`(`tinycss2` will be installed along with it)

## Test
<!-- How do you test your changes -->
**Code**:
```python
class Code(Scene):
    def construct(self):
        svg = SVGMobject("beer.svg", color=BLACK, height=6)
        self.add(svg)
```

**Result**:
![image](https://user-images.githubusercontent.com/44120331/151341038-152db106-51af-4dab-82b3-f1ecc1f94f49.png)

**Code**:
```python
class Code(Scene):
    def construct(self):
        svg = SVGMobject("line.svg")
        self.add(svg)
```
![line](https://user-images.githubusercontent.com/44120331/151341356-32b6102d-88ae-4f8d-a4f5-b9071068a840.svg)


**Result**:
![image](https://user-images.githubusercontent.com/44120331/151341239-cf34e08d-f4e1-4442-8cd1-9155f35ab027.png)
