### PR TITLE
Give the user feedback for SVGs that take a while

### DIFF
--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -17,6 +17,7 @@ from manimlib.constants import PI
 from manimlib.constants import TAU
 from manimlib.utils.iterables import adjacent_pairs
 from manimlib.utils.simple_functions import clip
+from manimlib.logger import log
 
 
 def cross(v1: np.ndarray, v2: np.ndarray) -> list[np.ndarray]:
@@ -415,6 +416,8 @@ def earclip_triangulation(verts: np.ndarray, ring_ends: list[int]) -> list:
 
     chilren = [[] for i in rings]
     for idx, i in enumerate(rings_sorted):
+        if len(rings_sorted) > 100 and (not idx%100 or idx+1==len(rings_sorted)):
+            log.info(f"SVG triangulation: {idx}/{len(rings_sorted)}")
         for j in rings_sorted[:idx][::-1]:
             if is_in_fast(i, j):
                 chilren[j].append(i)

--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -417,7 +417,7 @@ def earclip_triangulation(verts: np.ndarray, ring_ends: list[int]) -> list:
     chilren = [[] for i in rings]
     for idx, i in enumerate(rings_sorted):
         if len(rings_sorted) > 100 and (not idx%100 or idx+1==len(rings_sorted)):
-            log.info(f"SVG triangulation: {idx}/{len(rings_sorted)}")
+            log.debug(f"SVG triangulation: {idx+1}/{len(rings_sorted)}")
         for j in rings_sorted[:idx][::-1]:
             if is_in_fast(i, j):
                 chilren[j].append(i)

--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -4,11 +4,13 @@ import math
 import operator as op
 from functools import reduce
 from typing import Callable, Iterable, Sequence
+import platform
 
 import numpy as np
 import numpy.typing as npt
 from mapbox_earcut import triangulate_float32 as earcut
 from scipy.spatial.transform import Rotation
+from tqdm import tqdm as ProgressDisplay
 
 from manimlib.constants import RIGHT
 from manimlib.constants import DOWN
@@ -414,7 +416,16 @@ def earclip_triangulation(verts: np.ndarray, ring_ends: list[int]) -> list:
         ))
 
     chilren = [[] for i in rings]
-    for idx, i in enumerate(rings_sorted):
+    ringenum = ProgressDisplay(
+        enumerate(rings_sorted),
+        total=len(rings),
+        leave=False,
+        ascii=True if platform.system() == 'Windows' else None,
+        dynamic_ncols=True,
+        desc="SVG Triangulation",
+        delay=3,
+    )
+    for idx, i in ringenum:
         for j in rings_sorted[:idx][::-1]:
             if is_in_fast(i, j):
                 chilren[j].append(i)

--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -17,7 +17,6 @@ from manimlib.constants import PI
 from manimlib.constants import TAU
 from manimlib.utils.iterables import adjacent_pairs
 from manimlib.utils.simple_functions import clip
-from manimlib.logger import log
 
 
 def cross(v1: np.ndarray, v2: np.ndarray) -> list[np.ndarray]:
@@ -416,8 +415,6 @@ def earclip_triangulation(verts: np.ndarray, ring_ends: list[int]) -> list:
 
     chilren = [[] for i in rings]
     for idx, i in enumerate(rings_sorted):
-        if len(rings_sorted) > 100 and (idx%100 == 0 or idx+1 == len(rings_sorted)):
-            log.debug(f"SVG triangulation: {idx+1}/{len(rings_sorted)}")
         for j in rings_sorted[:idx][::-1]:
             if is_in_fast(i, j):
                 chilren[j].append(i)

--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -416,7 +416,7 @@ def earclip_triangulation(verts: np.ndarray, ring_ends: list[int]) -> list:
 
     chilren = [[] for i in rings]
     for idx, i in enumerate(rings_sorted):
-        if len(rings_sorted) > 100 and (not idx%100 or idx+1==len(rings_sorted)):
+        if len(rings_sorted) > 100 and (idx%100 == 0 or idx+1 == len(rings_sorted)):
             log.debug(f"SVG triangulation: {idx+1}/{len(rings_sorted)}")
         for j in rings_sorted[:idx][::-1]:
             if is_in_fast(i, j):


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Manim does not provide feedback to the user while processing a long-running SVG mobject.
Since manim typically runs so fast, a long-running SVG catches the user by surprise. Personally it took me a few hours to figure out that manim was not freezing, rather it was just taking a long time on a complicated SVG.


## Proposed changes
<!-- What you changed in those files -->
This change gives the user some feedback while processing a complicated SVG.
Specifically:  
If the SVG has over 100 rings to process, we display a counter to log.info once per 100 processed rings.  Thus the user learns manim is working on a long-running operation.
If the SVG has under 100 rings, this change has no effect. Manim will process it quick enough.

## Test
<!-- How do you test your changes -->
**Code**:
I tested with the Noto emoji - Afghan flag SVG.  Here is the complete scene code, which automatically gets the SVG from the internet so no additional files are needed. 
Paste into a blank _.py file and run manimgl _.py  
Try it without the pull request, and it will seem that manimgl has frozen with a blank screen.
Try it with the pull request, and rest reassured manim is working.
```
from manimlib import *

class Flagtest(Scene):
    def construct(self):
        flag_url = "https://raw.githubusercontent.com/googlefonts/noto-emoji/main/third_party/region-flags/svg/AF.svg"
        flag_mob = SVGMobject(flag_url, svg_default = { "stroke_width": 0 } )
        flag_mob.scale( min( self.camera.frame.get_width()/flag_mob.get_width(), self.camera.frame.get_height()/flag_mob.get_height() ) )
        self.add(flag_mob)
```

**Result**:
```
(manimlib) sunkisser@localhost ~/manimlib $ manimgl flagtest.py
ManimGL v1.5.0
[00:30:09] INFO     Using the default configuration file, which you can modify in            config.py:265
                    `/home/sunkisser/manimlib/manim/manimlib/default_config.yml`                          
           INFO     If you want to create a local configuration file, you can create a file  config.py:266
                    named `custom_config.yml`, or run `manimgl --config`                                  
[00:30:12] INFO     Tips: You are now in the interactive mode. Now you can use the keyboard   scene.py:119
                    and the mouse to interact with the scene. Just press `q` if you want to               
                    quit.                                                                                 
           INFO     SVG triangulation: 0/753                                              space_ops.py:420
[00:30:19] INFO     SVG triangulation: 100/753                                            space_ops.py:420
[00:30:33] INFO     SVG triangulation: 200/753                                            space_ops.py:420
[00:30:53] INFO     SVG triangulation: 300/753                                            space_ops.py:420
[00:31:17] INFO     SVG triangulation: 400/753                                            space_ops.py:420
[00:31:47] INFO     SVG triangulation: 500/753                                            space_ops.py:420
[00:32:20] INFO     SVG triangulation: 600/753                                            space_ops.py:420
[00:32:57] INFO     SVG triangulation: 700/753                                            space_ops.py:420
[00:33:13] INFO     SVG triangulation: 752/753                                            space_ops.py:420
```

