### PR TITLE
Fix `ImageMobject` by overriding `set_color` method

### DIFF
--- a/manimlib/mobject/types/image_mobject.py
+++ b/manimlib/mobject/types/image_mobject.py
@@ -48,6 +48,9 @@ class ImageMobject(Mobject):
             mob.data["opacity"] = np.array([[o] for o in listify(opacity)])
         return self
 
+    def set_color(self, color, opacity=None, recurse=None):
+        return self
+
     def point_to_rgb(self, point: np.ndarray) -> np.ndarray:
         x0, y0 = self.get_corner(UL)[:2]
         x1, y1 = self.get_corner(DR)[:2]


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Fixes #1790.

Because `set_color` of `ImageMobject` actually does nothing, I override it to just return itself to avoid #1790.