### PR TITLE
Specify UTF-8 encoding for tex files

### DIFF
--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -32,7 +32,7 @@ def get_tex_config():
             get_manim_dir(), "manimlib", "tex_templates",
             SAVED_TEX_CONFIG["template_file"],
         )
-        with open(template_filename, "r") as file:
+        with open(template_filename, "r", encoding="utf-8") as file:
             SAVED_TEX_CONFIG["tex_body"] = file.read()
     return SAVED_TEX_CONFIG
 
@@ -88,7 +88,7 @@ def tex_to_dvi(tex_file):
         if exit_code != 0:
             log_file = tex_file.replace(".tex", ".log")
             log.error("LaTeX Error!  Not a worry, it happens to the best of us.")
-            with open(log_file, "r") as file:
+            with open(log_file, "r", encoding="utf-8") as file:
                 for line in file.readlines():
                     if line.startswith("!"):
                         log.debug(f"The error could be: `{line[2:-1]}`")


### PR DESCRIPTION
## Motivation
In some cases the encoding of `open` in python may not be UTF-8 by default. This PR simply fixes this problem.

## Proposed changes
- M `manimlib/utils/tex_file_writing.py`
