### PR TITLE
Some fix

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -650,7 +650,7 @@ class ControlsExample(Scene):
 
         def text_updater(old_text):
             assert(isinstance(old_text, Text))
-            new_text = Text(self.textbox.get_value(), size=old_text.size)
+            new_text = Text(self.textbox.get_value(), font_size=old_text.font_size)
             # new_text.align_data_and_family(old_text)
             new_text.move_to(old_text)
             if self.checkbox.get_value():

--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -152,7 +152,7 @@ def angle_between_vectors(v1: np.ndarray, v2: np.ndarray) -> float:
     """
     n1 = get_norm(v1)
     n2 = get_norm(v2)
-    cos_angle = np.dot(v1, v2) / (n1 * n2)
+    cos_angle = np.dot(v1, v2) / np.float64(n1 * n2)
     return math.acos(clip(cos_angle, -1, 1))
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
Reduce warning from numpy:
```python
RuntimeWarning: invalid value encountered in double_scalars
  cos_angle = np.dot(v1, v2) / n1 * n2
```
by making the denominator also `np.float64`

Fix ControlsExample by changing `Text.size` to `Text.font_size`
