### PR TITLE
fix: can't parse<u>Boolean Operation</u>

### DIFF
--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -243,7 +243,7 @@ class MarkupText(StringMobject):
         )
 
     def get_substr_flag(self, substr: str) -> int:
-        if re.fullmatch(r"<\w[\s\S]*[^/]>", substr):
+        if re.fullmatch(r"<\w[\s\S]*[^/]*>", substr):
             return 1
         if substr.startswith("</"):
             return -1


### PR DESCRIPTION
code:
bool_ops_text = MarkupText("<u>Boolean Operation</u>").next_to(ellipse1, UP * 3)

error: 
ManimGL v1.6.1
<u>
</u>
Traceback (most recent call last):
  File "d:\anaconda3\envs\manim\Scripts\manimgl-script.py", line 33, in <module>
    sys.exit(load_entry_point('manimgl', 'console_scripts', 'manimgl')())
  File "g:\github\manim\manimlib\__main__.py", line 25, in main
    scene.run()
  File "g:\github\manim\manimlib\scene\scene.py", line 120, in run
    self.construct()
  File "G:\github\manim\sin.py", line 173, in construct
    bool_ops_text = MarkupText("<u>Boolean Operation</u>").next_to(ellipse1, UP * 3)
  File "g:\github\manim\manimlib\mobject\svg\text_mobject.py", line 123, in __init__
    super().__init__(text, **kwargs)
  File "g:\github\manim\manimlib\mobject\svg\string_mobject.py", line 77, in __init__
    self.parse()
  File "g:\github\manim\manimlib\mobject\svg\string_mobject.py", line 262, in parse
    self.get_cmd_span_pairs(cmd_spans, flags)
  File "g:\github\manim\manimlib\mobject\svg\string_mobject.py", line 313, in get_cmd_span_pairs
    raise ValueError("Missing open command")
ValueError: Missing open command

<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
fix: can't parse<u>Boolean Operation</u>

## Proposed changes
<!-- What you changed in those files -->
- manimlib\mobject\svg\text_mobject.py get_substr_flag

## Test
<!-- How do you test your changes -->
**Code**:
class BooleanOperations(Scene):
    def construct(self):
        ellipse1 = Ellipse(
            width=4.0, height=5.0, fill_opacity=0.5, color=BLUE, stroke_width=10
        ).move_to(LEFT)
        ellipse2 = ellipse1.copy().set_color(color=RED).move_to(RIGHT)
        bool_ops_text = MarkupText("<u>Boolean Operation</u>").next_to(ellipse1, UP * 3)
        ellipse_group = Group(bool_ops_text, ellipse1, ellipse2).move_to(LEFT * 3)
        self.play(FadeIn(ellipse_group))

**Result**:
GUI