### PR TITLE
Fix 2 typos

### DIFF
--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -124,11 +124,11 @@ class Animation(object):
             self.interpolate_submobject(*mobs, sub_alpha)
 
     def interpolate_submobject(self, submobject, starting_sumobject, alpha):
-        # Typically ipmlemented by subclass
+        # Typically implemented by subclass
         pass
 
     def get_sub_alpha(self, alpha, index, num_submobjects):
-        # TODO, make this more understanable, and/or combine
+        # TODO, make this more understandable, and/or combine
         # its functionality with AnimationGroup's method
         # build_animations_with_timings
         lag_ratio = self.lag_ratio


### PR DESCRIPTION
In manim cairo-backend, line 127 and 131,
Fixing typo: "ipmlemented" to "implemented" ; "understanable" to "understandable"