### PR TITLE
Updated tqdm to support also notebooks

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -13,7 +13,7 @@ from IPython.terminal.embed import InteractiveShellEmbed
 from IPython.core.getipython import get_ipython
 
 import numpy as np
-from tqdm import tqdm as ProgressDisplay
+from tqdm.auto import tqdm as ProgressDisplay
 
 from manimlib.animation.animation import prepare_animation
 from manimlib.animation.fading import VFadeInThenOut

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -8,7 +8,7 @@ import sys
 
 import numpy as np
 from pydub import AudioSegment
-from tqdm import tqdm as ProgressDisplay
+from tqdm.auto import tqdm as ProgressDisplay
 
 from manimlib.constants import FFMPEG_BIN
 from manimlib.logger import log

--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -8,7 +8,7 @@ import platform
 from mapbox_earcut import triangulate_float32 as earcut
 import numpy as np
 from scipy.spatial.transform import Rotation
-from tqdm import tqdm as ProgressDisplay
+from tqdm.auto import tqdm as ProgressDisplay
 
 from manimlib.constants import DOWN, OUT, RIGHT, UP
 from manimlib.constants import PI, TAU


### PR DESCRIPTION
## Motivation
When using `tqdm` in the context of Jupyter Notebooks, the CLI version does not cut it.

## Proposed changes
For this reason, the `tqdm` authors created the `tqdm.auto` dispatching, which displays an optimal version of `tqdm` for either CLI or jupyter notebooks depending on the context.

## Test
Using the package in a CLI or Jupyter Notebook environment will display a different loading bar.