### PR TITLE
Adjust some typings

### DIFF
--- a/docs/source/documentation/constants.rst
+++ b/docs/source/documentation/constants.rst
@@ -84,8 +84,6 @@ Text
 
 .. code-block:: python
 
-    START_X = 30
-    START_Y = 20
     NORMAL = "NORMAL"
     ITALIC = "ITALIC"
     OBLIQUE = "OBLIQUE"

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -64,8 +64,6 @@ JOINT_TYPE_MAP = {
 }
 
 # Related to Text
-START_X = 30
-START_Y = 20
 NORMAL = "NORMAL"
 ITALIC = "ITALIC"
 OBLIQUE = "OBLIQUE"

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -447,9 +447,7 @@ class MTex(_TexSVG):
         self.scale(SCALE_FACTOR_PER_FONT_POINT * self.font_size)
 
     @property
-    def hash_seed(
-        self
-    ) -> tuple[str, dict[str], dict[str, bool], str, list[str], str, str, bool]:
+    def hash_seed(self) -> tuple:
         return (
             self.__class__.__name__,
             self.svg_default,
@@ -462,9 +460,9 @@ class MTex(_TexSVG):
         )
 
     def get_file_path(self) -> str:
-        return self._get_file_path(self.use_plain_tex)
+        return self.get_file_path_(use_plain_tex=self.use_plain_tex)
 
-    def _get_file_path(self, use_plain_tex: bool) -> str:
+    def get_file_path_(self, use_plain_tex: bool) -> str:
         if use_plain_tex:
             tex_string = self.tex_string
         else:
@@ -501,7 +499,7 @@ class MTex(_TexSVG):
         if not self.use_plain_tex:
             labelled_svg_glyphs = self
         else:
-            file_path = self._get_file_path(use_plain_tex=False)
+            file_path = self.get_file_path_(use_plain_tex=False)
             labelled_svg_glyphs = _TexSVG(file_path)
 
         glyph_labels = [

--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -18,7 +18,12 @@ from manimlib.utils.tex_file_writing import get_tex_config
 from manimlib.utils.tex_file_writing import display_during_execution
 from manimlib.logger import log
 
-ManimColor = Union[str, colour.Color, Sequence[float]]
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from manimlib.mobject.types.vectorized_mobject import VMobject
+    ManimColor = Union[str, colour.Color, Sequence[float]]
 
 
 SCALE_FACTOR_PER_FONT_POINT = 0.001
@@ -29,7 +34,7 @@ def _get_neighbouring_pairs(iterable: Iterable) -> list:
 
 
 class _TexParser(object):
-    def __init__(self, tex_string: str, additional_substrings: str):
+    def __init__(self, tex_string: str, additional_substrings: list[str]):
         self.tex_string = tex_string
         self.whitespace_indices = self.get_whitespace_indices()
         self.backslash_indices = self.get_backslash_indices()
@@ -173,7 +178,7 @@ class _TexParser(object):
 
     def break_up_by_additional_substrings(
         self,
-        additional_substrings: Iterable[str]
+        additional_substrings: list[str]
     ) -> None:
         stripped_substrings = sorted(remove_list_redundancies([
             string.strip()
@@ -257,7 +262,7 @@ class _TexParser(object):
             "}"
         ])
 
-    def get_sorted_submob_indices(self, submob_labels: Iterable[int]) -> list[int]:
+    def get_sorted_submob_indices(self, submob_labels: list[int]) -> list[int]:
         def script_span_to_submob_range(script_span):
             tex_span = self.script_span_to_tex_span_dict[script_span]
             submob_indices = [
@@ -291,7 +296,7 @@ class _TexParser(object):
             ]
         return result
 
-    def get_submob_tex_strings(self, submob_labels: Iterable[int]) -> list[str]:
+    def get_submob_tex_strings(self, submob_labels: list[int]) -> list[str]:
         ordered_tex_spans = [
             self.tex_span_list[label] for label in submob_labels
         ]
@@ -385,7 +390,7 @@ class _TexParser(object):
 
     def get_containing_labels_by_tex_spans(
         self,
-        tex_spans: Iterable[tuple[int, int]]
+        tex_spans: list[tuple[int, int]]
     ) -> list[int]:
         return remove_list_redundancies(list(it.chain(*[
             self.containing_labels_dict[tex_span]
@@ -503,8 +508,10 @@ class MTex(_TexSVG):
             self.color_to_label(labelled_glyph.get_fill_color())
             for labelled_glyph in labelled_svg_glyphs
         ]
-        mob = self.build_mobject(self, glyph_labels)
-        self.set_submobjects(mob.submobjects)
+        rearranged_submobs = self.rearrange_submobjects(
+            self.submobjects, glyph_labels
+        )
+        self.set_submobjects(rearranged_submobs)
 
     @staticmethod
     def color_to_label(color: ManimColor) -> int:
@@ -512,13 +519,13 @@ class MTex(_TexSVG):
         rg = r * 256 + g
         return rg * 256 + b
 
-    def build_mobject(
+    def rearrange_submobjects(
         self,
-        svg_glyphs: _TexSVG | None,
-        glyph_labels: Iterable[int]
-    ) -> VGroup:
+        svg_glyphs: list[VMobject],
+        glyph_labels: list[int]
+    ) -> list[VMobject]:
         if not svg_glyphs:
-            return VGroup()
+            return []
 
         # Simply pack together adjacent mobjects with the same label.
         submobjects = []
@@ -552,11 +559,11 @@ class MTex(_TexSVG):
             submob.tex_string = submob_tex
             # Support `get_tex()` method here.
             submob.get_tex = MethodType(lambda inst: inst.tex_string, submob)
-        return VGroup(*rearranged_submobjects)
+        return rearranged_submobjects
 
     def get_part_by_tex_spans(
         self,
-        tex_spans: Iterable[tuple[int, int]]
+        tex_spans: list[tuple[int, int]]
     ) -> VGroup:
         labels = self.parser.get_containing_labels_by_tex_spans(tex_spans)
         return VGroup(*filter(
@@ -581,7 +588,7 @@ class MTex(_TexSVG):
             )
         ])
 
-    def get_part_by_tex(self, tex: str, index: int = 0) -> VGroup:
+    def get_part_by_tex(self, tex: str, index: int = 0) -> VMobject:
         all_parts = self.get_parts_by_tex(tex)
         return all_parts[index]
 
@@ -597,7 +604,7 @@ class MTex(_TexSVG):
             self.set_color_by_tex(tex, color)
         return self
 
-    def indices_of_part(self, part: Iterable[VGroup]) -> list[int]:
+    def indices_of_part(self, part: Iterable[VMobject]) -> list[int]:
         indices = [
             index for index, submob in enumerate(self.submobjects)
             if submob in part

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -189,30 +189,6 @@ class SVGMobject(VMobject):
         mob.shift(vec)
         return mob
 
-    def get_mobject_from(self, shape: se.GraphicObject) -> VMobject | None:
-        shape_class_to_func_map: dict[
-            type, Callable[[se.GraphicObject], VMobject]
-        ] = {
-            se.Path: self.path_to_mobject,
-            se.SimpleLine: self.line_to_mobject,
-            se.Rect: self.rect_to_mobject,
-            se.Circle: self.circle_to_mobject,
-            se.Ellipse: self.ellipse_to_mobject,
-            se.Polygon: self.polygon_to_mobject,
-            se.Polyline: self.polyline_to_mobject,
-            # se.Text: self.text_to_mobject,  # TODO
-        }
-        for shape_class, func in shape_class_to_func_map.items():
-            if isinstance(shape, shape_class):
-                mob = func(shape)
-                self.apply_style_to_mobject(mob, shape)
-                return mob
-
-        shape_class_name = shape.__class__.__name__
-        if shape_class_name != "SVGElement":
-            log.warning(f"Unsupported element type: {shape_class_name}")
-        return None
-
     @staticmethod
     def apply_style_to_mobject(
         mob: VMobject,

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -76,7 +76,7 @@ class SVGMobject(VMobject):
         SVG_HASH_TO_MOB_MAP[hash_val] = self.copy()
 
     @property
-    def hash_seed(self) -> tuple[str, dict[str], dict[str, bool], str]:
+    def hash_seed(self) -> tuple:
         # Returns data which can uniquely represent the result of `init_points`.
         # The hashed value of it is stored as a key in `SVG_HASH_TO_MOB_MAP`.
         return (

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -50,7 +50,7 @@ class SingleStringTex(SVGMobject):
             self.organize_submobjects_left_to_right()
 
     @property
-    def hash_seed(self) -> tuple[str, dict[str], dict[str, bool], str, str, bool]:
+    def hash_seed(self) -> tuple:
         return (
             self.__class__.__name__,
             self.svg_default,


### PR DESCRIPTION
## Motivation
Resolve conflicts of #1736 and #1751, and adjust some typings. 

## Proposed changes
- M `docs/source/documentation/constants.rst`: remove `START_X`, `START_Y` constants
- M `manimlib/constants.py`: remove `START_X`, `START_Y` constants
- M `manimlib/mobject/svg/mtex_mobject.py`: adjust typings
- M `manimlib/mobject/svg/svg_mobject.py`: remove unused method `get_mobject_from`
- M `manimlib/mobject/svg/text_mobject.py`: add type hints; remove an unused import

