### PR TITLE
Reorganize getters for ParametricCurve

### DIFF
--- a/manimlib/mobject/functions.py
+++ b/manimlib/mobject/functions.py
@@ -48,6 +48,18 @@ class ParametricCurve(VMobject):
             self.set_points([self.t_func(t_min)])
         return self
 
+    def get_t_func(self):
+        return self.t_func
+
+    def get_function(self):
+        if hasattr(self, "underlying_function"):
+            return self.underlying_function
+        if hasattr(self, "function"):
+            return self.function
+
+    def get_x_range(self):
+        if hasattr(self, "x_range"):
+            return self.x_range
 
 class FunctionGraph(ParametricCurve):
     CONFIG = {
@@ -66,12 +78,6 @@ class FunctionGraph(ParametricCurve):
             return [t, function(t), 0]
 
         super().__init__(parametric_function, self.x_range, **kwargs)
-
-    def get_function(self):
-        return self.function
-
-    def get_point_from_function(self, x):
-        return self.t_func(x)
 
 
 class ImplicitFunction(VMobject):


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Sometimes a graph is initialized with ```get_graph``` method, which stores the function into ```self.underlying_function``` attributes. While for function graphs, they are stored in ```self.function``` attribute.
Reorganizing getters can help to avoid Attribution error, when trying to initialize another graph that shares the same function with an existing graph.

