### PR TITLE
Add setitem to mobject

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -315,7 +315,10 @@ class Mobject(object):
             GroupClass = self.get_group_class()
             return GroupClass(*self.split().__getitem__(value))
         return self.split().__getitem__(value)
-
+    
+    def __setitem__(self, index, value):
+        return self.split().__setitem__(index, value)
+    
     def __iter__(self):
         return iter(self.split())
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
![image](https://user-images.githubusercontent.com/86190295/184071118-ede42cbd-ed11-47f2-bdd1-b8b4485d83e8.png)
We normally treat VGroup and mobjects as lists of submobjects. We should give them the same property like a list to get and modify a specific index of element.
## Proposed changes
<!-- What you changed in those files -->
- In mobject.mobject.py, added __setitem__ method under __getitem__

## Test
<!-- How do you test your changes -->
**Code**:
```python
    def str_list_to_tex_list(self, f: list[str]) -> VGroup:
        return  VGroup(
            *[Tex(s, **self.tex_kwargs)
            for s in f]
        )

    def construct(self): 
        formulas = [
            r"f(x)+g(x)=(m_{1}+m_{2})x+(b_{1}+b_{2})",
            r"[f(x)+g(x)]=m_{1}+m_{2}", #
            r"[f(x)+g(x)]=f'(x)+g'(x)", #
            r"f(x)\cdot g(x)=(m_{1}x+b_{1})(m_{2}x+b_{2})",
            r"=m_{1}m_{2}x^{2}+(m_{1}b_{2}+m_{2}b_{1})x+b_{1}b_{2}",
            r"[f(x)\cdot g(x)]=2m_{1}m_{2}+m_{1}b_{2}+m_{2}b_{1}", #
            r"[f(x)\cdot g(x)]=m_{1}(m_{2}+b_{2})+m_{2}(m_{1}+b_{1})", #
            r"[f(x)\cdot g(x)]=f'(x)g(x)+g'(x)f(x)" #
        ]
        formulas = self.str_list_to_tex_list(formulas).arrange(DOWN)
        di = [2, 3, 6, 7, 8]
        for i in di:
            i = i - 1
            cp = derivative_sign.copy().next_to(formulas[i], LEFT)
            self.add(cp)
            formulas[i] = VGroup(cp, formulas[i])
```
**Result**:
![image](https://user-images.githubusercontent.com/86190295/184071056-0ef97532-a537-4e16-9442-607ddb771a92.png)
