### PR TITLE
Fixing a typo ("termnial" -> "terminal")

### DIFF
--- a/docs/source/getting_started/example_scenes.rst
+++ b/docs/source/getting_started/example_scenes.rst
@@ -23,7 +23,7 @@ InteractiveDevlopment
             self.play(ShowCreation(square))
             self.wait()
 
-            # This opens an iPython termnial where you can keep writing
+            # This opens an iPython terminal where you can keep writing
             # lines as if they were part of this construct method.
             # In particular, 'square', 'circle' and 'self' will all be
             # part of the local namespace in that terminal.

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -593,7 +593,7 @@ class InteractiveDevelopment(Scene):
         self.play(ShowCreation(square))
         self.wait()
 
-        # This opens an iPython termnial where you can keep writing
+        # This opens an iPython terminal where you can keep writing
         # lines as if they were part of this construct method.
         # In particular, 'square', 'circle' and 'self' will all be
         # part of the local namespace in that terminal.


### PR DESCRIPTION
## Motivation
I fixed a typo in the documentation

## Proposed changes
I fixed a single typo "termnial" in the documentation.

## Test
It is a documentation change