### PR TITLE
Fix the width of riemann rectangles

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -235,6 +235,7 @@ class CoordinateSystem():
                                stroke_color=BLACK,
                                fill_opacity=1,
                                colors=(BLUE, GREEN),
+                               stroke_background=True,
                                show_signed_area=True):
         if x_range is None:
             x_range = self.x_range[:2]
@@ -257,7 +258,8 @@ class CoordinateSystem():
             height = get_norm(
                 self.i2gp(sample, graph) - self.c2p(sample, 0)
             )
-            rect = Rectangle(width=x1 - x0, height=height)
+            rect = Rectangle(width=self.x_axis.n2p(x1)[0] - self.x_axis.n2p(x0)[0], 
+                             height=height)
             rect.move_to(self.c2p(x0, 0), DL)
             rects.append(rect)
         result = VGroup(*rects)
@@ -266,6 +268,7 @@ class CoordinateSystem():
             stroke_width=stroke_width,
             stroke_color=stroke_color,
             fill_opacity=fill_opacity,
+            stroke_background=stroke_background
         )
         return result
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
Fix the width of riemann rectangles

## Proposed changes
Change the width from `x1 - x0` to `width=self.x_axis.n2p(x1)[0] - self.x_axis.n2p(x0)[0]`.

The former means the global coord width while the latter means custom coord width. 

## Test
<!-- How do you test your changes -->
![image](https://user-images.githubusercontent.com/55699713/158748366-98369da3-43d8-4f10-81c2-0dd0cb395a77.png)
