### PR TITLE
Fix bug with rendering progress bar

### DIFF
--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -122,8 +122,8 @@ def get_scenes_to_render(scene_classes, scene_config, config):
         fw_config = scene_config["file_writer_config"]
         if fw_config["write_to_movie"]:
             fw_config["total_frames"] = compute_total_frames(scene_class, scene_config)
-            scene = scene_class(**scene_config)
-            result.append(scene)
+        scene = scene_class(**scene_config)
+        result.append(scene)
     return result
 
 

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -111,11 +111,20 @@ def get_scenes_to_render(scene_classes, scene_config, config):
             log.error(f"No scene named {scene_name} found")
     if result:
         return result
+    
+    # another case
+    result=[]
     if len(scene_classes) == 1:
-        result = [scene_classes[0]]
+        scene_classes = [scene_classes[0]]
     else:
-        result = prompt_user_for_choice(scene_classes)
-    return [scene_class(**scene_config) for scene_class in result]
+        scene_classes = prompt_user_for_choice(scene_classes)
+    for scene_class in scene_classes:
+        fw_config = scene_config["file_writer_config"]
+        if fw_config["write_to_movie"]:
+            fw_config["total_frames"] = compute_total_frames(scene_class, scene_config)
+            scene = scene_class(**scene_config)
+            result.append(scene)
+    return result
 
 
 def get_scene_classes_from_module(module):


### PR DESCRIPTION
I've noticed that if no scene names are passed to `manimgl` explicitly, then the rendering progress bar will not be shown correctly.

To showcase the bug, suppose we have a file with only one Scene class in it:

```python
# my_scene.py
def MyScene(Scene):
    def construct(self):
        # some animations
# end of file
```
And I'd like to render it using `manimgl`. Then both of the following command line should work:
```bash
$ manimgl my_scene.py MyScene -w
$ manimgl my_scene.py -w
```
as there's only one scene in the file and the scene name can be omitted.

But when I omit the scene name(second case), the progress bar by `SceneFileWriter` during rendering will disappear/can't show correctly, which is annoying you're rendering long and intricate scenes.

## Motivation
Fix the bug with rendering progress bar as shown above.

I believe that this is a bug. But if it's an intended feature, please let me know.

## Proposed changes
The bug arises from the `SceneFileWriter` and `extract_scene` module.
In `SceneFileWriter`, if its requested to open movie pipe and, total frames of the Scene is counted to be >0, then it will show progress display. 
(See `scene_file_writer.py SceneFileWriter.open_movie_pipe(...)` func.)
However, in `extract_scene.get_scenes_to_render(...)`, if scene to render are passed from command line (selected from the prompt instead, or so), total frames of the scene is NOT counted. This makes `SceneFileWriter` confused and not display the rendering progress bar.

To fix this, I change `extract_scene.get_scenes_to_render(...)` so that all paths of it will count total_frames for the `SceneFileWriter`. (See codes for details)


## Test
The test code is oriented on command line for this bug.
**Code**:
First we have some scenes to render:
```python
# my_scene.py
def MyScene(Scene):
    def construct(self):
        r = Rectangle()
        self.add(r)
        # some arbitrary animations to render
        self.play(r.animate.shift(RIGHT))
        self.play(r.animate.shift(LEFT*3), run_time=3)
```
Then we call `manimgl` to render it on command line:
```bash
$ manimgl my_scene.py MyScene -w
$ manimgl my_scene.py -w
```
Normal window presenting mode is not broken, which can be shown by:
```bash
$ manimgl my_scene.py [MyScene]
```

**Result**:
In both case, rendering progress bar like this will appear:

```
Rendering MyScene.mp4 (1 MoveToTarget):  26%|##      | 31/120 [00:03<00:15,  5.71it/s]
```
Before bug fix, ONLY the first command line will have the progress bar.
