### PR TITLE
Fix bug: Issue#1844 Modified is_off_screen() function

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1035,13 +1035,13 @@ class Mobject(object):
         return self
 
     def is_off_screen(self):
-        if self.get_left()[0] > FRAME_X_RADIUS:
+        if self.get_left()[0] < -FRAME_X_RADIUS:
             return True
-        if self.get_right()[0] < -FRAME_X_RADIUS:
+        if self.get_right()[0] > FRAME_X_RADIUS:
             return True
-        if self.get_bottom()[1] > FRAME_Y_RADIUS:
+        if self.get_bottom()[1] < -FRAME_Y_RADIUS:
             return True
-        if self.get_top()[1] < -FRAME_Y_RADIUS:
+        if self.get_top()[1] > FRAME_Y_RADIUS:
             return True
         return False
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
To fix the issue https://github.com/3b1b/manim/issues/1844#issue-1317730247
## Proposed changes
- Changed the comparison conditions to check if object is outside the screen 

**Code**:
```py
def is_off_screen(self):
        if self.get_left()[0] < -FRAME_X_RADIUS:
            return True
        if self.get_right()[0] > FRAME_X_RADIUS:
            return True
        if self.get_bottom()[1] < -FRAME_Y_RADIUS:
            return True
        if self.get_top()[1] > FRAME_Y_RADIUS:
            return True
        return False
```
