### PR TITLE
Add support for `substring` and `case_sensitive` parameters

### DIFF
--- a/manimlib/mobject/svg/mtex_mobject.py
+++ b/manimlib/mobject/svg/mtex_mobject.py
@@ -314,19 +314,21 @@ class MTex(LabelledString):
 
     # Method alias
 
-    def get_parts_by_tex(self, tex: str) -> VGroup:
-        return self.get_parts_by_string(tex)
+    def get_parts_by_tex(self, tex: str, **kwargs) -> VGroup:
+        return self.get_parts_by_string(tex, **kwargs)
 
-    def get_part_by_tex(self, tex: str) -> VMobject:
-        return self.get_part_by_string(tex)
+    def get_part_by_tex(self, tex: str, **kwargs) -> VMobject:
+        return self.get_part_by_string(tex, **kwargs)
 
-    def set_color_by_tex(self, tex: str, color: ManimColor):
-        return self.set_color_by_string(tex, color)
+    def set_color_by_tex(self, tex: str, color: ManimColor, **kwargs):
+        return self.set_color_by_string(tex, color, **kwargs)
 
     def set_color_by_tex_to_color_map(
-        self, tex_to_color_map: dict[str, ManimColor]
+        self, tex_to_color_map: dict[str, ManimColor], **kwargs
     ):
-        return self.set_color_by_string_to_color_map(tex_to_color_map)
+        return self.set_color_by_string_to_color_map(
+            tex_to_color_map, **kwargs
+        )
 
     def get_tex(self) -> str:
         return self.get_string()

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -517,19 +517,21 @@ class MarkupText(LabelledString):
 
     # Method alias
 
-    def get_parts_by_text(self, text: str) -> VGroup:
-        return self.get_parts_by_string(text)
+    def get_parts_by_text(self, text: str, **kwargs) -> VGroup:
+        return self.get_parts_by_string(text, **kwargs)
 
-    def get_part_by_text(self, text: str) -> VMobject:
-        return self.get_part_by_string(text)
+    def get_part_by_text(self, text: str, **kwargs) -> VMobject:
+        return self.get_part_by_string(text, **kwargs)
 
-    def set_color_by_text(self, text: str, color: ManimColor):
-        return self.set_color_by_string(text, color)
+    def set_color_by_text(self, text: str, color: ManimColor, **kwargs):
+        return self.set_color_by_string(text, color, **kwargs)
 
     def set_color_by_text_to_color_map(
-        self, text_to_color_map: dict[str, ManimColor]
+        self, text_to_color_map: dict[str, ManimColor], **kwargs
     ):
-        return self.set_color_by_string_to_color_map(text_to_color_map)
+        return self.set_color_by_string_to_color_map(
+            text_to_color_map, **kwargs
+        )
 
     def get_text(self) -> str:
         return self.get_string()

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -315,9 +315,13 @@ class MarkupText(LabelledString):
             return self.find_substr(substr_or_span)
 
         span = tuple([
-            (index if index >= 0 else index + self.string_len)
-            if index is not None else substitute
-            for index, substitute in zip(substr_or_span, self.full_span)
+            (
+                min(index, self.string_len)
+                if index >= 0
+                else max(index + self.string_len, 0)
+            )
+            if index is not None else default_index
+            for index, default_index in zip(substr_or_span, self.full_span)
         ])
         if span[0] >= span[1]:
             return []


### PR DESCRIPTION
## Motivation
Add support for `substring` and `case_sensitive` parameters for `LabelledString.get_parts_by_string` method, and other relative methods as well.

## Proposed changes
- M `manimlib/mobject/svg/labelled_string.py`
- M `manimlib/mobject/svg/mtex_mobject.py`
- M `manimlib/mobject/svg/text_mobject.py`
