### PR TITLE
Added a \overset as a special string

### DIFF
--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -100,6 +100,18 @@ class SingleStringTex(SVGMobject):
             filler = "{\\quad}"
             tex += filler
 
+        should_add_double_filler = reduce(op.or_, [
+            tex == "\\overset",
+            # TODO: these can't be used since they change
+            # the latex draw order.
+            # tex == "\\frac", # you can use \\over as a alternative 
+            # tex == "\\dfrac",
+            # tex == "\\binom",
+        ])
+        if should_add_double_filler:
+            filler = "{\\quad}{\\quad}"
+            tex += filler
+
         if tex == "\\substack":
             tex = "\\quad"
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Makes something like `Tex("\overset", "{def A}", "{=}")` work.

## Proposed changes
Added `"\\overset"` -> `"\\overset{\\quad}{\\quad}"` and documented why \frac and friends do not work (yet).


## Test
<!-- How do you test your changes -->
**Code**:
```python
  color = {"isolate": ["{A}", "{B}"], "tex_to_color_map": {"{A}": GREEN, "{B}": BLUE}}
  t = Tex(r"a{B}c", r"\overset", "{A}{=} a{B}c", **color)
  self.play(Write(t))
```
**Result**:
![Screenshot_2022-04-08_22-58-07](https://user-images.githubusercontent.com/5936614/162529742-6a0df8a2-8384-4c7a-8064-303ee47c179a.png)
