### PR TITLE
Make isinstance check work for python 3.7-3.9

### DIFF
--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -198,7 +198,7 @@ class VMobject(Mobject):
         if width is not None:
             for mob in self.get_family(recurse):
                 data = mob.data if mob.get_num_points() > 0 else mob._data_defaults
-                if isinstance(width, float | int):
+                if isinstance(width, (float, int)):
                     data['stroke_width'][:, 0] = width
                 else:
                     data['stroke_width'][:, 0] = resize_with_interpolation(


### PR DESCRIPTION
The type union operator wasn't added until Python 3.10. This was added a few days ago, which caused manim to crash with a TypeError for earlier versions of Python. This CL causes the code to do the same thing, but it works for <3.10 versions of Python too.

Fixes #1968