### PR TITLE
Refactor `LabelledString` and relevant classes

### DIFF
--- a/manimlib/mobject/numbers.py
+++ b/manimlib/mobject/numbers.py
@@ -6,11 +6,8 @@ from manimlib.constants import *
 from manimlib.mobject.svg.tex_mobject import SingleStringTex
 from manimlib.mobject.svg.text_mobject import Text
 from manimlib.mobject.types.vectorized_mobject import VMobject
-from manimlib.utils.iterables import hash_obj
 
 T = TypeVar("T", bound=VMobject)
-
-string_to_mob_map: dict[str, VMobject] = {}
 
 
 class DecimalNumber(VMobject):
@@ -92,9 +89,7 @@ class DecimalNumber(VMobject):
         return self.data["font_size"][0]
 
     def string_to_mob(self, string: str, mob_class: Type[T] = Text, **kwargs) -> T:
-        if (string, hash_obj(kwargs)) not in string_to_mob_map:
-            string_to_mob_map[(string, hash_obj(kwargs))] = mob_class(string, font_size=1, **kwargs)
-        mob = string_to_mob_map[(string, hash_obj(kwargs))].copy()
+        mob = mob_class(string, font_size=1, **kwargs)
         mob.scale(self.get_font_size())
         return mob
 

--- a/manimlib/mobject/svg/labelled_string.py
+++ b/manimlib/mobject/svg/labelled_string.py
@@ -146,8 +146,6 @@ class LabelledString(_StringSVG):
     def take_nearest_value(seq: list[int], val: int, index_shift: int) -> int:
         sorted_seq = sorted(seq)
         index = LabelledString.find_region_index(sorted_seq, val)
-        if index == -1:
-            raise IndexError
         return sorted_seq[index + index_shift]
 
     @staticmethod

--- a/manimlib/mobject/svg/labelled_string.py
+++ b/manimlib/mobject/svg/labelled_string.py
@@ -113,24 +113,14 @@ class LabelledString(_StringSVG):
     def get_substr(self, span: Span) -> str:
         return self.string[slice(*span)]
 
-    def handle_regex_method(func):
-        def wrapper(self, pattern, pos=0, endpos=9223372036854775807):
-            return func()(
-                re.compile(pattern), self.string, pos=pos, endpos=endpos
-            )
-        return wrapper
+    def finditer(self, pattern, **kwargs):
+        return re.compile(pattern).finditer(self.string, **kwargs)
 
-    @handle_regex_method
-    def finditer():
-        return re.Pattern.finditer
+    def search(self, pattern, **kwargs):
+        return re.compile(pattern).search(self.string, **kwargs)
 
-    @handle_regex_method
-    def search():
-        return re.Pattern.search
-
-    @handle_regex_method
-    def match():
-        return re.Pattern.match
+    def match(self, pattern, **kwargs):
+        return re.compile(pattern).match(self.string, **kwargs)
 
     def find_spans(self, pattern: str) -> list[Span]:
         return [match_obj.span() for match_obj in self.finditer(pattern)]

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -58,6 +58,7 @@ class SVGMobject(VMobject):
         },
         "path_string_config": {},
     }
+
     def __init__(self, file_name: str | None = None, **kwargs):
         super().__init__(**kwargs)
         self.file_name = file_name or self.file_name

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -311,7 +311,7 @@ class MarkupText(LabelledString):
         self, substr_or_span: str | tuple[int | None, int | None]
     ) -> list[Span]:
         if isinstance(substr_or_span, str):
-            return self.find_substr(substr)
+            return self.find_substr(substr_or_span)
 
         string_len = len(self.string)
         span_begin, span_end = substr_or_span


### PR DESCRIPTION
## Motivation
Some refactors on `LabelledString` and relevant classes.

## Proposed changes
- M `manimlib/mobject/numbers.py`: Remove the cache dict, since `SVGMobject`s are already cached.
- M `manimlib/mobject/svg/labelled_string.py`: Support passing in `svg_default.color` and `svg_default.fill_color` as aliases of `base_color`; improve algorithm.
- M `manimlib/mobject/svg/mtex_mobject.py`: Some refactors.
- M `manimlib/mobject/svg/text_mobject.py`: Some refactors.
- M `manimlib/mobject/svg/svg_mobject.py`: Add an empty line.
