### PR TITLE
Reorganize inheriting order and refactor SVGMobject

### DIFF
--- a/manimlib/mobject/svg/drawings.py
+++ b/manimlib/mobject/svg/drawings.py
@@ -318,9 +318,6 @@ class Bubble(SVGMobject):
         self.content = Mobject()
         self.refresh_triangulation()
 
-    def init_colors(self):
-        VMobject.init_colors(self)
-
     def get_tip(self):
         # TODO, find a better way
         return self.get_corner(DOWN + self.direction) - 0.6 * self.direction

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -71,8 +71,6 @@ class Text(SVGMobject):
         PangoUtils.remove_last_M(file_name)
         self.remove_empty_path(file_name)
         SVGMobject.__init__(self, file_name, **kwargs)
-        if self.color:
-            self.set_fill(self.color)
         self.text = text
         if self.disable_ligatures:
             self.apply_space_chars()


### PR DESCRIPTION
## Motivation
Fix some potential bugs left in #1731.

## Proposed changes
- M `manimlib/mobject/svg/svg_mobject.py`: Add `svg_default` dictionary to allow users to specifically fill in style attributes to elements whose style is not specified in svg scope (and the functionality of `init_colors` is therefore preserved); use `xml.dom.ElementTree` package to parse style attributes in the outer svg tag; use `SVG_HASH_TO_MOB_MAP` to cache svg mobjects
- M `manimlib/mobject/svg/drawings.py`: Remove unnecessary `init_colors` override
- M `manimlib/mobject/svg/text_mobject.py`: Remove unnecessary `set_fill` process
- M `manimlib/mobject/svg/mtex_mobject.py`: Reorganize inheriting structure (`MTex` inherits from `SVGMobject`)
- M `manimlib/mobject/svg/tex_mobject.py`: Reorganize inheriting structure (`SingleStringTex` inherits from `SVGMobject`)
