### PR TITLE
Request to remove static decorators to resolve the recent issue : TypeError: 'staticmethod' object is not callable

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -551,7 +551,6 @@ class Mobject(object):
             return result
         return wrapper
 
-    @stash_mobject_pointers
     def serialize(self):
         return pickle.dumps(self)
 
@@ -566,7 +565,6 @@ class Mobject(object):
         except AttributeError:
             return copy.deepcopy(self)
 
-    @stash_mobject_pointers
     def copy(self, deep: bool = False):
         if deep:
             return self.deepcopy()
@@ -1751,24 +1749,19 @@ class Mobject(object):
             return self
         return wrapper
 
-    @affects_shader_info_id
     def fix_in_frame(self):
         self.uniforms["is_fixed_in_frame"] = 1.0
         self.is_fixed_in_frame = True
         return self
-
-    @affects_shader_info_id
     def unfix_from_frame(self):
         self.uniforms["is_fixed_in_frame"] = 0.0
         self.is_fixed_in_frame = False
         return self
 
-    @affects_shader_info_id
     def apply_depth_test(self):
         self.depth_test = True
         return self
 
-    @affects_shader_info_id
     def deactivate_depth_test(self):
         self.depth_test = False
         return self

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -1008,7 +1008,6 @@ class VMobject(Mobject):
         self.needs_new_triangulation = False
         return tri_indices
 
-    @staticmethod
     def triggers_refreshed_triangulation(func: Callable):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
@@ -1018,28 +1017,23 @@ class VMobject(Mobject):
                 self.refresh_triangulation()
         return wrapper
 
-    @triggers_refreshed_triangulation
     def set_points(self, points: Vect3Array):
         super().set_points(points)
         return self
 
-    @triggers_refreshed_triangulation
     def append_points(self, points: Vect3Array):
         super().append_points(points)
         return self
 
-    @triggers_refreshed_triangulation
     def reverse_points(self):
         super().reverse_points()
         return self
 
-    @triggers_refreshed_triangulation
     def set_data(self, data: dict):
         super().set_data(data)
         return self
 
     # TODO, how to be smart about tangents here?
-    @triggers_refreshed_triangulation
     def apply_function(
         self,
         function: Callable[[Vect3], Vect3],


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
When running Example today, using ***manimgl example_scenes.py OpeningManimExample*** , after I follow the installation steps exactly on my macOS, I keep gettting getting ***TypeError: 'staticmethod' object is not callable***. It is not just me. There is one other who got the same issue too. Please see (https://github.com/3b1b/manim/issues/1945).

## Proposed changes
<!-- What you changed in those files -->
Ao, I tried removing all the static decorators which gives the errors from manim/manimlib/mobject/mobject.py and manim/manimlib/mobject/types/vectorized_mobject.py.

The exact lines are
- manim/manimlib/mobject/mobject.py", line 555
- manim/manimlib/mobject/mobject.py", line 569
- manim/manimlib/mobject/mobject.py", line 1753
- manim/manimlib/mobject/types/vectorized_mobject.py", line 1022

## Test
<!-- How do you test your changes -->
**Result**: After the removal of all static decorators in the two files, I was able to run the example. It will show the following and a window with animations.

```
ManimGL v1.6.1
[01:33:49] INFO     Using the default configuration file, which you can modify in                                      config.py:348
                    `/Users/pi/Desktop/manim/manim/manimlib/default_config.yml`                                                     
           INFO     If you want to create a local configuration file, you can create a file named `custom_config.yml`, config.py:349
                    or run `manimgl --config`
```