### PR TITLE
Refactor MTex and implement TransformMatchingMTex

### DIFF
--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -237,7 +237,7 @@ class _TexParser(object):
                     f"\"{tex_string[slice(*span_tuple)]}\""
                     for span_tuple in span_tuple_pair
                 ))
-            sys.exit(2)
+            raise ValueError
 
     def analyse_containing_labels(self):
         for span_0, tex_span_0 in self.tex_spans_dict.items():
@@ -299,8 +299,7 @@ class _TexParser(object):
         return result.replace(color_command_placeholder, "\\color[RGB]")
 
     def raise_tex_parsing_error(self, message):
-        log.error(f"Failed to parse tex ({message}): \"{self.tex_string}\"")
-        sys.exit(2)
+        raise ValueError(f"Failed to parse tex ({message}): \"{self.tex_string}\"")
 
     @staticmethod
     def get_color_related_commands_dict():
@@ -581,8 +580,7 @@ class MTex(VMobject):
         span_tuples = self.find_span_components_of_custom_span(custom_span_tuple)
         if span_tuples is None:
             tex = self.tex_string[slice(*custom_span_tuple)]
-            log.error(f"Failed to get span of tex: \"{tex}\"")
-            sys.exit(2)
+            raise ValueError(f"Failed to get span of tex: \"{tex}\"")
         return self.get_part_by_span_tuples(span_tuples)
 
     def get_parts_by_tex(self, tex):
@@ -613,19 +611,12 @@ class MTex(VMobject):
             if submob in part
         ]
         if not indices:
-            log.error("Failed to find part in tex")
-            sys.exit(2)
+            raise ValueError("Failed to find part in tex")
         return indices
 
     def indices_of_part_by_tex(self, tex, index=0):
         part = self.get_part_by_tex(tex, index=index)
         return self.indices_of_part(part)
-
-    def indices_of_all_parts_by_tex(self, tex, index=0):
-        all_parts = self.get_parts_by_tex(tex)
-        return list(it.chain(*[
-            self.indices_of_part(part) for part in all_parts
-        ]))
 
     def range_of_part(self, part):
         indices = self.indices_of_part(part)

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -371,8 +371,8 @@ class MTex(VMobject):
                 self.add(*TEX_HASH_TO_MOB_MAP[labelled_hash_val].copy())
             else:
                 with display_during_execution(f"Writing \"{tex_string}\""):
-                    filename = tex_to_svg_file(labelled_full_tex)
-                    labelled_svg_glyphs = _TexSVG(filename).parse_labels()
+                    labelled_svg_glyphs = MTex.get_svg_glyphs(labelled_full_tex)
+                    labelled_svg_glyphs.parse_labels()
                     self.add(*labelled_svg_glyphs)
                     self.build_submobjects()
                     TEX_HASH_TO_MOB_MAP[labelled_hash_val] = self.copy()
@@ -388,8 +388,7 @@ class MTex(VMobject):
             self.add(*TEX_HASH_TO_MOB_MAP[hash_val].copy())
         else:
             with display_during_execution(f"Writing \"{tex_string}\""):
-                filename = tex_to_svg_file(full_tex)
-                svg_glyphs = _TexSVG(filename)
+                svg_glyphs = MTex.get_svg_glyphs(full_tex)
                 if require_labelled_tex_file:
                     labelled_svg_mob = TEX_HASH_TO_MOB_MAP[labelled_hash_val]
                     for glyph, labelled_glyph in zip(svg_glyphs, it.chain(*labelled_svg_mob)):
@@ -428,6 +427,11 @@ class MTex(VMobject):
             tex_config["text_to_replace"],
             new_tex
         )
+
+    @staticmethod
+    def get_svg_glyphs(full_tex):
+        filename = tex_to_svg_file(full_tex)
+        return _TexSVG(filename)
 
     def build_submobjects(self):
         if not self.submobjects:

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -583,6 +583,12 @@ class MTex(VMobject):
     def get_tex(self):
         return self.tex_string
 
+    def get_submob_tex(self):
+        return [
+            submob.get_tex()
+            for submob in self.submobjects
+        ]
+
     def get_specified_substrings(self):
         return self.__parser.get_specified_substrings()
 

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -242,7 +242,7 @@ class _TexParser(object):
             for flag in range(2)
         ], key=lambda t: (t[0], -t[2], -t[1])))
         command_pieces = [
-            ("{{{{\\color[HTML]{{{:06x}}}".format(label), "}}")[flag]
+            ("{{" + self.get_color_command(label), "}}")[flag]
             for flag, label in zip(flags, labels)
         ][1:-1]
         command_pieces.insert(0, "")
@@ -251,6 +251,17 @@ class _TexParser(object):
             for tex_span in _get_neighbouring_pairs(indices)
         ]
         return "".join(it.chain(*zip(command_pieces, string_pieces)))
+
+    @staticmethod
+    def get_color_command(label):
+        rg, b = divmod(label, 256)
+        r, g = divmod(rg, 256)
+        return "".join([
+            "\\color[RGB]",
+            "{",
+            ",".join(map(str, (r, g, b))),
+            "}"
+        ])
 
     def get_sorted_submob_indices(self, submob_labels):
         def script_span_to_submob_range(script_span):
@@ -447,7 +458,7 @@ class MTex(VMobject):
                     labelled_tex_content
                 )
                 glyph_labels = [
-                    MTex.color_to_label(labelled_glyph.fill_color)
+                    self.color_to_label(labelled_glyph.fill_color)
                     for labelled_glyph in labelled_svg_glyphs
                 ]
                 mob = self.build_mobject(labelled_svg_glyphs, glyph_labels)
@@ -464,7 +475,7 @@ class MTex(VMobject):
             tex_content = self.get_tex_file_content(self.tex_string)
             svg_glyphs = self.tex_content_to_glyphs(tex_content)
             glyph_labels = [
-                MTex.color_to_label(labelled_glyph.fill_color)
+                self.color_to_label(labelled_glyph.fill_color)
                 for labelled_glyph in labelled_svg_glyphs
             ]
             mob = self.build_mobject(svg_glyphs, glyph_labels)

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -1,6 +1,5 @@
 import itertools as it
 import re
-import sys
 from types import MethodType
 
 from manimlib.constants import BLACK
@@ -40,198 +39,198 @@ class _TexSVG(SVGMobject):
         },
     }
 
-    @staticmethod
-    def color_to_label(fill_color):
-        r, g, b = color_to_int_rgb(fill_color)
-        rg = r * 256 + g
-        return rg * 256 + b
-
-    def parse_labels(self):
-        for glyph in self:
-            glyph.glyph_label = _TexSVG.color_to_label(glyph.fill_color)
-        return self
-
 
 class _TexSpan(object):
-    def __init__(self, script_type, label):
-        # `script_type`: 0 for normal, 1 for subscript, 2 for superscript.
-        # Only those spans with `script_type == 0` will be colored.
-        self.script_type = script_type
+    def __init__(self, label, script_type, command_span):
         self.label = label
+        # `script_type`: 0 for normal, 1 for subscript, 2 for superscript.
+        self.script_type = script_type
+        self.command_span = command_span
         self.containing_labels = []
 
     def __repr__(self):
-        return "_TexSpan(" + ", ".join([
-            attrib_name + "=" + str(getattr(self, attrib_name))
-            for attrib_name in ["script_type", "label", "containing_labels"]
+        return self.__class__.__name__ + "(" + ", ".join([
+            key + "=" + repr(value)
+            for key, value in self.__dict__.items()
+            if not key.startswith("__")
         ]) + ")"
 
 
 class _TexParser(object):
     def __init__(self, tex_string, additional_substrings):
         self.tex_string = tex_string
+        self.whitespace_indices = self.get_whitespace_indices()
+        self.backslash_indices = self.get_backslash_indices()
+        self.script_indices = self.get_script_indices()
+        self.brace_indices_dict = self.get_brace_indices_dict()
         self.tex_spans_dict = {}
-        self.current_label = -1
-        self.brace_index_pairs = self.get_brace_index_pairs()
-        self.existing_color_command_spans = self.get_existing_color_command_spans()
-        self.has_existing_color_commands = any(self.existing_color_command_spans.values())
-        self.specified_substring_spans = []
+        self.labels_count = 0
+        self.specified_substrings = []
         self.add_tex_span((0, len(tex_string)))
-        self.break_up_by_double_braces()
         self.break_up_by_scripts()
+        self.break_up_by_double_braces()
         self.break_up_by_additional_substrings(additional_substrings)
-        self.specified_substrings = remove_list_redundancies([
-            tex_string[slice(*span_tuple)]
-            for span_tuple in self.specified_substring_spans
-        ])
-        self.check_if_overlap()
+        self.specified_substrings = remove_list_redundancies(
+            self.specified_substrings
+        )
+        self.check_if_partially_overlap()
         self.analyse_containing_labels()
 
-    @staticmethod
-    def label_to_color_tuple(rgb):
-        # Get a unique color different from black.
-        rg, b = divmod(rgb, 256)
-        r, g = divmod(rg, 256)
-        return r, g, b
-
-    def add_tex_span(self, span_tuple, script_type=0, label=-1):
+    def add_tex_span(self, span_tuple, script_type=0, command_span=None):
         if span_tuple in self.tex_spans_dict:
             return
 
-        if script_type == 0:
-            # Should be additionally labelled.
-            self.current_label += 1
-            label = self.current_label
-
-        tex_span = _TexSpan(script_type, label)
+        if command_span is None:
+            command_span = span_tuple
+        tex_span = _TexSpan(self.labels_count, script_type, command_span)
         self.tex_spans_dict[span_tuple] = tex_span
+        self.labels_count += 1
 
-    def get_brace_index_pairs(self):
-        result = []
-        left_brace_indices = []
-        for match_obj in re.finditer(r"(\\*)(\{|\})", self.tex_string):
-            # Braces following even numbers of backslashes are counted.
-            if len(match_obj.group(1)) % 2 == 1:
-                continue
-            if match_obj.group(2) == "{":
-                left_brace_index = match_obj.span(2)[0]
-                left_brace_indices.append(left_brace_index)
-            else:
-                left_brace_index = left_brace_indices.pop()
-                right_brace_index = match_obj.span(2)[1]
-                result.append((left_brace_index, right_brace_index))
-        if left_brace_indices:
-            self.raise_tex_parsing_error("unmatched braces")
-        return result
+    def get_whitespace_indices(self):
+        return [
+            match_obj.start()
+            for match_obj in re.finditer(r"\s", self.tex_string)
+        ]
 
-    def get_existing_color_command_spans(self):
-        tex_string = self.tex_string
-        color_related_commands_dict = _TexParser.get_color_related_commands_dict()
-        commands = color_related_commands_dict.keys()
-        result = {
-            command_name: []
-            for command_name in commands
-        }
-        brace_index_pairs = self.brace_index_pairs
-        pattern = "|".join([
-            re.escape(command_name)
-            for command_name in commands
+    def get_backslash_indices(self):
+        # Newlines (`\\`) don't count.
+        return [
+            match_obj.end() - 1
+            for match_obj in re.finditer(r"\\+", self.tex_string)
+            if len(match_obj.group()) % 2 == 1
+        ]
+
+    def filter_out_escaped_characters(self, indices):
+        return list(filter(
+            lambda index: index - 1 not in self.backslash_indices,
+            indices
+        ))
+
+    def get_script_indices(self):
+        return self.filter_out_escaped_characters([
+            match_obj.start()
+            for match_obj in re.finditer(r"[_^]", self.tex_string)
         ])
-        for match_obj in re.finditer(pattern, tex_string):
-            span_tuple = match_obj.span()
-            command_begin_index = span_tuple[0]
-            command_name = match_obj.group()
-            n_braces = color_related_commands_dict[command_name]
-            for _ in range(n_braces):
-                span_tuple = min(filter(
-                    lambda t: t[0] >= span_tuple[1],
-                    brace_index_pairs
-                ))
-            result[command_name].append(
-                (command_begin_index, span_tuple[1])
-            )
-        return result
 
-    def break_up_by_double_braces(self):
-        # Match paired double braces (`{{...}}`).
-        skip_pair = False
-        for prev_span_tuple, span_tuple in _get_neighbouring_pairs(
-            self.brace_index_pairs
-        ):
-            if skip_pair:
-                skip_pair = False
-                continue
-            if all([
-                span_tuple[0] == prev_span_tuple[0] - 1,
-                span_tuple[1] == prev_span_tuple[1] + 1
-            ]):
-                self.add_tex_span(span_tuple)
-                self.specified_substring_spans.append(span_tuple)
-                skip_pair = True
+    def get_brace_indices_dict(self):
+        tex_string = self.tex_string
+        indices = self.filter_out_escaped_characters([
+            match_obj.start()
+            for match_obj in re.finditer(r"[{}]", tex_string)
+        ])
+        result = {}
+        left_brace_indices_stack = []
+        for index in indices:
+            if tex_string[index] == "{":
+                left_brace_indices_stack.append(index)
+            else:
+                left_brace_index = left_brace_indices_stack.pop()
+                result[left_brace_index] = index
+        return result
 
     def break_up_by_scripts(self):
         # Match subscripts & superscripts.
         tex_string = self.tex_string
-        brace_indices_dict = dict(self.brace_index_pairs)
-        for match_obj in re.finditer(r"((?<!\\)(_|\^)\s*)|(\s+(_|\^)\s*)", tex_string):
-            script_type = 1 if "_" in match_obj.group() else 2
-            token_begin, token_end = match_obj.span()
-            if token_end in brace_indices_dict:
-                content_span = (token_end, brace_indices_dict[token_end])
+        whitespace_indices = self.whitespace_indices
+        brace_indices_dict = self.brace_indices_dict
+        for script_index in self.script_indices:
+            script_type = 1 if tex_string[script_index] == "_" else 2
+            content_begin = script_index + 1
+            while content_begin in whitespace_indices:
+                content_begin += 1
+            if content_begin in brace_indices_dict.keys():
+                content_end = brace_indices_dict[content_begin] + 1
             else:
-                content_match_obj = re.match(r"\w|\\[a-zA-Z]+", tex_string[token_end:])
-                if not content_match_obj:
-                    self.raise_tex_parsing_error("unclear subscript/superscript")
-                content_span = tuple([
-                    index + token_end for index in content_match_obj.span()
-                ])
-            self.add_tex_span(content_span)
-            label = self.tex_spans_dict[content_span].label
+                pattern = re.compile(r"\w|\\[a-zA-Z]+")
+                match_obj = pattern.match(tex_string, pos=content_begin)
+                if not match_obj:
+                    script_name = ("subscript", "superscript")[script_type - 1]
+                    log.warning(f"Unclear {script_name} while parsing")
+                    continue
+                content_end = match_obj.end()
             self.add_tex_span(
-                (token_begin, content_span[1]),
+                (script_index, content_end),
                 script_type=script_type,
-                label=label
+                command_span=(content_begin, content_end)
             )
 
+    def break_up_by_double_braces(self):
+        # Match paired double braces (`{{...}}`).
+        tex_string = self.tex_string
+        reversed_indices_dict = dict(
+            item[::-1] for item in self.brace_indices_dict.items()
+        )
+        skip = False
+        for prev_right_index, right_index in _get_neighbouring_pairs(
+            list(reversed_indices_dict.keys())
+        ):
+            if skip:
+                skip = False
+                continue
+            if right_index != prev_right_index + 1:
+                continue
+            left_index = reversed_indices_dict[right_index]
+            prev_left_index = reversed_indices_dict[prev_right_index]
+            if left_index != prev_left_index - 1:
+                continue
+            span_tuple = (left_index, right_index + 1)
+            self.add_tex_span(span_tuple)
+            self.specified_substrings.append(tex_string[slice(*span_tuple)])
+            skip = True
+
     def break_up_by_additional_substrings(self, additional_substrings):
+        stripped_substrings = sorted(remove_list_redundancies([
+            string.strip()
+            for string in additional_substrings
+        ]))
+        if "" in stripped_substrings:
+            stripped_substrings.remove("")
+
         tex_string = self.tex_string
         all_span_tuples = []
-        for string in additional_substrings:
-            # Only match non-crossing strings.
-            for match_obj in re.finditer(re.escape(string), tex_string):
+        for string in stripped_substrings:
+            match_objs = list(re.finditer(re.escape(string), tex_string))
+            if not match_objs:
+                continue
+            self.specified_substrings.append(string)
+            for match_obj in match_objs:
                 all_span_tuples.append(match_obj.span())
 
+        whitespace_indices = self.whitespace_indices
         script_spans_dict = dict([
             span_tuple[::-1]
             for span_tuple, tex_span in self.tex_spans_dict.items()
             if tex_span.script_type != 0
         ])
         for span_begin, span_end in all_span_tuples:
-            if span_end in script_spans_dict.values():
-                # Deconstruct spans with subscripts & superscripts.
-                while span_end in script_spans_dict:
+            # Deconstruct spans containing one out of two scripts.
+            if span_end in script_spans_dict.keys():
+                whitespace_span_end = span_end
+                while whitespace_span_end in whitespace_indices:
+                    whitespace_span_end += 1
+                if whitespace_span_end in script_spans_dict.values():
                     span_end = script_spans_dict[span_end]
-                if span_begin >= span_end:
-                    continue
-            span_tuple = (span_begin, span_end)
-            self.add_tex_span(span_tuple)
-            self.specified_substring_spans.append(span_tuple)
+                    while span_end in whitespace_indices:
+                        span_end -= 1
+                    if span_begin >= span_end:
+                        continue
+            self.add_tex_span((span_begin, span_end))
 
-    def check_if_overlap(self):
+    def check_if_partially_overlap(self):
         span_tuples = sorted(
             self.tex_spans_dict.keys(),
             key=lambda t: (t[0], -t[1])
         )
         overlapping_span_pairs = []
-        for i, span_0 in enumerate(span_tuples):
-            for span_1 in span_tuples[i + 1 :]:
+        for index, span_0 in enumerate(span_tuples):
+            for span_1 in span_tuples[index + 1:]:
                 if span_0[1] <= span_1[0]:
                     continue
                 if span_0[1] < span_1[1]:
                     overlapping_span_pairs.append((span_0, span_1))
         if overlapping_span_pairs:
             tex_string = self.tex_string
-            log.error("Overlapping substring pairs occur in MTex:")
+            log.error("Partially overlapping substring pairs occur in MTex:")
             for span_tuple_pair in overlapping_span_pairs:
                 log.error(", ".join(
                     f"\"{tex_string[slice(*span_tuple)]}\""
@@ -241,324 +240,145 @@ class _TexParser(object):
 
     def analyse_containing_labels(self):
         for span_0, tex_span_0 in self.tex_spans_dict.items():
-            if tex_span_0.script_type != 0:
-                continue
             for span_1, tex_span_1 in self.tex_spans_dict.items():
                 if _contains(span_1, span_0):
                     tex_span_1.containing_labels.append(tex_span_0.label)
 
     def get_labelled_tex_string(self):
         tex_string = self.tex_string
-        if self.current_label == 0 and not self.has_existing_color_commands:
-            return tex_string
-
-        # Remove the span of extire tex string.
         indices_with_labels = sorted([
-            (span_tuple[i], i, span_tuple[1 - i], tex_span.label)
-            for span_tuple, tex_span in self.tex_spans_dict.items()
-            if tex_span.script_type == 0
-            for i in range(2)
-        ], key=lambda t: (t[0], -t[1], -t[2]))[1:]
-
-        # Prevent from "\\color[RGB]" being replaced.
-        # Hopefully tex string doesn't contain such a substring...
-        color_command_placeholder = "{{\\iffalse \\fi}}"
-        result = tex_string[: indices_with_labels[0][0]]
-        for index_with_label, next_index_with_label in _get_neighbouring_pairs(
-            indices_with_labels
-        ):
-            index, flag, _, label = index_with_label
-            next_index, *_ = next_index_with_label
-            # Adding one more pair of braces will help maintain the glyghs of tex file...
-            if flag == 0:
-                color_tuple = _TexParser.label_to_color_tuple(label)
-                result += "".join([
-                    "{{",
-                    color_command_placeholder,
-                    "{",
-                    ",".join(map(str, color_tuple)),
-                    "}"
-                ])
-            else:
-                result += "}}"
-            result += tex_string[index : next_index]
-
-        color_related_commands_dict = _TexParser.get_color_related_commands_dict()
-        for command_name, command_spans in self.existing_color_command_spans.items():
-            if not command_spans:
-                continue
-            n_braces = color_related_commands_dict[command_name]
-            command_to_replace = command_name + n_braces * "{black}"
-            commands = {
-                tex_string[slice(*span_tuple)]
-                for span_tuple in command_spans
-            }
-            for command in commands:
-                result = result.replace(command, command_to_replace)
-
-        return result.replace(color_command_placeholder, "\\color[RGB]")
-
-    def raise_tex_parsing_error(self, message):
-        raise ValueError(f"Failed to parse tex ({message}): \"{self.tex_string}\"")
-
-    @staticmethod
-    def get_color_related_commands_dict():
-        # Only list a few commands that are commonly used.
-        return {
-            "\\color": 1,
-            "\\textcolor": 1,
-            "\\pagecolor": 1,
-            "\\colorbox": 1,
-            "\\fcolorbox": 2,
-        }
-
-
-class MTex(VMobject):
-    CONFIG = {
-        "fill_opacity": 1.0,
-        "stroke_width": 0,
-        "font_size": 48,
-        "alignment": "\\centering",
-        "tex_environment": "align*",
-        "isolate": [],
-        "tex_to_color_map": {},
-        "use_plain_tex_file": False,
-    }
-
-    def __init__(self, tex_string, **kwargs):
-        super().__init__(**kwargs)
-        tex_string = tex_string.strip()
-        # Prevent from passing an empty string.
-        if not tex_string:
-            tex_string = "\\quad"
-        self.tex_string = tex_string
-
-        self.generate_mobject()
-
-        self.set_color_by_tex_to_color_map(self.tex_to_color_map)
-        self.scale(SCALE_FACTOR_PER_FONT_POINT * self.font_size)
-
-    def get_additional_substrings_to_break_up(self):
-        result = remove_list_redundancies([
-            *self.tex_to_color_map.keys(), *self.isolate
-        ])
-        if "" in result:
-            result.remove("")
-        return result
-
-    def get_parser(self):
-        return _TexParser(self.tex_string, self.get_additional_substrings_to_break_up())
-
-    def generate_mobject(self):
-        tex_string = self.tex_string
-        tex_parser = self.get_parser()
-        self.tex_spans_dict = tex_parser.tex_spans_dict
-        self.specified_substrings = tex_parser.specified_substrings
-        fill_color = self.get_fill_color()
-
-        # Cannot simultaneously be false, so at least one file is generated.
-        require_labelled_tex_file = tex_parser.current_label != 0
-        require_plain_tex_file = any([
-            self.use_plain_tex_file,
-            tex_parser.has_existing_color_commands,
-            tex_parser.current_label == 0
-        ])
-
-        if require_labelled_tex_file:
-            labelled_full_tex = self.get_tex_file_body(tex_parser.get_labelled_tex_string())
-            labelled_hash_val = hash(labelled_full_tex)
-            if labelled_hash_val in TEX_HASH_TO_MOB_MAP:
-                self.add(*TEX_HASH_TO_MOB_MAP[labelled_hash_val].copy())
-            else:
-                with display_during_execution(f"Writing \"{tex_string}\""):
-                    labelled_svg_glyphs = MTex.get_svg_glyphs(labelled_full_tex)
-                    labelled_svg_glyphs.parse_labels()
-                    self.add(*labelled_svg_glyphs)
-                    self.build_submobjects()
-                    TEX_HASH_TO_MOB_MAP[labelled_hash_val] = self.copy()
-            if not require_plain_tex_file:
-                self.set_fill(color=fill_color)
-                return self
-
-        # require_plain_tex_file == True
-        self.set_submobjects([])
-        full_tex = self.get_tex_file_body(tex_string, fill_color=fill_color)
-        hash_val = hash(full_tex)
-        if hash_val in TEX_HASH_TO_MOB_MAP:
-            self.add(*TEX_HASH_TO_MOB_MAP[hash_val].copy())
-        else:
-            with display_during_execution(f"Writing \"{tex_string}\""):
-                svg_glyphs = MTex.get_svg_glyphs(full_tex)
-                if require_labelled_tex_file:
-                    labelled_svg_mob = TEX_HASH_TO_MOB_MAP[labelled_hash_val]
-                    for glyph, labelled_glyph in zip(svg_glyphs, it.chain(*labelled_svg_mob)):
-                        glyph.glyph_label = labelled_glyph.glyph_label
-                else:
-                    for glyph in svg_glyphs:
-                        glyph.glyph_label = 0
-                self.add(*svg_glyphs)
-                self.build_submobjects()
-                TEX_HASH_TO_MOB_MAP[hash_val] = self.copy()
-        return self
-
-    def get_tex_file_body(self, new_tex, fill_color=None):
-        if self.tex_environment:
-            new_tex = "\n".join([
-                f"\\begin{{{self.tex_environment}}}",
-                new_tex,
-                f"\\end{{{self.tex_environment}}}"
-            ])
-        if self.alignment:
-            new_tex = "\n".join([self.alignment, new_tex])
-        if fill_color:
-            int_rgb = color_to_int_rgb(fill_color)
-            color_command = "".join([
-                "\\color[RGB]",
-                "{",
-                ",".join(map(str, int_rgb)),
-                "}"
-            ])
-            new_tex = "\n".join(
-                [color_command, new_tex]
+            (
+                tex_span.command_span[i],
+                i,
+                tex_span.command_span[1 - i],
+                tex_span.label
             )
+            for tex_span in self.tex_spans_dict.values()
+            for i in range(2)
+        ], key=lambda t: (t[0], -t[1], -t[2]))
+        indices, flags, _, labels = zip(*indices_with_labels)
+        command_pieces = [
+            ("{{\\color[HTML]{" + "{:06x}".format(label) + "}", "}}")[flag]
+            for flag, label in zip(flags, labels)
+        ][1:-1]
+        command_pieces.insert(0, "")
+        string_pieces = [
+            tex_string[slice(*span_tuple)]
+            for span_tuple in _get_neighbouring_pairs(indices)
+        ]
+        return "".join(it.chain(*zip(command_pieces, string_pieces)))
 
-        tex_config = get_tex_config()
-        return tex_config["tex_body"].replace(
-            tex_config["text_to_replace"],
-            new_tex
-        )
+    def require_labelled_tex_file(self):
+        return self.labels_count > 1
 
-    @staticmethod
-    def get_svg_glyphs(full_tex):
-        filename = tex_to_svg_file(full_tex)
-        return _TexSVG(filename)
-
-    def build_submobjects(self):
-        if not self.submobjects:
-            return
-        self.init_colors()
-        for glyph in self.submobjects:
-            glyph.set_fill(glyph.fill_color)
-        self.group_submobjects()
-        self.sort_scripts_in_tex_order()
-        self.assign_submob_tex_strings()
-
-    def group_submobjects(self):
-        # Simply pack together adjacent mobjects with the same label.
-        new_submobjects = []
-        def append_new_submobject(glyphs):
-            if glyphs:
-                submobject = VGroup(*glyphs)
-                submobject.submob_label = glyphs[0].glyph_label
-                new_submobjects.append(submobject)
-
-        new_glyphs = []
-        current_glyph_label = 0
-        for glyph in self.submobjects:
-            if glyph.glyph_label == current_glyph_label:
-                new_glyphs.append(glyph)
-            else:
-                append_new_submobject(new_glyphs)
-                new_glyphs = [glyph]
-                current_glyph_label = glyph.glyph_label
-        append_new_submobject(new_glyphs)
-        self.set_submobjects(new_submobjects)
-
-    def sort_scripts_in_tex_order(self):
-        # LaTeX always puts superscripts before subscripts.
-        # This function sorts the submobjects of scripts in the order of tex given.
+    def get_sorted_submob_indices(self, submob_labels):
+        whitespace_indices = self.whitespace_indices
         tex_spans_dict = self.tex_spans_dict
-        index_and_span_list = sorted([
-            (index, span_tuple)
+        indices_with_spans = sorted([
+            (*span_tuple[::(-1, 1)[tex_span.script_type - 1]], tex_span)
             for span_tuple, tex_span in tex_spans_dict.items()
             if tex_span.script_type != 0
-            for index in span_tuple
         ])
 
         switch_range_pairs = []
-        for index_and_span_0, index_and_span_1 in _get_neighbouring_pairs(
-            index_and_span_list
+        for index_with_span_0, index_with_span_1 in _get_neighbouring_pairs(
+            indices_with_spans
         ):
-            index_0, span_tuple_0 = index_and_span_0
-            index_1, span_tuple_1 = index_and_span_1
-            if index_0 != index_1:
+            index_0, _, tex_span_0 = index_with_span_0
+            index_1, _, tex_span_1 = index_with_span_1
+            if tex_span_0.script_type != 1 or tex_span_1.script_type != 2:
                 continue
             if not all([
-                tex_spans_dict[span_tuple_0].script_type == 1,
-                tex_spans_dict[span_tuple_1].script_type == 2
+                index in whitespace_indices
+                for index in range(index_0, index_1)
             ]):
                 continue
-            submob_range_0 = self.range_of_part(
-                self.get_part_by_span_tuples([span_tuple_0])
-            )
-            submob_range_1 = self.range_of_part(
-                self.get_part_by_span_tuples([span_tuple_1])
-            )
-            switch_range_pairs.append((submob_range_0, submob_range_1))
+            indices_0 = [
+                i for i, label in enumerate(submob_labels)
+                if label in tex_span_0.containing_labels
+            ]
+            range_0 = range(indices_0[0], indices_0[-1] + 1)
+            indices_1 = [
+                i for i, label in enumerate(submob_labels)
+                if label in tex_span_1.containing_labels
+            ]
+            range_1 = range(indices_1[0], indices_1[-1] + 1)
+            switch_range_pairs.append((range_0, range_1))
 
         switch_range_pairs.sort(key=lambda t: (t[0].stop, -t[0].start))
-        indices = list(range(len(self.submobjects)))
-        for submob_range_0, submob_range_1 in switch_range_pairs:
+        indices = list(range(len(submob_labels)))
+        for range_0, range_1 in switch_range_pairs:
             indices = [
-                *indices[: submob_range_1.start],
-                *indices[submob_range_0.start : submob_range_0.stop],
-                *indices[submob_range_1.stop : submob_range_0.start],
-                *indices[submob_range_1.start : submob_range_1.stop],
-                *indices[submob_range_0.stop :]
+                *indices[:range_1.start],
+                *indices[range_0.start:range_0.stop],
+                *indices[range_1.stop:range_0.start],
+                *indices[range_1.start:range_1.stop],
+                *indices[range_0.stop:]
             ]
+        return indices
 
-        submobs = self.submobjects
-        self.set_submobjects([submobs[i] for i in indices])
-
-    def assign_submob_tex_strings(self):
+    def get_submob_tex_strings(self, submob_labels):
         # Not sure whether this is the best practice...
-        # This temporarily supports `TransformMatchingTex`.
-        tex_string = self.tex_string
         tex_spans_dict = self.tex_spans_dict
-        # Use tex strings including "_", "^".
-        label_dict = {}
-        for span_tuple, tex_span in tex_spans_dict.items():
-            if tex_span.script_type != 0:
-                label_dict[tex_span.label] = span_tuple
-            else:
-                if tex_span.label not in label_dict:
-                    label_dict[tex_span.label] = span_tuple
-
-        curr_labels = [submob.submob_label for submob in self.submobjects]
-        prev_labels = [curr_labels[-1], *curr_labels[:-1]]
-        next_labels = [*curr_labels[1:], curr_labels[0]]
+        labels = submob_labels + [submob_labels[0]]
+        label_dict = {
+            tex_span.label: span_tuple
+            for span_tuple, tex_span in tex_spans_dict.items()
+        }
+        span_tuples = [label_dict[label] for label in labels]
         tex_string_spans = []
-        for curr_label, prev_label, next_label in zip(
-            curr_labels, prev_labels, next_labels
-        ):
-            curr_span_tuple = label_dict[curr_label]
-            prev_span_tuple = label_dict[prev_label]
-            next_span_tuple = label_dict[next_label]
-            containing_labels = tex_spans_dict[curr_span_tuple].containing_labels
-            tex_string_spans.append([
-                prev_span_tuple[1] if prev_label in containing_labels else curr_span_tuple[0],
-                next_span_tuple[0] if next_label in containing_labels else curr_span_tuple[1]
-            ])
-        tex_string_spans[0][0] = label_dict[curr_labels[0]][0]
-        tex_string_spans[-1][1] = label_dict[curr_labels[-1]][1]
-        for submob, tex_string_span in zip(self.submobjects, tex_string_spans):
-            submob.tex_string = tex_string[slice(*tex_string_span)]
-            # Support `get_tex()` method here.
-            submob.get_tex = MethodType(lambda inst: inst.tex_string, submob)
+        for index, label in enumerate(span_tuples[:-1]):
+            containing_labels = tex_spans_dict[label].containing_labels
+            if labels[index - 1] in containing_labels:
+                span_begin = span_tuples[index - 1][1]
+            else:
+                span_begin = span_tuples[index][0]
+            if labels[index + 1] in containing_labels:
+                span_end = span_tuples[index + 1][0]
+            else:
+                span_end = span_tuples[index][1]
+            tex_string_spans.append([span_begin, span_end])
+        tex_string_spans[0][0] = label_dict[submob_labels[0]][0]
+        tex_string_spans[-1][1] = label_dict[submob_labels[-1]][1]
 
-    def get_part_by_span_tuples(self, span_tuples):
-        tex_spans_dict = self.tex_spans_dict
-        labels = set(it.chain(*[
-            tex_spans_dict[span_tuple].containing_labels
-            for span_tuple in span_tuples
-        ]))
-        return VGroup(*filter(
-            lambda submob: submob.submob_label in labels,
-            self.submobjects
+        tex_string = self.tex_string
+        left_brace_indices = sorted(self.brace_indices_dict.keys())
+        right_brace_indices = sorted(self.brace_indices_dict.values())
+        ignored_indices = sorted(it.chain(
+            self.whitespace_indices,
+            left_brace_indices,
+            right_brace_indices,
+            self.script_indices
         ))
+        result = []
+        for tex_string_span in tex_string_spans:
+            span_begin, span_end = tex_string_span
+            while span_begin in ignored_indices:
+                span_begin += 1
+            if span_begin >= span_end:
+                result.append("")
+                continue
+            while span_end - 1 in ignored_indices:
+                span_end -= 1
+            unclosed_left_brace = 0
+            unclosed_right_brace = 0
+            for index in range(span_begin, span_end):
+                if index in left_brace_indices:
+                    unclosed_left_brace += 1
+                elif index in right_brace_indices:
+                    if unclosed_left_brace == 0:
+                        unclosed_right_brace += 1
+                    else:
+                        unclosed_left_brace -= 1
+            result.append("".join([
+                unclosed_right_brace * "{",
+                tex_string[span_begin:span_end],
+                unclosed_left_brace * "}"
+            ]))
+        return result
 
     def find_span_components_of_custom_span(self, custom_span_tuple):
-        tex_string = self.tex_string
+        whitespace_indices = self.whitespace_indices
         span_choices = sorted(filter(
             lambda t: _contains(custom_span_tuple, t),
             self.tex_spans_dict.keys()
@@ -570,21 +390,161 @@ class MTex(VMobject):
         result = []
         while span_begin != span_end:
             if span_begin not in span_choices_dict:
-                if tex_string[span_begin].strip():
-                    return None
-                # Whitespaces may occur between spans.
-                span_begin += 1
-                continue
+                if span_begin in whitespace_indices:
+                    # Whitespaces may occur between spans.
+                    span_begin += 1
+                    continue
+                return None
             next_begin = span_choices_dict[span_begin]
             result.append((span_begin, next_begin))
             span_begin = next_begin
         return result
 
+    def get_containing_labels_by_span_tuples(self, span_tuples):
+        return remove_list_redundancies(list(it.chain(*[
+            self.tex_spans_dict[span_tuple].containing_labels
+            for span_tuple in span_tuples
+        ])))
+
+    def get_specified_substrings(self):
+        return self.specified_substrings
+
+    def get_all_isolated_substrings(self):
+        return remove_list_redundancies([
+            self.tex_string[slice(*span_tuple)]
+            for span_tuple in self.tex_spans_dict.keys()
+        ])
+
+
+class MTex(VMobject):
+    CONFIG = {
+        "fill_opacity": 1.0,
+        "stroke_width": 0,
+        "font_size": 48,
+        "alignment": "\\centering",
+        "tex_environment": "align*",
+        "isolate": [],
+        "tex_to_color_map": {},
+    }
+
+    def __init__(self, tex_string, **kwargs):
+        super().__init__(**kwargs)
+        tex_string = tex_string.strip()
+        # Prevent from passing an empty string.
+        if not tex_string:
+            tex_string = "\\quad"
+        self.tex_string = tex_string
+
+        self.__parser = _TexParser(
+            self.tex_string,
+            [*self.tex_to_color_map.keys(), *self.isolate]
+        )
+        self.generate_mobject()
+        self.init_colors()
+        self.set_color_by_tex_to_color_map(self.tex_to_color_map)
+        self.scale(SCALE_FACTOR_PER_FONT_POINT * self.font_size)
+
+    @staticmethod
+    def color_to_label(color):
+        r, g, b = color_to_int_rgb(color)
+        rg = r * 256 + g
+        return rg * 256 + b
+
+    def generate_mobject(self):
+        parser = self.__parser
+        labelled_tex = self.get_tex_file_body(parser.get_labelled_tex_string())
+        hash_val = hash(labelled_tex)
+        if hash_val not in TEX_HASH_TO_MOB_MAP:
+            with display_during_execution(f"Writing \"{self.tex_string}\""):
+                full_tex = self.get_tex_file_body(self.tex_string)
+                if parser.require_labelled_tex_file():
+                    labelled_svg_glyphs = MTex.tex_to_glyphs(labelled_tex)
+                    svg_glyphs = MTex.tex_to_glyphs(full_tex)
+                    for glyph, labelled_glyph in zip(
+                        svg_glyphs, labelled_svg_glyphs
+                    ):
+                        glyph.glyph_label = MTex.color_to_label(
+                            labelled_glyph.fill_color
+                        )
+                else:
+                    svg_glyphs = MTex.tex_to_glyphs(full_tex)
+                    for glyph in svg_glyphs:
+                        glyph.glyph_label = 0
+            TEX_HASH_TO_MOB_MAP[hash_val] = self.build_submobjects(svg_glyphs)
+        self.add(*TEX_HASH_TO_MOB_MAP[hash_val].copy())
+
+    def get_tex_file_body(self, new_tex):
+        if self.tex_environment:
+            new_tex = "\n".join([
+                f"\\begin{{{self.tex_environment}}}",
+                new_tex,
+                f"\\end{{{self.tex_environment}}}"
+            ])
+        if self.alignment:
+            new_tex = "\n".join([self.alignment, new_tex])
+
+        tex_config = get_tex_config()
+        return tex_config["tex_body"].replace(
+            tex_config["text_to_replace"],
+            new_tex
+        )
+
+    @staticmethod
+    def tex_to_glyphs(full_tex):
+        filename = tex_to_svg_file(full_tex)
+        return _TexSVG(filename)
+
+    def build_submobjects(self, svg_glyphs):
+        if not svg_glyphs:
+            return []
+
+        # Simply pack together adjacent mobjects with the same label.
+        submobjects = []
+        submob_labels = []
+        new_glyphs = []
+        current_glyph_label = svg_glyphs[0].glyph_label
+        for glyph in svg_glyphs:
+            if glyph.glyph_label == current_glyph_label:
+                new_glyphs.append(glyph)
+            else:
+                submobject = VGroup(*new_glyphs)
+                submob_labels.append(new_glyphs[0].glyph_label)
+                submobjects.append(submobject)
+                new_glyphs = [glyph]
+                current_glyph_label = glyph.glyph_label
+        submobject = VGroup(*new_glyphs)
+        submob_labels.append(new_glyphs[0].glyph_label)
+        submobjects.append(submobject)
+        for submob, label in zip(submobjects, submob_labels):
+            submob.submob_label = label
+
+        parser = self.__parser
+        indices = parser.get_sorted_submob_indices(submob_labels)
+        submobjects = [submobjects[index] for index in indices]
+
+        submob_tex_strings = parser.get_submob_tex_strings(submob_labels)
+        for submob, submob_tex in zip(submobjects, submob_tex_strings):
+            submob.tex_string = submob_tex
+            # Support `get_tex()` method here.
+            submob.get_tex = MethodType(lambda inst: inst.tex_string, submob)
+        return submobjects
+
+    def get_part_by_span_tuples(self, span_tuples):
+        labels = self.__parser.get_containing_labels_by_span_tuples(
+            span_tuples
+        )
+        return VGroup(*filter(
+            lambda submob: submob.submob_label in labels,
+            self.submobjects
+        ))
+
     def get_part_by_custom_span_tuple(self, custom_span_tuple):
-        span_tuples = self.find_span_components_of_custom_span(custom_span_tuple)
+        span_tuples = self.__parser.find_span_components_of_custom_span(
+            custom_span_tuple
+        )
         if span_tuples is None:
             tex = self.tex_string[slice(*custom_span_tuple)]
-            raise ValueError(f"Failed to get span of tex: \"{tex}\"")
+            raise ValueError(f"Failed to match mobjects from tex: \"{tex}\"")
         return self.get_part_by_span_tuples(span_tuples)
 
     def get_parts_by_tex(self, tex):
@@ -602,11 +562,8 @@ class MTex(VMobject):
         return self
 
     def set_color_by_tex_to_color_map(self, tex_to_color_map):
-        for tex, color in list(tex_to_color_map.items()):
-            try:
-                self.set_color_by_tex(tex, color)
-            except:
-                pass
+        for tex, color in tex_to_color_map.items():
+            self.set_color_by_tex(tex, color)
         return self
 
     def indices_of_part(self, part):
@@ -622,33 +579,14 @@ class MTex(VMobject):
         part = self.get_part_by_tex(tex, index=index)
         return self.indices_of_part(part)
 
-    def range_of_part(self, part):
-        indices = self.indices_of_part(part)
-        return range(indices[0], indices[-1] + 1)
-
-    def range_of_part_by_tex(self, tex, index=0):
-        part = self.get_part_by_tex(tex, index=index)
-        return self.range_of_part(part)
-
-    def index_of_part(self, part):
-        return self.indices_of_part(part)[0]
-
-    def index_of_part_by_tex(self, tex, index=0):
-        part = self.get_part_by_tex(tex, index=index)
-        return self.index_of_part(part)
-
     def get_tex(self):
         return self.tex_string
 
-    def get_all_isolated_substrings(self):
-        tex_string = self.tex_string
-        return remove_list_redundancies([
-            tex_string[slice(*span_tuple)]
-            for span_tuple in self.tex_spans_dict.keys()
-        ])
-
     def get_specified_substrings(self):
-        return self.specified_substrings
+        return self.__parser.get_specified_substrings()
+
+    def get_all_isolated_substrings(self):
+        return self.__parser.get_all_isolated_substrings()
 
 
 class MTexText(MTex):

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -256,15 +256,15 @@ class _TexParser(object):
         def script_span_to_submob_range(script_span):
             tex_span = self.script_span_to_tex_span_dict[script_span]
             submob_indices = [
-                i for i, label in enumerate(submob_labels)
+                index for index, label in enumerate(submob_labels)
                 if label in self.containing_labels_dict[tex_span]
             ]
             return range(submob_indices[0], submob_indices[-1] + 1)
 
         filtered_script_span_pairs = filter(
             lambda script_span_pair: all([
-                self.script_span_to_char_dict[script_span] == "_^"[i]
-                for i, script_span in enumerate(script_span_pair)
+                self.script_span_to_char_dict[script_span] == character
+                for script_span, character in zip(script_span_pair, "_^")
             ]),
             self.neighbouring_script_span_pairs
         )
@@ -567,7 +567,7 @@ class MTex(VMobject):
 
     def indices_of_part(self, part):
         indices = [
-            i for i, submob in enumerate(self.submobjects)
+            index for index, submob in enumerate(self.submobjects)
             if submob in part
         ]
         if not indices:

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -549,7 +549,9 @@ class MTex(VMobject):
     def get_parts_by_tex(self, tex):
         return VGroup(*[
             self.get_part_by_custom_span(match_obj.span())
-            for match_obj in re.finditer(re.escape(tex), self.tex_string)
+            for match_obj in re.finditer(
+                re.escape(tex.strip()), self.tex_string
+            )
         ])
 
     def get_part_by_tex(self, tex, index=0):

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -3,6 +3,7 @@ import re
 import sys
 from types import MethodType
 
+from manimlib.constants import BLACK
 from manimlib.mobject.svg.svg_mobject import SVGMobject
 from manimlib.mobject.types.vectorized_mobject import VMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
@@ -31,6 +32,7 @@ def _get_neighbouring_pairs(iterable):
 
 class _TexSVG(SVGMobject):
     CONFIG = {
+        "color": BLACK,
         "height": None,
         "path_string_config": {
             "should_subdivide_sharp_curves": True,
@@ -39,17 +41,14 @@ class _TexSVG(SVGMobject):
     }
 
     @staticmethod
-    def color_str_to_label(color_str):
-        if len(color_str) == 4:
-            # "#RGB" => "#RRGGBB"
-            color_str = "#" + "".join([c * 2 for c in color_str[1:]])
-        if color_str == "#ffffff":
-            return 0
-        return int(color_str[1:], 16)
+    def color_to_label(fill_color):
+        r, g, b = color_to_int_rgb(fill_color)
+        rg = r * 256 + g
+        return rg * 256 + b
 
     def parse_labels(self):
         for glyph in self:
-            glyph.glyph_label = _TexSVG.color_str_to_label(glyph.fill_color)
+            glyph.glyph_label = _TexSVG.color_to_label(glyph.fill_color)
         return self
 
 
@@ -90,8 +89,7 @@ class _TexParser(object):
 
     @staticmethod
     def label_to_color_tuple(rgb):
-        # Get a unique color different from black,
-        # or the svg file will not include the color information.
+        # Get a unique color different from black.
         rg, b = divmod(rgb, 256)
         r, g = divmod(rg, 256)
         return r, g, b
@@ -306,6 +304,7 @@ class _TexParser(object):
 
     @staticmethod
     def get_color_related_commands_dict():
+        # Only list a few commands that are commonly used.
         return {
             "\\color": 1,
             "\\textcolor": 1,


### PR DESCRIPTION
## Motivation
This is (possibly) the last overall refactoring applied to MTex class. The structure is updated to prevent from polluting namespace, and some algorithms of methods are improved.

There are some small difference between this version and former pull requests. For example,
- Color-related commands, from now on, are not allowed since they are really tricky to hangle in MTex;
- Substrings specified are stripped;
- Whitespaces and "\_", "^" can be skipped when matching tex (you can match "a b" if "a" and "b" are isolated);
- Tex strings of submobjects are formatted so that they can be matched more easily.

Also, the class `TransformMatchingMTex` is implemented. It tries to match as long and complete strings as possible. Hope this would be helpful :) 

## MTex guideline
### Basic usage
**Relative methods**
```python
MTex.__init__(self, tex_string, **kwargs)
MTexText.__init__(self, tex_string, **kwargs)
```

MTex only takes in a complete tex string. The string is stripped at the very beginning to avoid problems.
```python
mtex = MTex("\\mathrm{e}^{i \\pi} + 1 = 0")
self.add(mtex)
```
<details>
<summary>Result</summary>

![MTexTest0](https://user-images.githubusercontent.com/50232075/152153506-cec82eb0-0618-4976-8b63-3515e1d002ec.png)
</details>

```python
questionable_mtex = MTex("\\mathrm{e}^{i \\pi}", "+", "1", "=", "0")  # Not okay
# TypeError: __init__() takes 2 positional arguments but 6 were given
```

The default configuration is listed as follows:
```python
CONFIG = {
    "fill_opacity": 1.0,
    "stroke_width": 0,
    "font_size": 48,
    "alignment": "\\centering",
    "tex_environment": "align*",
    "isolate": [],
    "tex_to_color_map": {},
    "use_plain_tex": False,
}
```

Just like Tex, MTex is rendered in math mode by default, as `tex_environment` is set to `"align*"`. Users may use other environments like:
```python
mtex = MTex("\\mathrm{e}^{i \\pi} + 1 = 0", tex_environment="equation")
self.add(mtex)
```
<details>
<summary>Result</summary>

![MTexTest1](https://user-images.githubusercontent.com/50232075/152153536-2c433456-d895-47cd-af3f-c6eadd937c57.png)
</details>

```python
# mtextext = MTex("text", tex_environment=None)
# Equivalent to:
mtextext = MTexText("text")
self.add(mtextext)
```
<details>
<summary>Result</summary>

![MTexTest2](https://user-images.githubusercontent.com/50232075/152153555-8c127ef2-575d-4c95-bd3f-a63e5d480962.png)
</details>

If an environment takes in parameters, please include `\begin` and `\end` commands in the content.
```python
table = MTexText("""
    \\begin{table}[htb]
    \\begin{center}
    \\label{table:1} 
    \\begin{tabular}{|c|c|c|}
    \\hline \\textbf{Algorithms} & \\textbf{Complexity} & \\textbf{Overhead} \\\\
    \\hline algorithm 1 & high & low \\\\
    \\hline algorithm 2 & high & low \\\\
    \\hline algorithm 3 & low & low \\\\
    \\hline
    \\end{tabular}
    \\end{center}
    \\end{table}
""")
self.add(table)
```
<details>
<summary>Result</summary>

![MTexTest3](https://user-images.githubusercontent.com/50232075/152153573-ed494afe-c8e0-42b6-acd1-218f0db7dedc.png)
</details>

### Specify substrings
**Relative methods**
```python
MTex.__init__(self, tex_string, isolate=isolate, tex_to_color_map=tex_to_color_map, use_plain_tex=use_plain_tex)
MTex.get_specified_substrings(self)
```

Users may specify some substrings for manipulation using one of the following methods:
- Enclose a substring by a pair of double braces (the final substring will have braces included);
- Set a substring as a key of `tex_to_color_map` dict;
- Add a substring to `isolate` list.

Every substring specified should be a valid tex string itself. Or, more particularly, after inserting a pair of braces enclosing it, the tex string should still be valid.
```
"\left( x + y \right)^2"
"x": valid
"x + y": valid
"\left( x + y \right)": valid
"\left(": invalid
"2": valid (but not recommended, since superscripts are already broken up and needn't be specified)
"^2": valid (but not recommended)
"(": invalid
```

Each two substrings specified shall not partially overlap, but one completely overlapping another is okay:
```
"abcd"
"abc" and "d" can coexist
"abc" and "bc" can coexist
"abc" and "cd" cannot coexist
```

All substrings specified through one of the methods above will be included in `specified_substrings` list, which is available by calling `self.get_specified_substrings()`.
```python
mtex = MTex("{{1}}234", isolate=["2"], tex_to_color_map={"3": BLUE})
print(mtex.get_specified_substrings())
# ['{{1}}', '2', '3']
```

Specifying substrings may change the shape of svg rendered, since the tex string is modified after all. Users may specify `use_plain_tex=True` to avoid alteration in shape.

```python
group = VGroup(
    MTex("1 + 1", isolate=["+"]),
    MTex("1 + 1", isolate=["+"], use_plain_tex=True),
    MTex("1 {{+}} 1"),
).arrange(DOWN)
self.add(group)
```
<details>
<summary>Result</summary>

![MTexTest4](https://user-images.githubusercontent.com/50232075/152494883-dc0854f3-8332-49d9-b51f-6655628df538.png)
</details>

### Selecting mobjects through substrings
**Relative methods**
```python
MTex.get_parts_by_tex(self, tex)
MTex.get_part_by_tex(self, tex, index=0)
MTex.set_color_by_tex(self, tex, color)
MTex.indices_of_part_by_tex(self, tex, index=0)
MTex.get_isolated_substrings(self)
MTex.get_submob_tex(self)
```

Users may search for submobjects that a substring refers to using `get_parts_by_tex()` or `get_part_by_tex()` method. `get_parts_by_tex()` returns a VGroup with several parts, each of which is a VGroup of submobjects given by a possible match object. Note that in MTex, "part" is regarded as a VGroup of submobjects. The string should be part of the original tex string, and should be able to be split into several substrings that are in the list given by `get_isolated_substrings()`, and a few characters leftover should be whitespaces or "\_", "^".

MTex tries to assign each submobject with a formatted tex string (which is stripped and braces are matched). You may check out their tex strings via `get_submob_tex()`. This method can be used together with `index_labels()`. However, the process cannot ensure 100% correctness, and tex strings are only assigned for reference.
```python
mtex = MTex(
    "\\Vert \\mathbf{x} \\Vert_{p} = \\sqrt[{p}]{x_1^{p} + x_2^{p} + \\cdots + x_n^{p}}",
    tex_to_color_map={
        "{p}": GREEN_B,
        "x_1": BLUE_B,
        "x_2": BLUE_C,
        "x_n": BLUE_E,
    }
)
group = VGroup(mtex, mtex.copy()).arrange(DOWN)
self.add(group, index_labels(group[1]))
print(mtex.get_specified_substrings())
# ['x_1', 'x_2', 'x_n', '{p}']
print(mtex.get_isolated_substrings())
# ['\\Vert \\mathbf{x} \\Vert_{p} = \\sqrt[{p}]{x_1^{p} + x_2^{p} + \\cdots + x_n^{p}}', '1', '2', 'n', 'x', '{p}']
print(mtex.get_submob_tex())
# ['\\Vert \\mathbf{x} \\Vert', 'p', '= \\sqrt[', 'p', ']', 'x', '1', 'p', '+', 'x', '2', 'p', '+ \\cdots +', 'x', 'n', 'p']
mtex.get_parts_by_tex("{p}")  # Specified substring: okay
mtex.get_parts_by_tex("x_1^{p}")  # Can be split into "x", "1", "{p}" with "_", "^" leftover: okay
# mtex.get_parts_by_tex("{x_1^{p} + x_2^{p} + \\cdots + x_n^{p}}")  # Not okay
# ValueError: Failed to match mobjects from tex: "{x_1^{p} + x_2^{p} + \cdots + x_n^{p}}"
```
<details>
<summary>Result</summary>

![MTexTest5](https://user-images.githubusercontent.com/50232075/152629956-ab428c2d-bec6-4247-bf3b-081a82f41c4c.png)
</details>

```python
mtex = MTex(
    "{{\\Gamma \\left( {z} \\right)}} = {{\\int_{0}^{\\infty} \\mathrm{e}^{- t} t^{{{z} - 1}} \\mathrm{d} t}}",
    isolate=[
        "=",
        "\\int_{0}^{\\infty} \\mathrm{e}^{- t}",
        "\\mathrm{d} t"
    ],
    tex_to_color_map={
        "{z}": YELLOW,
        "\\mathrm{e}": MAROON_A
    }
)
group = VGroup(mtex, mtex.copy()).arrange(DOWN)
self.add(group, index_labels(group[1]))
print(mtex.get_specified_substrings())
# ['{{\\Gamma \\left( {z} \\right)}}', '{{{z} - 1}}', '{{\\int_{0}^{\\infty} \\mathrm{e}^{- t} t^{{{z} - 1}} \\mathrm{d} t}}', '=', '\\int_{0}^{\\infty} \\mathrm{e}^{- t}', '\\mathrm{d} t', '\\mathrm{e}', '{z}']
print(mtex.get_isolated_substrings())
# ['{{\\Gamma \\left( {z} \\right)}} = {{\\int_{0}^{\\infty} \\mathrm{e}^{- t} t^{{{z} - 1}} \\mathrm{d} t}}', '{0}', '{\\infty}', '{- t}', '{{{z} - 1}}', '{{\\Gamma \\left( {z} \\right)}}', '{{\\int_{0}^{\\infty} \\mathrm{e}^{- t} t^{{{z} - 1}} \\mathrm{d} t}}', '=', '\\int_{0}^{\\infty} \\mathrm{e}^{- t}', '\\mathrm{d} t', '\\mathrm{e}', '{z}']
print(mtex.get_submob_tex())
# ['\\Gamma \\left(', 'z', '\\right)', '=', '\\int', '0', '\\infty', '\\mathrm{e}', '- t', 't', 'z', '- 1', '\\mathrm{d} t']
mtex.get_parts_by_tex("{{{z} - 1}}")  # Specified substring: okay
mtex.get_parts_by_tex("_{0}")  # Subscript that consists of "{0}" and "_": okay
mtex.get_parts_by_tex("{{\\Gamma \\left( {z} \\right)}} =")  # Can be split into two specified substrings and a whitespace: okay
# mtex.get_parts_by_tex("\\int_{0}^{\\infty} \\mathrm{e}^{- t} t^{{{z} - 1}}")  # Not okay
# ValueError: Failed to match mobjects from tex: "\int_{0}^{\infty} \mathrm{e}^{- t} t^{{{z} - 1}}"
```
<details>
<summary>Result</summary>

![MTexTest6](https://user-images.githubusercontent.com/50232075/152629973-d5d9da25-a74e-4807-870d-3a767474f848.png)
</details>

### Coloring

**Relative methods**
```python
MTex.__init__(self, tex_string, color=color, tex_to_color_map=tex_to_color_map)
MTex.set_color_by_tex(self, tex, color)
MTex.set_color_by_tex_to_color_map(self, tex_to_color_map)
```

Users may specify `color` attribute to control the base color of MTex, and specify `tex_to_color_map` attribute to color different parts of MTex. Pay attention that **color-related commands in the content of tex string (like `\color`, `\textcolor`, etc.) will lead to error in MTex**, so please avoid them.

The `set_color_by_tex()` method will override the color of target submobjects.
```python
mtex = MTex(
    "R {{G}} B",
    tex_to_color_map={"R {{G}}": RED},
    color=BLUE
)
mtex.set_color_by_tex("{{G}}", GREEN)
self.add(mtex)
```
<details>
<summary>Result</summary>

![MTexTest7](https://user-images.githubusercontent.com/50232075/152153658-1ff62451-194b-4b6d-bd03-f86a3cf75441.png)
</details>
