### PR TITLE
Winding fill

### DIFF
--- a/manimlib/animation/fading.py
+++ b/manimlib/animation/fading.py
@@ -103,12 +103,8 @@ class FadeTransform(Transform):
         self.stretch = stretch
         self.dim_to_match = dim_to_match
 
-        group_type = Group
-        if isinstance(mobject, VMobject) and isinstance(target_mobject, VMobject):
-            group_type = VGroup
-
         mobject.save_state()
-        super().__init__(group_type(mobject, target_mobject.copy()), **kwargs)
+        super().__init__(Group(mobject, target_mobject.copy()), **kwargs)
 
     def begin(self) -> None:
         self.ending_mobject = self.mobject.copy()

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -457,7 +457,10 @@ class Camera(object):
             self.ctx.enable(moderngl.BLEND)
             self.ctx.blend_func = moderngl.ONE, moderngl.ONE
             self.ctx.blend_equation = moderngl.FUNC_SUBTRACT
-            render_group["vao"].render(int(shader_wrapper.render_primitive))
+            render_group["vao"].render(
+                int(shader_wrapper.render_primitive),
+                instances=2,
+            )
             self.ctx.blend_func = moderngl.DEFAULT_BLENDING
             self.ctx.blend_equation = moderngl.FUNC_ADD
             self.fbo.use()

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -479,7 +479,7 @@ class Camera(object):
         self.fill_fbo.clear(0.0, 0.0, 0.0, 0.0)
         self.fill_fbo.use()
         self.ctx.blend_func = (
-            moderngl.ONE, moderngl.ZERO,
+            moderngl.ONE, moderngl.ONE,
             moderngl.ONE, moderngl.ONE,
         )
         vao.render(render_primitive)

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -476,12 +476,9 @@ class Camera(object):
         if not winding:
             vao.render(moderngl.TRIANGLES)
             return
-        self.fill_fbo.clear(0.0, 0.0, 0.0, 0.0)
+        self.fill_fbo.clear()
         self.fill_fbo.use()
-        self.ctx.blend_func = (
-            moderngl.ONE, moderngl.ONE,
-            moderngl.ONE, moderngl.ONE,
-        )
+        self.ctx.blend_func = (moderngl.ONE, moderngl.ONE)
         vao.render(render_primitive)
         self.ctx.blend_func = moderngl.DEFAULT_BLENDING
         self.fbo.use()

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -502,7 +502,7 @@ class Camera(object):
         # Data buffer
         vert_data = shader_wrapper.vert_data
         indices = shader_wrapper.vert_indices
-        if indices is None:
+        if len(indices) == 0:
             ibo = None
         elif single_use:
             ibo = self.ctx.buffer(indices.astype(np.uint32))

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1264,7 +1264,7 @@ class Mobject(object):
             if color is not None:
                 if isinstance(color, list):
                     rgbs = np.array(list(map(color_to_rgb, color)))
-                    resize_with_interpolation(rgbs, len(data))
+                    rgbs = resize_with_interpolation(rgbs, len(data))
                 else:
                     rgbs = color_to_rgb(color)
                 data[name][:, :3] = rgbs

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1841,7 +1841,7 @@ class Mobject(object):
 
     def init_shader_data(self):
         # TODO, only call this when needed?
-        self.shader_indices = None
+        self.shader_indices = np.zeros(0)
         self.shader_wrapper = ShaderWrapper(
             vert_data=self.data,
             shader_folder=self.shader_folder,

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1673,9 +1673,12 @@ class Mobject(object):
         for submob, sf in zip(self.submobjects, split_factors):
             new_submobs.append(submob)
             for k in range(1, sf):
-                new_submobs.append(submob.copy().scale(0))
+                new_submobs.append(submob.invisible_copy())
         self.set_submobjects(new_submobs)
         return self
+
+    def invisible_copy(self):
+        return self.copy().set_opacity(0)
 
     # Interpolate
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1673,12 +1673,7 @@ class Mobject(object):
         for submob, sf in zip(self.submobjects, split_factors):
             new_submobs.append(submob)
             for k in range(1, sf):
-                new_submob = submob.copy()
-                # If the submobject is at all transparent, then
-                # make the copy completely transparent
-                if submob.get_opacity() < 1:
-                    new_submob.set_opacity(0)
-                new_submobs.append(new_submob)
+                new_submobs.append(submob.copy().scale(0))
         self.set_submobjects(new_submobs)
         return self
 

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 SVG_HASH_TO_MOB_MAP: dict[int, list[VMobject]] = {}
-PATH_TO_POINTS: dict[str, Tuple[Vect3Array, np.ndarray]] = {}
+PATH_TO_POINTS: dict[str, Vect3Array] = {}
 
 
 def _convert_point_to_3d(x: float, y: float) -> np.ndarray:
@@ -320,16 +320,14 @@ class VMobjectFromSVGPath(VMobject):
                 self.set_points(self.get_points_without_null_curves())
             # So triangulation doesn't get messed up
             self.subdivide_intersections()
+            # Always default to orienting outward
+            if self.get_unit_normal()[2] < 0:
+                self.reverse_points()
             # Save for future use
-            PATH_TO_POINTS[path_string] = (
-                self.get_points().copy(),
-                self.get_triangulation().copy()
-            )
+            PATH_TO_POINTS[path_string] = self.get_points().copy()
         else:
-            points, triangulation = PATH_TO_POINTS[path_string]
+            points = PATH_TO_POINTS[path_string]
             self.set_points(points)
-            self.triangulation = triangulation
-            self.needs_new_triangulation = False
 
     def handle_commands(self) -> None:
         segment_class_to_func_map = {

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -1154,7 +1154,7 @@ class VMobject(Mobject):
             uniforms=self.uniforms,
             shader_folder=self.fill_shader_folder,
             render_primitive=self.fill_render_primitive,
-            render_to_texture=True,
+            is_fill=True,
         )
         self.stroke_shader_wrapper = ShaderWrapper(
             vert_data=stroke_data,

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -875,6 +875,7 @@ class VMobject(Mobject):
             new_points = np.vstack(paths)
             mob.resize_points(len(new_points), resize_func=resize_preserving_order)
             mob.set_points(new_points)
+            mob.get_joint_products()
         return self
 
     def insert_n_curves(self, n: int, recurse: bool = True):
@@ -1069,8 +1070,8 @@ class VMobject(Mobject):
 
         # Find all the unit tangent vectors at each joint
         a0, h, a1 = points[0:-1:2], points[1::2], points[2::2]
-        a0_to_h = normalize_along_axis(h - a0, 1)
-        h_to_a1 = normalize_along_axis(a1 - h, 1)
+        a0_to_h = h - a0
+        h_to_a1 = a1 - h
 
         vect_to_vert = np.zeros(points.shape)
         vect_from_vert = np.zeros(points.shape)

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -142,6 +142,19 @@ class VMobject(Mobject):
             raise Exception("All submobjects must be of type VMobject")
         super().add(*vmobjects)
 
+    def add_background_rectangle(
+        self,
+        color: ManimColor | None = None,
+        opacity: float = 0.75,
+        **kwargs
+    ):
+        normal = self.family_members_with_points()[0].get_unit_normal()
+        super().add_background_rectangle(color, opacity, **kwargs)
+        rect = self.background_rectangle
+        if np.dot(rect.get_unit_normal(), normal) < 0:
+            rect.reverse_points()
+        return self
+
     # Colors
     def init_colors(self):
         self.set_fill(

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -931,7 +931,7 @@ class VMobject(Mobject):
         assert(isinstance(vmobject, VMobject))
         vm_points = vmobject.get_points()
         if a <= 0 and b >= 1:
-            self.set_points(vm_points, refresh=False)
+            self.set_points(vm_points)
             return self
         num_curves = vmobject.get_num_curves()
 

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -878,6 +878,12 @@ class VMobject(Mobject):
             mob.get_joint_products()
         return self
 
+    def invisible_copy(self):
+        result = self.copy()
+        result.append_vectorized_mobject(self.copy().reverse_points())
+        result.set_opacity(0)
+        return result
+
     def insert_n_curves(self, n: int, recurse: bool = True):
         for mob in self.get_family(recurse):
             if mob.get_num_curves() > 0:
@@ -1107,6 +1113,7 @@ class VMobject(Mobject):
             if refresh:
                 self.refresh_triangulation()
                 self.refresh_joint_products()
+            return self
         return wrapper
 
     @triggers_refreshed_triangulation

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -89,6 +89,7 @@ class VMobject(Mobject):
         use_simple_quadratic_approx: bool = False,
         # Measured in pixel widths
         anti_alias_width: float = 1.0,
+        use_winding_fill: bool = True,
         **kwargs
     ):
         self.fill_color = fill_color or color or DEFAULT_FILL_COLOR
@@ -103,7 +104,7 @@ class VMobject(Mobject):
         self.flat_stroke = flat_stroke
         self.use_simple_quadratic_approx = use_simple_quadratic_approx
         self.anti_alias_width = anti_alias_width
-        self._use_winding_fill = True
+        self._use_winding_fill = use_winding_fill
 
         self.needs_new_triangulation = True
         self.triangulation = np.zeros(0, dtype='i4')

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -845,8 +845,8 @@ class VMobject(Mobject):
             sp2 = self.insert_n_curves_to_point_list(diff2, sp2)
             if n > 0:
                 # Add intermediate anchor to mark path end
-                new_subpaths1.append(new_subpaths1[0][-1])
-                new_subpaths2.append(new_subpaths2[0][-1])
+                new_subpaths1.append(new_subpaths1[-1][-1])
+                new_subpaths2.append(new_subpaths2[-1][-1])
             new_subpaths1.append(sp1)
             new_subpaths2.append(sp2)
 

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -1183,7 +1183,6 @@ class VMobject(Mobject):
         for submob in family:
             if submob.has_fill():
                 submob.data["base_point"][:] = submob.data["point"][0]
-                # submob.data["base_color"][:] = submob.data["fill_color"][0]
                 fill_datas.append(submob.data[fill_names])
                 # Add dummy
                 fill_datas.append(submob.data[fill_names][-1:])

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -34,7 +34,7 @@ class ShaderWrapper(object):
         depth_test: bool = False,
         use_clip_plane: bool = False,
         render_primitive: int = moderngl.TRIANGLE_STRIP,
-        render_to_texture: bool = False,
+        is_fill: bool = False,
     ):
         self.vert_data = vert_data
         self.vert_indices = vert_indices
@@ -45,7 +45,7 @@ class ShaderWrapper(object):
         self.depth_test = depth_test
         self.use_clip_plane = use_clip_plane
         self.render_primitive = str(render_primitive)
-        self.render_to_texture = render_to_texture
+        self.is_fill = is_fill
         self.init_program_code()
         self.refresh_id()
 

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -37,7 +37,7 @@ class ShaderWrapper(object):
         is_fill: bool = False,
     ):
         self.vert_data = vert_data
-        self.vert_indices = vert_indices or np.zeros(0)
+        self.vert_indices = (vert_indices or np.zeros(0)).astype(int)
         self.vert_attributes = vert_data.dtype.names
         self.shader_folder = shader_folder
         self.uniforms = uniforms or dict()
@@ -154,6 +154,7 @@ class ShaderWrapper(object):
         np.concatenate(data_list, out=self.vert_data)
 
         if indices_list is None:
+            self.vert_indices = resize_array(self.vert_indices, 0)
             return self
 
         total_verts = sum(len(vi) for vi in indices_list)

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -34,6 +34,7 @@ class ShaderWrapper(object):
         depth_test: bool = False,
         use_clip_plane: bool = False,
         render_primitive: int = moderngl.TRIANGLE_STRIP,
+        render_to_texture: bool = False,
     ):
         self.vert_data = vert_data
         self.vert_indices = vert_indices
@@ -44,6 +45,7 @@ class ShaderWrapper(object):
         self.depth_test = depth_test
         self.use_clip_plane = use_clip_plane
         self.render_primitive = str(render_primitive)
+        self.render_to_texture = render_to_texture
         self.init_program_code()
         self.refresh_id()
 

--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -2,29 +2,20 @@
 
 in vec4 color;
 in float fill_all;  // Either 0 or 1
-in float uv_anti_alias_width;
 
 in float orientation;
 in vec2 uv_coords;
-in float is_linear;
 
 out vec4 frag_color;
-
-float sdf(){
-    float x0 = uv_coords.x;
-    float y0 = uv_coords.y;
-    if(bool(is_linear)) return abs(y0);
-
-    float Fxy = y0 - x0 * x0;
-    if(orientation * Fxy >= 0) return 0.0;
-
-    return abs(Fxy) / sqrt(1 + 4 * x0 * x0);
-}
-
 
 void main() {
     if (color.a == 0) discard;
     frag_color = color;
-    if (bool(fill_all)) return;
-    frag_color.a *= smoothstep(1, 0, sdf() / uv_anti_alias_width);
+    if (orientation == 0) return;
+
+    float x0 = uv_coords.x;
+    float y0 = uv_coords.y;
+    float Fxy = y0 - x0 * x0;
+    if(orientation * Fxy < 0) discard;
+
 }

--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -1,9 +1,7 @@
 #version 330
 
 in vec4 color;
-in float fill_all;  // Either 0 or 1
-
-in float orientation;
+in float fill_all;
 in vec2 uv_coords;
 
 out vec4 frag_color;
@@ -11,11 +9,9 @@ out vec4 frag_color;
 void main() {
     if (color.a == 0) discard;
     frag_color = color;
-    if (orientation == 0) return;
+    if (bool(fill_all)) return;
 
-    float x0 = uv_coords.x;
-    float y0 = uv_coords.y;
-    float Fxy = y0 - x0 * x0;
-    if(orientation * Fxy < 0) discard;
-
+    float x = uv_coords.x;
+    float y = uv_coords.y;
+    if(y - x * x < 0) discard;
 }

--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -1,7 +1,10 @@
 #version 330
 
+uniform bool winding;
+
 in vec4 color;
 in float fill_all;
+in float orientation;
 in vec2 uv_coords;
 
 out vec4 frag_color;
@@ -9,9 +12,14 @@ out vec4 frag_color;
 void main() {
     if (color.a == 0) discard;
     frag_color = color;
+
+    if(winding && orientation > 0) frag_color *= -1;
+
     if (bool(fill_all)) return;
 
     float x = uv_coords.x;
     float y = uv_coords.y;
-    if(y - x * x < 0) discard;
+    float Fxy = (y - x * x);
+    if(!winding && orientation > 0) Fxy *= -1;
+    if(Fxy < 0) discard;
 }

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -1,7 +1,7 @@
 #version 330
 
 layout (triangles) in;
-layout (triangle_strip, max_vertices = 7) out;
+layout (triangle_strip, max_vertices = 3) out;
 
 uniform float anti_alias_width;
 uniform float pixel_size;
@@ -11,11 +11,10 @@ in vec3 verts[3];
 in vec4 v_color[3];
 in vec3 v_base_point[3];
 in float v_vert_index[3];
-
+in float v_inst_id[3];
 
 out vec4 color;
-
-out float orientation;
+out float fill_all;
 // uv space is where the curve coincides with y = x^2
 out vec2 uv_coords;
 
@@ -38,31 +37,29 @@ void main(){
     // actually only need every other strip element
     if (int(v_vert_index[0]) % 2 == 1) return;
 
-    // Curves are marked as eneded when the handle after
+    // Curves are marked as ended when the handle after
     // the first anchor is set equal to that anchor
     if (verts[0] == verts[1]) return;
 
     vec3 unit_normal = get_unit_normal(verts[0], verts[1], verts[2]);
 
-    // Emit main triangle
-    orientation = 0.0;
-    uv_coords = vec2(0.0);
-    emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
-    emit_vertex_wrapper(v_base_point[0], v_color[1], unit_normal);
-    emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
-
-    // Emit edge triangle
-    orientation = 1.0;
-    uv_coords = vec2(0, 0);
-    // Two dummies
-    emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
-    emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
-    // Inner corner
-    uv_coords = vec2(0.5, 0);
-    emit_vertex_wrapper(verts[1], v_color[1], unit_normal);
-    // Last corner
-    uv_coords = vec2(1.0, 1.0);
-    emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
-    EndPrimitive();
+    if(int(v_inst_id[0]) % 2 == 0){
+        // Emit main triangle
+        fill_all = float(true);
+        uv_coords = vec2(0.0);
+        emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
+        emit_vertex_wrapper(v_base_point[0], v_color[0], unit_normal);
+        emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
+    }else{
+        // Emit edge triangle
+        fill_all = float(false);
+        uv_coords = vec2(0.0, 0.0);
+        emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
+        uv_coords = vec2(0.5, 0);
+        emit_vertex_wrapper(verts[1], v_color[1], unit_normal);
+        uv_coords = vec2(1.0, 1.0);
+        emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
+        EndPrimitive();
+    }
 }
 

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -41,18 +41,21 @@ void main(){
     // the first anchor is set equal to that anchor
     if (verts[0] == verts[1]) return;
 
+    if (v_color[0].a == 0 && v_color[1].a == 0 && v_color[2].a == 0) return;
+
     vec3 unit_normal = get_unit_normal(verts[0], verts[1], verts[2]);
 
     if(int(v_inst_id[0]) % 2 == 0){
         // Emit main triangle
-        fill_all = float(true);
+        fill_all = 1.0;
         uv_coords = vec2(0.0);
         emit_vertex_wrapper(v_base_point[0], v_color[0], unit_normal);
         emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
         emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
     }else{
         // Emit edge triangle
-        fill_all = float(false);
+        fill_all = 0.0;
+        // A quadratic bezier curve with these points coincides with y = x^2
         vec2 uv_coords_arr[3] = vec2[3](
             vec2(0.0, 0.0),
             vec2(0.5, 0),

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -1,129 +1,68 @@
 #version 330
 
 layout (triangles) in;
-layout (triangle_strip, max_vertices = 5) out;
+layout (triangle_strip, max_vertices = 7) out;
 
 uniform float anti_alias_width;
 uniform float pixel_size;
+uniform vec3 corner;
 
 in vec3 verts[3];
-in float v_orientation[3];
 in vec4 v_color[3];
+in vec3 v_base_point[3];
 in float v_vert_index[3];
 
+
 out vec4 color;
-out float fill_all;
-out float uv_anti_alias_width;
 
 out float orientation;
 // uv space is where the curve coincides with y = x^2
 out vec2 uv_coords;
-out float is_linear;
-
-const float ANGLE_THRESHOLD = 1e-3;
 
 
 // Analog of import for manim only
 #INSERT get_gl_Position.glsl
-#INSERT get_xyz_to_uv.glsl
+#INSERT get_unit_normal.glsl
 #INSERT finalize_color.glsl
 
 
-void emit_vertex_wrapper(vec3 point, int index, vec3 unit_normal){
-    color = finalize_color(v_color[index], point, unit_normal);
+void emit_vertex_wrapper(vec3 point, vec4 v_color, vec3 unit_normal){
+    color = finalize_color(v_color, point, unit_normal);
     gl_Position = get_gl_Position(point);
     EmitVertex();
 }
 
 
-void emit_simple_triangle(vec3 unit_normal){
-    for(int i = 0; i < 3; i++){
-        emit_vertex_wrapper(verts[i], i, unit_normal);
-    }
-    EndPrimitive();
-}
-
-
-void emit_pentagon(
-    // Triangle vertices
-    vec3 p0,
-    vec3 p1,
-    vec3 p2,
-    // Unit tangent vector
-    vec3 t01,
-    vec3 t12,
-    vec3 unit_normal
-){
-    // Vectors perpendicular to the curve in the plane of the curve
-    // pointing outside the curve
-    vec3 p0_perp = cross(t01, unit_normal);
-    vec3 p2_perp = cross(t12, unit_normal);
-
-    float angle = acos(clamp(dot(t01, t12), -1, 1));
-    is_linear = float(angle < ANGLE_THRESHOLD);
-
-    if(bool(is_linear)){
-        // Cross with unit z vector
-        p0_perp = normalize(vec3(-t01.y, t01.x, 0));
-        p2_perp = p0_perp;
-    }
-
-    bool fill_inside = orientation > 0.0;
-    float aaw = anti_alias_width * pixel_size;
-    vec3 corners[5] = vec3[5](p0, p0, p1, p2, p2);
-
-    if(fill_inside || bool(is_linear)){
-        // Add buffer outside the curve
-        corners[0] += aaw * p0_perp;
-        corners[2] += 0.5 * aaw * (p0_perp + p2_perp);
-        corners[4] += aaw * p2_perp;
-    } else{
-        // Add buffer inside the curve
-        corners[1] -= aaw * p0_perp;
-        corners[3] -= aaw * p2_perp;
-    }
-
-    // Compute xy_to_uv matrix, and potentially re-evaluate bezier degree
-    bool too_steep;
-    mat4 xyz_to_uv = get_xyz_to_uv(p0, p1, p2, 10.0, too_steep);
-    if(too_steep) is_linear = 1.0;
-    uv_anti_alias_width = aaw * length(xyz_to_uv[0].xyz);
-
-    for(int i = 0; i < 5; i++){
-        int j = int[5](0, 0, 1, 2, 2)[i];
-        vec3 corner = corners[i];
-        uv_coords = (xyz_to_uv * vec4(corner, 1.0)).xy;
-        emit_vertex_wrapper(corner, j, unit_normal);
-    }
-    EndPrimitive();
-}
-
-
 void main(){
-    // If vert indices are sequential, don't fill all
-    fill_all = float(
-        (v_vert_index[1] - v_vert_index[0]) != 1.0 ||
-        (v_vert_index[2] - v_vert_index[1]) != 1.0
-    );
+    // We use the triangle strip primative, but
+    // actually only need every other strip element
+    if (int(v_vert_index[0]) % 2 == 1) return;
 
-    vec3 p0 = verts[0];
-    vec3 p1 = verts[1];
-    vec3 p2 = verts[2];
-    vec3 t01 = p1 - p0;
-    vec3 t12 = p2 - p1;
-    vec3 unit_normal = normalize(cross(t01, t12));
+    // Curves are marked as eneded when the handle after
+    // the first anchor is set equal to that anchor
+    if (verts[0] == verts[1]) return;
 
-    if(bool(fill_all)){
-        emit_simple_triangle(unit_normal);
-        return;
-    }
-    orientation = v_orientation[1];
+    vec3 unit_normal = get_unit_normal(verts[0], verts[1], verts[2]);
 
-    emit_pentagon(
-        p0, p1, p2,
-        normalize(t01),
-        normalize(t12),
-        unit_normal
-    );
+    // Emit main triangle
+    orientation = 0.0;
+    uv_coords = vec2(0.0);
+    emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
+    emit_vertex_wrapper(v_base_point[0], v_color[1], unit_normal);
+    emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
+
+    // Emit edge triangle
+    orientation = 1.0;
+    uv_coords = vec2(0, 0);
+    // Two dummies
+    emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
+    emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
+    // Inner corner
+    uv_coords = vec2(0.5, 0);
+    emit_vertex_wrapper(verts[1], v_color[1], unit_normal);
+    // Last corner
+    uv_coords = vec2(1.0, 1.0);
+    emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
+    EndPrimitive();
 }
 

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -43,7 +43,7 @@ void emit_triangle(vec3 points[3], vec4 v_color[3]){
 }
 
 
-void emit_in_triangle(){
+void emit_simple_triangle(){
     emit_triangle(
         vec3[3](verts[0], verts[1], verts[2]),
         vec4[3](v_color[0], v_color[1], v_color[2])
@@ -70,7 +70,7 @@ void main(){
         );
         // Edge triangle
         fill_all = 0.0;
-        emit_in_triangle();
+        emit_simple_triangle();
     }else{
         // In this case, one should fill all if the vertices are
         // not in sequential order
@@ -78,7 +78,7 @@ void main(){
             (v_vert_index[1] - v_vert_index[0]) != 1.0 ||
             (v_vert_index[2] - v_vert_index[1]) != 1.0
         );
-        emit_in_triangle();
+        emit_simple_triangle();
     }
 }
 

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -47,19 +47,22 @@ void main(){
         // Emit main triangle
         fill_all = float(true);
         uv_coords = vec2(0.0);
-        emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
         emit_vertex_wrapper(v_base_point[0], v_color[0], unit_normal);
+        emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
         emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
     }else{
         // Emit edge triangle
         fill_all = float(false);
-        uv_coords = vec2(0.0, 0.0);
-        emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
-        uv_coords = vec2(0.5, 0);
-        emit_vertex_wrapper(verts[1], v_color[1], unit_normal);
-        uv_coords = vec2(1.0, 1.0);
-        emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
-        EndPrimitive();
+        vec2 uv_coords_arr[3] = vec2[3](
+            vec2(0.0, 0.0),
+            vec2(0.5, 0),
+            vec2(1.0, 1.0)
+        );
+        for(int i = 0; i < 3; i ++){
+            uv_coords = uv_coords_arr[i];
+            emit_vertex_wrapper(verts[i], v_color[i], unit_normal);
+        }
     }
+    EndPrimitive();
 }
 

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -1,23 +1,27 @@
 #version 330
 
 layout (triangles) in;
-layout (triangle_strip, max_vertices = 3) out;
+layout (triangle_strip, max_vertices = 6) out;
 
-uniform float anti_alias_width;
-uniform float pixel_size;
-uniform vec3 corner;
+uniform bool winding;
 
 in vec3 verts[3];
 in vec4 v_color[3];
 in vec3 v_base_point[3];
 in float v_vert_index[3];
-in float v_inst_id[3];
 
 out vec4 color;
 out float fill_all;
+out float orientation;
 // uv space is where the curve coincides with y = x^2
 out vec2 uv_coords;
 
+// A quadratic bezier curve with these points coincides with y = x^2
+const vec2 SIMPLE_QUADRATIC[3] = vec2[3](
+    vec2(0.0, 0.0),
+    vec2(0.5, 0),
+    vec2(1.0, 1.0)
+);
 
 // Analog of import for manim only
 #INSERT get_gl_Position.glsl
@@ -25,47 +29,56 @@ out vec2 uv_coords;
 #INSERT finalize_color.glsl
 
 
-void emit_vertex_wrapper(vec3 point, vec4 v_color, vec3 unit_normal){
-    color = finalize_color(v_color, point, unit_normal);
-    gl_Position = get_gl_Position(point);
-    EmitVertex();
+void emit_triangle(vec3 points[3], vec4 v_color[3]){
+    vec3 unit_normal = get_unit_normal(points[0], points[1], points[2]);
+    orientation = sign(unit_normal.z);
+
+    for(int i = 0; i < 3; i++){
+        uv_coords = SIMPLE_QUADRATIC[i];
+        color = finalize_color(v_color[i], points[i], unit_normal);
+        gl_Position = get_gl_Position(points[i]);
+        EmitVertex();
+    }
+    EndPrimitive();
+}
+
+
+void emit_in_triangle(){
+    emit_triangle(
+        vec3[3](verts[0], verts[1], verts[2]),
+        vec4[3](v_color[0], v_color[1], v_color[2])
+    );
 }
 
 
 void main(){
     // We use the triangle strip primative, but
     // actually only need every other strip element
-    if (int(v_vert_index[0]) % 2 == 1) return;
+    if (winding && int(v_vert_index[0]) % 2 == 1) return;
 
     // Curves are marked as ended when the handle after
     // the first anchor is set equal to that anchor
     if (verts[0] == verts[1]) return;
 
-    if (v_color[0].a == 0 && v_color[1].a == 0 && v_color[2].a == 0) return;
-
-    vec3 unit_normal = get_unit_normal(verts[0], verts[1], verts[2]);
-
-    if(int(v_inst_id[0]) % 2 == 0){
+    vec3 mid_vert;
+    if(winding){
         // Emit main triangle
         fill_all = 1.0;
-        uv_coords = vec2(0.0);
-        emit_vertex_wrapper(v_base_point[0], v_color[0], unit_normal);
-        emit_vertex_wrapper(verts[0], v_color[0], unit_normal);
-        emit_vertex_wrapper(verts[2], v_color[2], unit_normal);
-    }else{
-        // Emit edge triangle
-        fill_all = 0.0;
-        // A quadratic bezier curve with these points coincides with y = x^2
-        vec2 uv_coords_arr[3] = vec2[3](
-            vec2(0.0, 0.0),
-            vec2(0.5, 0),
-            vec2(1.0, 1.0)
+        emit_triangle(
+            vec3[3](v_base_point[0], verts[0], verts[2]),
+            vec4[3](v_color[1], v_color[0], v_color[2])
         );
-        for(int i = 0; i < 3; i ++){
-            uv_coords = uv_coords_arr[i];
-            emit_vertex_wrapper(verts[i], v_color[i], unit_normal);
-        }
+        // Edge triangle
+        fill_all = 0.0;
+        emit_in_triangle();
+    }else{
+        // In this case, one should fill all if the vertices are
+        // not in sequential order
+        fill_all = float(
+            (v_vert_index[1] - v_vert_index[0]) != 1.0 ||
+            (v_vert_index[2] - v_vert_index[1]) != 1.0
+        );
+        emit_in_triangle();
     }
-    EndPrimitive();
 }
 

--- a/manimlib/shaders/quadratic_bezier_fill/vert.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/vert.glsl
@@ -9,10 +9,12 @@ out vec4 v_joint_product;
 out vec4 v_color;
 out vec3 v_base_point;
 out float v_vert_index;
+out float v_inst_id;
 
 void main(){
     verts = point;
     v_color = fill_rgba;
     v_base_point = base_point;
     v_vert_index = gl_VertexID;
+    v_inst_id = gl_InstanceID;
 }

--- a/manimlib/shaders/quadratic_bezier_fill/vert.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/vert.glsl
@@ -2,17 +2,17 @@
 
 in vec3 point;
 in vec4 fill_rgba;
-in float orientation;
-in float vert_index;
+in vec3 base_point;
 
 out vec3 verts;  // Bezier control point
-out float v_orientation;
+out vec4 v_joint_product;
 out vec4 v_color;
+out vec3 v_base_point;
 out float v_vert_index;
 
 void main(){
     verts = point;
-    v_orientation = orientation;
     v_color = fill_rgba;
-    v_vert_index = vert_index;
+    v_base_point = base_point;
+    v_vert_index = gl_VertexID;
 }

--- a/manimlib/shaders/quadratic_bezier_fill/vert.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/vert.glsl
@@ -5,16 +5,13 @@ in vec4 fill_rgba;
 in vec3 base_point;
 
 out vec3 verts;  // Bezier control point
-out vec4 v_joint_product;
 out vec4 v_color;
 out vec3 v_base_point;
 out float v_vert_index;
-out float v_inst_id;
 
 void main(){
     verts = point;
     v_color = fill_rgba;
     v_base_point = base_point;
     v_vert_index = gl_VertexID;
-    v_inst_id = gl_InstanceID;
 }

--- a/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
@@ -154,7 +154,7 @@ void main() {
     // actually only need every other strip element
     if (int(v_vert_index[0]) % 2 == 1) return;
 
-    // Curves are marked as eneded when the handle after
+    // Curves are marked as ended when the handle after
     // the first anchor is set equal to that anchor
     if (verts[0] == verts[1]) return;
 

--- a/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
@@ -100,7 +100,6 @@ void get_corners(
     float buff2 = 0.5 * v_stroke_width[2] + aaw;
 
     vec4 jp0 = normalize(v_joint_product[0]);
-    vec4 jp1 = normalize(v_joint_product[1]);
     vec4 jp2 = normalize(v_joint_product[2]);
 
     // Add correction for sharp angles to prevent weird bevel effects
@@ -140,7 +139,7 @@ void get_corners(
     vec3 c5 = p2 - p2_perp;
     // Move the inner middle control point to make
     // room for the curve
-    float orientation = dot(normal0, jp1.xyz);
+    float orientation = dot(normal0, v_joint_product[1].xyz);
     if(orientation >= 0.0)     c2 = 0.5 * (c0 + c4);
     else if(orientation < 0.0) c3 = 0.5 * (c1 + c5);
 

--- a/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_stroke/geom.glsl
@@ -99,13 +99,17 @@ void get_corners(
     float buff0 = 0.5 * v_stroke_width[0] + aaw;
     float buff2 = 0.5 * v_stroke_width[2] + aaw;
 
+    vec4 jp0 = normalize(v_joint_product[0]);
+    vec4 jp1 = normalize(v_joint_product[1]);
+    vec4 jp2 = normalize(v_joint_product[2]);
+
     // Add correction for sharp angles to prevent weird bevel effects
-    if(v_joint_product[0].w < -0.9) buff0 *= 10 * (v_joint_product[0].w + 1.0);
-    if(v_joint_product[2].w < -0.9) buff2 *= 10 * (v_joint_product[2].w + 1.0);
+    if(jp0.w < -0.9) buff0 *= 10 * (jp0.w + 1.0);
+    if(jp2.w < -0.9) buff2 *= 10 * (jp2.w + 1.0);
 
     // Unit normal and joint angles
-    vec3 normal0 = get_joint_unit_normal(v_joint_product[0]);
-    vec3 normal2 = get_joint_unit_normal(v_joint_product[2]);
+    vec3 normal0 = get_joint_unit_normal(jp0);
+    vec3 normal2 = get_joint_unit_normal(jp2);
     // Set global unit normal
     unit_normal = normal0;
 
@@ -136,14 +140,14 @@ void get_corners(
     vec3 c5 = p2 - p2_perp;
     // Move the inner middle control point to make
     // room for the curve
-    float orientation = dot(normal0, v_joint_product[1].xyz);
+    float orientation = dot(normal0, jp1.xyz);
     if(orientation >= 0.0)     c2 = 0.5 * (c0 + c4);
     else if(orientation < 0.0) c3 = 0.5 * (c1 + c5);
 
     // Account for previous and next control points
     if(bool(flat_stroke)){
-        create_joint(v_joint_product[0], v01, buff0, c1, c1, c0, c0);
-        create_joint(v_joint_product[2], -v12, buff2, c5, c5, c4, c4);
+        create_joint(jp0, v01, buff0, c1, c1, c0, c0);
+        create_joint(jp2, -v12, buff2, c5, c5, c4, c4);
     }
 
     corners = vec3[6](c0, c1, c2, c3, c4, c5);
@@ -164,7 +168,7 @@ void main() {
     vec3 v01 = normalize(p1 - p0);
     vec3 v12 = normalize(p2 - p1);
 
-    float cos_angle = v_joint_product[1].w;
+    float cos_angle = normalize(v_joint_product[1]).w;
     is_linear = float(cos_angle > COS_THRESHOLD);
 
     // We want to change the coordinates to a space where the curve


### PR DESCRIPTION
There have been many issues associated with triangulating VMobjects to illustrate their fill. Transforms between VMobjects with fill often show strange triangulation artifacts and can be laggy when the triangulation needs to be recomputed on each frame.

This change introduces a mode that obviates the need for such a triangulation and makes it the default. It's essentially based on [this blog post](https://medium.com/@evanwallace/easy-scalable-text-rendering-on-the-gpu-c3f4d782c5ac), and makes use of blending signed alpha values to effectively compute the winding number of a curve around each pixel.

Filled VMobjects are given a separate rendering pass to a texture using a specific blending mode, which is then blended with the rest of the scene using default alpha blending.

It may cause some unexpected blending behavior, and can be turned off by calling `vmobject.use_winding_fill(False)`