### PR TITLE
Clean dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-argparse
 colour
 numpy
 Pillow
@@ -15,7 +14,6 @@ pygments
 pyyaml
 rich
 screeninfo
-pyreadline; sys_platform == 'win32'
 validators
 ipython
 PyOpenGL

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,24 @@ project_urls =
     Documentation = https://3b1b.github.io/manim/
     Source Code = https://github.com/3b1b/manim
 license = MIT
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: MIT License
+    Topic :: Scientific/Engineering
+    Topic :: Multimedia :: Video
+    Topic :: Multimedia :: Graphics
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
+    Natural Language :: English
 
 [options]
 packages = find:
-include_package_data=True
-install_requires = 
+include_package_data = True
+install_requires =
     colour
     numpy
     Pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ license = MIT
 packages = find:
 include_package_data=True
 install_requires = 
-    argparse
     colour
     numpy
     Pillow
@@ -34,7 +33,6 @@ install_requires =
     pyyaml
     rich
     screeninfo
-    pyreadline; sys_platform == 'win32'
     validators
     ipython
     PyOpenGL


### PR DESCRIPTION
## Proposed changes
<!-- What you changed in those files -->
- remove `argparse` because it is a built in module
- remove `pyreadline` as it is no longer needed and does not work with python 3.9+
- add classifiers to package metadata