### PR TITLE
Handle explicit color-related commands

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -109,8 +109,8 @@ class Mobject(object):
             "reflectiveness": self.reflectiveness,
         }
 
-    def init_colors(self):
-        self.set_color(self.color, self.opacity)
+    def init_colors(self, override=True):
+        self.set_color(self.color, self.opacity, override)
 
     def init_points(self):
         # Typically implemented in subclass, unlpess purposefully left blank

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -109,8 +109,8 @@ class Mobject(object):
             "reflectiveness": self.reflectiveness,
         }
 
-    def init_colors(self, override=True):
-        self.set_color(self.color, self.opacity, override)
+    def init_colors(self):
+        self.set_color(self.color, self.opacity)
 
     def init_points(self):
         # Typically implemented in subclass, unlpess purposefully left blank

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -237,7 +237,7 @@ class _TexParser(object):
                     f"\"{tex_string[slice(*span_tuple)]}\""
                     for span_tuple in span_tuple_pair
                 ))
-            sys.exit(2)
+            raise ValueError
 
     def analyse_containing_labels(self):
         for span_0, tex_span_0 in self.tex_spans_dict.items():
@@ -299,8 +299,7 @@ class _TexParser(object):
         return result.replace(color_command_placeholder, "\\color[RGB]")
 
     def raise_tex_parsing_error(self, message):
-        log.error(f"Failed to parse tex ({message}): \"{self.tex_string}\"")
-        sys.exit(2)
+        raise ValueError(f"Failed to parse tex ({message}): \"{self.tex_string}\"")
 
     @staticmethod
     def get_color_related_commands_dict():
@@ -581,8 +580,7 @@ class MTex(VMobject):
         span_tuples = self.find_span_components_of_custom_span(custom_span_tuple)
         if span_tuples is None:
             tex = self.tex_string[slice(*custom_span_tuple)]
-            log.error(f"Failed to get span of tex: \"{tex}\"")
-            sys.exit(2)
+            raise ValueError(f"Failed to get span of tex: \"{tex}\"")
         return self.get_part_by_span_tuples(span_tuples)
 
     def get_parts_by_tex(self, tex):
@@ -613,19 +611,12 @@ class MTex(VMobject):
             if submob in part
         ]
         if not indices:
-            log.error("Failed to find part in tex")
-            sys.exit(2)
+            raise ValueError("Failed to find part in tex")
         return indices
 
     def indices_of_part_by_tex(self, tex, index=0):
         part = self.get_part_by_tex(tex, index=index)
         return self.indices_of_part(part)
-
-    def indices_of_all_parts_by_tex(self, tex, index=0):
-        all_parts = self.get_parts_by_tex(tex)
-        return list(it.chain(*[
-            self.indices_of_part(part) for part in all_parts
-        ]))
 
     def range_of_part(self, part):
         indices = self.indices_of_part(part)

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -349,8 +349,6 @@ class MTex(VMobject):
         self.tex_spans_dict = tex_parser.tex_spans_dict
 
         fill_color = self.get_fill_color()
-        stroke_width = self.get_stroke_width()
-
         # Cannot simultaneously be false, so at least one file is generated.
         require_labelled_tex_file = tex_parser.current_label != 0
         require_plain_tex_file = any([
@@ -362,7 +360,7 @@ class MTex(VMobject):
 
         if require_labelled_tex_file:
             labelled_full_tex = self.get_tex_file_body(tex_parser.get_labelled_expression())
-            labelled_hash_val = hash((labelled_full_tex, stroke_width))
+            labelled_hash_val = hash(labelled_full_tex)
             if labelled_hash_val in TEX_HASH_TO_MOB_MAP:
                 if not require_plain_tex_file:
                     self.add(*TEX_HASH_TO_MOB_MAP[labelled_hash_val].copy())
@@ -370,10 +368,7 @@ class MTex(VMobject):
             else:
                 with display_during_execution(f"Writing \"{tex_string}\""):
                     filename = tex_to_svg_file(labelled_full_tex)
-                    labelled_svg_glyphs = _LabelledTex(
-                        filename,
-                        stroke_width=stroke_width
-                    )
+                    labelled_svg_glyphs = _LabelledTex(filename)
                     self.add(*labelled_svg_glyphs)
                     self.build_submobjects()
                 TEX_HASH_TO_MOB_MAP[labelled_hash_val] = self.copy()
@@ -383,17 +378,13 @@ class MTex(VMobject):
         # require_plain_tex_file == True
         self.set_submobjects([])
         full_tex = self.get_tex_file_body(tex_string)
-        hash_val = hash((full_tex, fill_color, stroke_width))
+        hash_val = hash((full_tex, fill_color))
         if hash_val in TEX_HASH_TO_MOB_MAP:
             self.add(*TEX_HASH_TO_MOB_MAP[hash_val].copy())
             return self
         with display_during_execution(f"Writing \"{tex_string}\""):
             filename = tex_to_svg_file(full_tex)
-            svg_glyphs = _PlainTex(
-                filename,
-                fill_color=fill_color,
-                stroke_width=stroke_width
-            )
+            svg_glyphs = _PlainTex(filename, fill_color=fill_color)
             if require_labelled_tex_file:
                 labelled_svg_mob = TEX_HASH_TO_MOB_MAP[labelled_hash_val]
                 for glyph, labelled_glyph in zip(svg_glyphs, it.chain(*labelled_svg_mob)):

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -3,6 +3,7 @@ import re
 import sys
 from types import MethodType
 
+from manimlib.constants import BLACK
 from manimlib.mobject.svg.svg_mobject import SVGMobject
 from manimlib.mobject.types.vectorized_mobject import VMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
@@ -31,6 +32,7 @@ def _get_neighbouring_pairs(iterable):
 
 class _TexSVG(SVGMobject):
     CONFIG = {
+        "color": BLACK,
         "height": None,
         "path_string_config": {
             "should_subdivide_sharp_curves": True,
@@ -39,17 +41,14 @@ class _TexSVG(SVGMobject):
     }
 
     @staticmethod
-    def color_str_to_label(color_str):
-        if len(color_str) == 4:
-            # "#RGB" => "#RRGGBB"
-            color_str = "#" + "".join([c * 2 for c in color_str[1:]])
-        if color_str == "#ffffff":
-            return 0
-        return int(color_str[1:], 16)
+    def color_to_label(fill_color):
+        r, g, b = color_to_int_rgb(fill_color)
+        rg = r * 256 + g
+        return rg * 256 + b
 
     def parse_labels(self):
         for glyph in self:
-            glyph.glyph_label = _TexSVG.color_str_to_label(glyph.fill_color)
+            glyph.glyph_label = _TexSVG.color_to_label(glyph.fill_color)
         return self
 
 
@@ -90,8 +89,7 @@ class _TexParser(object):
 
     @staticmethod
     def label_to_color_tuple(rgb):
-        # Get a unique color different from black,
-        # or the svg file will not include the color information.
+        # Get a unique color different from black.
         rg, b = divmod(rgb, 256)
         r, g = divmod(rg, 256)
         return r, g, b
@@ -306,6 +304,7 @@ class _TexParser(object):
 
     @staticmethod
     def get_color_related_commands_dict():
+        # Only list a few commands that are commonly used.
         return {
             "\\color": 1,
             "\\textcolor": 1,


### PR DESCRIPTION
## Proposed changes
- M `manimlib/mobject/svg/mtex_mobject.py`
> Since MTex uses color for indexing submobjects, tex that originally brought with `\color` commands (or `\textcolor`, etc.) will cause failure. So I handled such a situation. Also, I reconstructed the algorithm in `generate_tex()` function, making svg files generated as few as possible.
- M `manimlib/mobject/mobject.py`: remove unused parameter

## Test
**Code**:
```python
from manimlib import *


class MathjaxTest(Scene):
    def construct(self):
        mtex = MTex(
            "{\\color{green} R G} {{Y}} B",
            tex_to_color_map={"R": RED},
            color=BLUE
        )
        mtex.set_color_by_tex("{{Y}}", YELLOW)
        self.add(mtex)
```

**Result**:
![MathjaxTest](https://user-images.githubusercontent.com/50232075/151387986-7c3e664c-4c3a-4772-b36b-9469b840dc49.png)
