### PR TITLE
Fix a logistic bug

### DIFF
--- a/manimlib/mobject/svg/string_mobject.py
+++ b/manimlib/mobject/svg/string_mobject.py
@@ -174,8 +174,8 @@ class StringMobject(SVGMobject, ABC):
             ):
                 l = self.full_span[1]
                 span = tuple(
+                    default_index if index is None else
                     min(index, l) if index >= 0 else max(index + l, 0)
-                    if index is not None else default_index
                     for index, default_index in zip(sel, self.full_span)
                 )
                 return [span]


### PR DESCRIPTION
## Motivation
There's a logistic bug when handling `None` in spans. My apologies for that.

## Proposed changes
- M `manimlib/mobject/svg/string_mobject.py`
