### PR TITLE
Add `set_anim_args` to `.animate` method

### DIFF
--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -176,9 +176,9 @@ class MoveToTarget(Transform):
 
 
 class _MethodAnimation(MoveToTarget):
-    def __init__(self, mobject: Mobject, methods: Callable):
+    def __init__(self, mobject: Mobject, methods: list[Callable], **kwargs):
         self.methods = methods
-        super().__init__(mobject)
+        super().__init__(mobject, **kwargs)
 
 
 class ApplyMethod(Transform):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -2015,7 +2015,8 @@ class _AnimationBuilder:
         self.overridden_animation = None
         self.mobject.generate_target()
         self.is_chaining = False
-        self.methods = []
+        self.methods: list[Callable] = []
+        self.anim_args = {}
 
     def __getattr__(self, method_name: str):
         method = getattr(self.mobject.target, method_name)
@@ -2040,13 +2041,17 @@ class _AnimationBuilder:
         self.is_chaining = True
         return update_target
 
+    def set_anim_args(self, **kwargs):
+        self.anim_args = kwargs
+        return self
+
     def build(self):
         from manimlib.animation.transform import _MethodAnimation
 
         if self.overridden_animation:
             return self.overridden_animation
 
-        return _MethodAnimation(self.mobject, self.methods)
+        return _MethodAnimation(self.mobject, self.methods, **self.anim_args)
 
 
 def override_animate(method):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -2042,6 +2042,18 @@ class _AnimationBuilder:
         return update_target
 
     def set_anim_args(self, **kwargs):
+        '''
+        You can change the args of :class:`~manimlib.animation.transform.Transform`, such as
+
+        - ``run_time``
+        - ``time_span``
+        - ``rate_func``
+        - ``lag_ratio``
+        - ``path_arc``
+        - ``path_func``
+
+        and so on.
+        '''
         self.anim_args = kwargs
         return self
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -2017,6 +2017,7 @@ class _AnimationBuilder:
         self.is_chaining = False
         self.methods: list[Callable] = []
         self.anim_args = {}
+        self.can_pass_args = True
 
     def __getattr__(self, method_name: str):
         method = getattr(self.mobject.target, method_name)
@@ -2041,6 +2042,9 @@ class _AnimationBuilder:
         self.is_chaining = True
         return update_target
 
+    def __call__(self, **kwargs):
+        return self.set_anim_args(**kwargs)
+
     def set_anim_args(self, **kwargs):
         '''
         You can change the args of :class:`~manimlib.animation.transform.Transform`, such as
@@ -2054,7 +2058,15 @@ class _AnimationBuilder:
 
         and so on.
         '''
+
+        if not self.can_pass_args:
+            raise ValueError(
+                "Animation arguments can only be passed by calling ``animate`` "
+                "or ``set_anim_args`` and can only be passed once",
+            )
+
         self.anim_args = kwargs
+        self.can_pass_args = False
         return self
 
     def build(self):


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

With the pr of manim community, we can easily use `.animate` method to build Animation, but we cannot change the arguments of Animations. With the `set_anim_args` method, we can change args of Animation. Since `_AnimationBuilder` will build it into `MoveToTarget`, we can also use `path_arc` or `path_func` and so on.

## Test

```python
class TestAnimateArgs(Scene):
    def construct(self) -> None:
        a = Circle().to_edge(LEFT)
        anim_builder = (
            a
            .animate
            .scale(3)
            .to_edge(RIGHT)
            .set_anim_args(run_time=3, time_span=(1, 2), rate_func=double_smooth, path_arc=PI/2)
        )
        self.play(anim_builder)
```


https://user-images.githubusercontent.com/55699713/189510867-2d94d2c5-f8bc-44ed-a3e4-697df835cea4.mp4


