### PR TITLE
Refactor render out of camera (plus winding fill blending fix)

### DIFF
--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -65,7 +65,6 @@ class Animation(object):
             self.rate_func = squish_rate_func(
                 self.rate_func, start / self.run_time, end / self.run_time,
             )
-        self.mobject.refresh_shader_data()
         self.mobject.set_animating_status(True)
         self.starting_mobject = self.create_starting_mobject()
         if self.suspend_mobject_updating:

--- a/manimlib/animation/creation.py
+++ b/manimlib/animation/creation.py
@@ -30,15 +30,6 @@ class ShowPartial(Animation, ABC):
         self.should_match_start = should_match_start
         super().__init__(mobject, **kwargs)
 
-    def begin(self) -> None:
-        super().begin()
-        if not self.should_match_start:
-            self.mobject.lock_matching_data(self.mobject, self.starting_mobject)
-
-    def finish(self) -> None:
-        super().finish()
-        self.mobject.unlock_data()
-
     def interpolate_submobject(
         self,
         submob: VMobject,
@@ -114,11 +105,9 @@ class DrawBorderThenFill(Animation):
         self.outline = self.get_outline()
         super().begin()
         self.mobject.match_style(self.outline)
-        self.mobject.lock_matching_data(self.mobject, self.outline)
 
     def finish(self) -> None:
         super().finish()
-        self.mobject.unlock_data()
         self.mobject.refresh_joint_products()
 
     def get_outline(self) -> VMobject:
@@ -146,9 +135,6 @@ class DrawBorderThenFill(Animation):
         if index == 1 and self.sm_to_index[hash(submob)] == 0:
             # First time crossing over
             submob.set_data(outline.data)
-            submob.unlock_data()
-            if not self.mobject.has_updaters:
-                submob.lock_matching_data(submob, start)
             submob.needs_new_triangulation = False
             self.sm_to_index[hash(submob)] = 1
 

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -70,7 +70,8 @@ class Transform(Animation):
     def finish(self) -> None:
         super().finish()
         self.mobject.unlock_data()
-        self.mobject.become(self.target_mobject)
+        if self.target_mobject is not None:
+            self.mobject.become(self.target_mobject)
 
     def create_target(self) -> Mobject:
         # Has no meaningful effect here, but may be useful

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -121,6 +121,10 @@ class Transform(Animation):
         target_copy: Mobject,
         alpha: float
     ):
+        if alpha == 0:
+            submob.become(start)
+        elif alpha == 1:
+            submob.become(target_copy)
         submob.interpolate(start, target_copy, alpha, self.path_func)
         return self
 

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -121,10 +121,6 @@ class Transform(Animation):
         target_copy: Mobject,
         alpha: float
     ):
-        if alpha == 0:
-            submob.become(start)
-        elif alpha == 1:
-            submob.become(target_copy)
         submob.interpolate(start, target_copy, alpha, self.path_func)
         return self
 

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -70,6 +70,7 @@ class Transform(Animation):
     def finish(self) -> None:
         super().finish()
         self.mobject.unlock_data()
+        self.mobject.become(self.target_mobject)
 
     def create_target(self) -> Mobject:
         # Has no meaningful effect here, but may be useful

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -1,25 +1,20 @@
 from __future__ import annotations
 
 import itertools as it
-import math
 
 import moderngl
 import numpy as np
 import OpenGL.GL as gl
 from PIL import Image
-from scipy.spatial.transform import Rotation
 
+from manimlib.camera.camera_frame import CameraFrame
 from manimlib.constants import BLACK
-from manimlib.constants import DEGREES, RADIANS
 from manimlib.constants import DEFAULT_FPS
 from manimlib.constants import DEFAULT_PIXEL_HEIGHT, DEFAULT_PIXEL_WIDTH
-from manimlib.constants import FRAME_HEIGHT, FRAME_WIDTH
-from manimlib.constants import DOWN, LEFT, ORIGIN, OUT, RIGHT, UP
+from manimlib.constants import FRAME_WIDTH
 from manimlib.mobject.mobject import Mobject
 from manimlib.mobject.mobject import Point
 from manimlib.utils.color import color_to_rgba
-from manimlib.utils.simple_functions import fdiv
-from manimlib.utils.space_ops import normalize
 
 from typing import TYPE_CHECKING
 
@@ -28,161 +23,6 @@ if TYPE_CHECKING:
     from manimlib.typing import ManimColor, Vect3
     from manimlib.window import Window
     from typing import Any, Iterable
-
-class CameraFrame(Mobject):
-    def __init__(
-        self,
-        frame_shape: tuple[float, float] = (FRAME_WIDTH, FRAME_HEIGHT),
-        center_point: Vect3 = ORIGIN,
-        focal_dist_to_height: float = 2.0,
-        **kwargs,
-    ):
-        self.frame_shape = frame_shape
-        self.center_point = center_point
-        self.focal_dist_to_height = focal_dist_to_height
-        self.view_matrix = np.identity(4)
-        super().__init__(**kwargs)
-
-    def init_uniforms(self) -> None:
-        super().init_uniforms()
-        # As a quaternion
-        self.uniforms["orientation"] = Rotation.identity().as_quat()
-        self.uniforms["focal_dist_to_height"] = self.focal_dist_to_height
-
-    def init_points(self) -> None:
-        self.set_points([ORIGIN, LEFT, RIGHT, DOWN, UP])
-        self.set_width(self.frame_shape[0], stretch=True)
-        self.set_height(self.frame_shape[1], stretch=True)
-        self.move_to(self.center_point)
-
-    def set_orientation(self, rotation: Rotation):
-        self.uniforms["orientation"][:] = rotation.as_quat()
-        return self
-
-    def get_orientation(self):
-        return Rotation.from_quat(self.uniforms["orientation"])
-
-    def to_default_state(self):
-        self.center()
-        self.set_height(FRAME_HEIGHT)
-        self.set_width(FRAME_WIDTH)
-        self.set_orientation(Rotation.identity())
-        return self
-
-    def get_euler_angles(self):
-        return self.get_orientation().as_euler("zxz")[::-1]
-
-    def get_theta(self):
-        return self.get_euler_angles()[0]
-
-    def get_phi(self):
-        return self.get_euler_angles()[1]
-
-    def get_gamma(self):
-        return self.get_euler_angles()[2]
-
-    def get_inverse_camera_rotation_matrix(self):
-        return self.get_orientation().as_matrix().T
-
-    def get_view_matrix(self):
-        """
-        Returns a 4x4 for the affine transformation mapping a point
-        into the camera's internal coordinate system
-        """
-        result = self.view_matrix
-        result[:] = np.identity(4)
-        result[:3, 3] = -self.get_center()
-        rotation = np.identity(4)
-        rotation[:3, :3] = self.get_inverse_camera_rotation_matrix()
-        result[:] = np.dot(rotation, result)
-        return result
-
-    def rotate(self, angle: float, axis: np.ndarray = OUT, **kwargs):
-        rot = Rotation.from_rotvec(angle * normalize(axis))
-        self.set_orientation(rot * self.get_orientation())
-        return self
-
-    def set_euler_angles(
-        self,
-        theta: float | None = None,
-        phi: float | None = None,
-        gamma: float | None = None,
-        units: float = RADIANS
-    ):
-        eulers = self.get_euler_angles()  # theta, phi, gamma
-        for i, var in enumerate([theta, phi, gamma]):
-            if var is not None:
-                eulers[i] = var * units
-        self.set_orientation(Rotation.from_euler("zxz", eulers[::-1]))
-        return self
-
-    def reorient(
-        self,
-        theta_degrees: float | None = None,
-        phi_degrees: float | None = None,
-        gamma_degrees: float | None = None,
-    ):
-        """
-        Shortcut for set_euler_angles, defaulting to taking
-        in angles in degrees
-        """
-        self.set_euler_angles(theta_degrees, phi_degrees, gamma_degrees, units=DEGREES)
-        return self
-
-    def set_theta(self, theta: float):
-        return self.set_euler_angles(theta=theta)
-
-    def set_phi(self, phi: float):
-        return self.set_euler_angles(phi=phi)
-
-    def set_gamma(self, gamma: float):
-        return self.set_euler_angles(gamma=gamma)
-
-    def increment_theta(self, dtheta: float):
-        self.rotate(dtheta, OUT)
-        return self
-
-    def increment_phi(self, dphi: float):
-        self.rotate(dphi, self.get_inverse_camera_rotation_matrix()[0])
-        return self
-
-    def increment_gamma(self, dgamma: float):
-        self.rotate(dgamma, self.get_inverse_camera_rotation_matrix()[2])
-        return self
-
-    def set_focal_distance(self, focal_distance: float):
-        self.uniforms["focal_dist_to_height"] = focal_distance / self.get_height()
-        return self
-
-    def set_field_of_view(self, field_of_view: float):
-        self.uniforms["focal_dist_to_height"] = 2 * math.tan(field_of_view / 2)
-        return self
-
-    def get_shape(self):
-        return (self.get_width(), self.get_height())
-
-    def get_center(self) -> np.ndarray:
-        # Assumes first point is at the center
-        return self.get_points()[0]
-
-    def get_width(self) -> float:
-        points = self.get_points()
-        return points[2, 0] - points[1, 0]
-
-    def get_height(self) -> float:
-        points = self.get_points()
-        return points[4, 1] - points[3, 1]
-
-    def get_focal_distance(self) -> float:
-        return self.uniforms["focal_dist_to_height"] * self.get_height()
-
-    def get_field_of_view(self) -> float:
-        return 2 * math.atan(self.uniforms["focal_dist_to_height"] / 2)
-
-    def get_implied_camera_location(self) -> np.ndarray:
-        to_camera = self.get_inverse_camera_rotation_matrix()[2]
-        dist = self.get_focal_distance()
-        return self.get_center() + dist * to_camera
 
 
 class Camera(object):

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -294,7 +294,7 @@ class Camera(object):
         primitive = int(shader_wrapper.render_primitive)
         self.set_shader_uniforms(shader_program, shader_wrapper)
         self.set_ctx_depth_test(shader_wrapper.depth_test)
-        self.set_ctx_clip_plane(shader_wrapper.use_clip_plane)
+        self.set_ctx_clip_plane(shader_wrapper.use_clip_plane())
 
         if shader_wrapper.is_fill:
             self.render_fill(render_group["vao"], primitive, shader_wrapper.vert_indices)

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -67,7 +67,6 @@ class Camera(object):
         self.perspective_uniforms = dict()
         self.init_frame(**frame_config)
         self.init_context(window)
-        self.init_shaders()
         self.init_textures()
         self.init_light_source()
         self.refresh_perspective_uniforms()
@@ -365,7 +364,8 @@ class Camera(object):
         vbo = self.ctx.buffer(vert_data)
 
         # Program and vertex array
-        shader_program, vert_format = self.get_shader_program(shader_wrapper)
+        shader_program = shader_wrapper.program
+        vert_format = shader_wrapper.vert_format
         attributes = shader_wrapper.vert_attributes
         vao = self.ctx.vertex_array(
             program=shader_program,
@@ -392,22 +392,6 @@ class Camera(object):
         self.mob_to_render_groups = {}
 
     # Shaders
-    def init_shaders(self) -> None:
-        # Initialize with the null id going to None
-        self.id_to_shader_program: dict[int, tuple[moderngl.Program, str] | None] = {hash(""): None}
-
-    def get_shader_program(
-        self,
-        shader_wrapper: ShaderWrapper
-    ) -> tuple[moderngl.Program, str] | None:
-        sid = shader_wrapper.get_program_id()
-        if sid not in self.id_to_shader_program:
-            # Create shader program for the first time, then cache
-            # in the id_to_shader_program dictionary
-            program = self.ctx.program(**shader_wrapper.get_program_code())
-            vert_format = moderngl.detect_format(program, shader_wrapper.vert_attributes)
-            self.id_to_shader_program[sid] = (program, vert_format)
-        return self.id_to_shader_program[sid]
 
     def set_shader_uniforms(
         self,

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -337,7 +337,7 @@ class Camera(object):
     def generate_render_group_list(self, mobject: Mobject) -> Iterable[dict[str, Any]]:
         return (
             self.get_render_group(sw, single_use=mobject.is_changing())
-            for sw in mobject.get_shader_wrapper_list()
+            for sw in mobject.get_shader_wrapper_list(self.ctx)
         )
 
     def get_render_group(

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import itertools as it
-
 import moderngl
 import numpy as np
 import OpenGL.GL as gl
@@ -15,15 +13,12 @@ from manimlib.constants import FRAME_WIDTH
 from manimlib.mobject.mobject import Mobject
 from manimlib.mobject.mobject import Point
 from manimlib.utils.color import color_to_rgba
-from manimlib.utils.shaders import get_texture_id
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from manimlib.shader_wrapper import ShaderWrapper
     from manimlib.typing import ManimColor, Vect3
     from manimlib.window import Window
-    from typing import Any, Iterable
 
 
 class Camera(object):

--- a/manimlib/camera/camera_frame.py
+++ b/manimlib/camera/camera_frame.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from manimlib.constants import DEGREES, RADIANS
+from manimlib.constants import FRAME_HEIGHT, FRAME_WIDTH
+from manimlib.constants import DOWN, LEFT, ORIGIN, OUT, RIGHT, UP
+from manimlib.mobject.mobject import Mobject
+from manimlib.utils.space_ops import normalize
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from manimlib.typing import Vect3
+
+
+class CameraFrame(Mobject):
+    def __init__(
+        self,
+        frame_shape: tuple[float, float] = (FRAME_WIDTH, FRAME_HEIGHT),
+        center_point: Vect3 = ORIGIN,
+        focal_dist_to_height: float = 2.0,
+        **kwargs,
+    ):
+        self.frame_shape = frame_shape
+        self.center_point = center_point
+        self.focal_dist_to_height = focal_dist_to_height
+        self.view_matrix = np.identity(4)
+        super().__init__(**kwargs)
+
+    def init_uniforms(self) -> None:
+        super().init_uniforms()
+        # As a quaternion
+        self.uniforms["orientation"] = Rotation.identity().as_quat()
+        self.uniforms["focal_dist_to_height"] = self.focal_dist_to_height
+
+    def init_points(self) -> None:
+        self.set_points([ORIGIN, LEFT, RIGHT, DOWN, UP])
+        self.set_width(self.frame_shape[0], stretch=True)
+        self.set_height(self.frame_shape[1], stretch=True)
+        self.move_to(self.center_point)
+
+    def set_orientation(self, rotation: Rotation):
+        self.uniforms["orientation"][:] = rotation.as_quat()
+        return self
+
+    def get_orientation(self):
+        return Rotation.from_quat(self.uniforms["orientation"])
+
+    def to_default_state(self):
+        self.center()
+        self.set_height(FRAME_HEIGHT)
+        self.set_width(FRAME_WIDTH)
+        self.set_orientation(Rotation.identity())
+        return self
+
+    def get_euler_angles(self):
+        return self.get_orientation().as_euler("zxz")[::-1]
+
+    def get_theta(self):
+        return self.get_euler_angles()[0]
+
+    def get_phi(self):
+        return self.get_euler_angles()[1]
+
+    def get_gamma(self):
+        return self.get_euler_angles()[2]
+
+    def get_inverse_camera_rotation_matrix(self):
+        return self.get_orientation().as_matrix().T
+
+    def get_view_matrix(self):
+        """
+        Returns a 4x4 for the affine transformation mapping a point
+        into the camera's internal coordinate system
+        """
+        result = self.view_matrix
+        result[:] = np.identity(4)
+        result[:3, 3] = -self.get_center()
+        rotation = np.identity(4)
+        rotation[:3, :3] = self.get_inverse_camera_rotation_matrix()
+        result[:] = np.dot(rotation, result)
+        return result
+
+    def rotate(self, angle: float, axis: np.ndarray = OUT, **kwargs):
+        rot = Rotation.from_rotvec(angle * normalize(axis))
+        self.set_orientation(rot * self.get_orientation())
+        return self
+
+    def set_euler_angles(
+        self,
+        theta: float | None = None,
+        phi: float | None = None,
+        gamma: float | None = None,
+        units: float = RADIANS
+    ):
+        eulers = self.get_euler_angles()  # theta, phi, gamma
+        for i, var in enumerate([theta, phi, gamma]):
+            if var is not None:
+                eulers[i] = var * units
+        self.set_orientation(Rotation.from_euler("zxz", eulers[::-1]))
+        return self
+
+    def reorient(
+        self,
+        theta_degrees: float | None = None,
+        phi_degrees: float | None = None,
+        gamma_degrees: float | None = None,
+    ):
+        """
+        Shortcut for set_euler_angles, defaulting to taking
+        in angles in degrees
+        """
+        self.set_euler_angles(theta_degrees, phi_degrees, gamma_degrees, units=DEGREES)
+        return self
+
+    def set_theta(self, theta: float):
+        return self.set_euler_angles(theta=theta)
+
+    def set_phi(self, phi: float):
+        return self.set_euler_angles(phi=phi)
+
+    def set_gamma(self, gamma: float):
+        return self.set_euler_angles(gamma=gamma)
+
+    def increment_theta(self, dtheta: float):
+        self.rotate(dtheta, OUT)
+        return self
+
+    def increment_phi(self, dphi: float):
+        self.rotate(dphi, self.get_inverse_camera_rotation_matrix()[0])
+        return self
+
+    def increment_gamma(self, dgamma: float):
+        self.rotate(dgamma, self.get_inverse_camera_rotation_matrix()[2])
+        return self
+
+    def set_focal_distance(self, focal_distance: float):
+        self.uniforms["focal_dist_to_height"] = focal_distance / self.get_height()
+        return self
+
+    def set_field_of_view(self, field_of_view: float):
+        self.uniforms["focal_dist_to_height"] = 2 * math.tan(field_of_view / 2)
+        return self
+
+    def get_shape(self):
+        return (self.get_width(), self.get_height())
+
+    def get_center(self) -> np.ndarray:
+        # Assumes first point is at the center
+        return self.get_points()[0]
+
+    def get_width(self) -> float:
+        points = self.get_points()
+        return points[2, 0] - points[1, 0]
+
+    def get_height(self) -> float:
+        points = self.get_points()
+        return points[4, 1] - points[3, 1]
+
+    def get_focal_distance(self) -> float:
+        return self.uniforms["focal_dist_to_height"] * self.get_height()
+
+    def get_field_of_view(self) -> float:
+        return 2 * math.atan(self.uniforms["focal_dist_to_height"] / 2)
+
+    def get_implied_camera_location(self) -> np.ndarray:
+        to_camera = self.get_inverse_camera_rotation_matrix()[2]
+        dist = self.get_focal_distance()
+        return self.get_center() + dist * to_camera

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -414,10 +414,7 @@ def get_window_config(args: Namespace, custom_config: dict, camera_config: dict)
     if not (args.full_screen or custom_config["full_screen"]):
         window_width //= 2
     window_height = int(window_width / aspect_ratio)
-    return dict(
-        full_size=(camera_config["pixel_width"], camera_config["pixel_height"]),
-        size=(window_width, window_height),
-    )
+    return dict(size=(window_width, window_height))
 
 
 def get_camera_config(args: Namespace, custom_config: dict) -> dict:

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1618,9 +1618,6 @@ class Mobject(object):
 
     def align_data(self, mobject: Mobject) -> None:
         for mob1, mob2 in zip(self.get_family(), mobject.get_family()):
-            # In case any data arrays get resized when aligned to shader data
-            mob1.refresh_shader_data()
-            mob2.refresh_shader_data()
             mob1.align_points(mob2)
 
     def align_points(self, mobject: Mobject):
@@ -1731,8 +1728,6 @@ class Mobject(object):
         """
         if self.has_updaters:
             return
-        # Be sure shader data has most up to date information
-        self.refresh_shader_data()
         self.locked_data_keys = set(keys)
 
     def lock_matching_data(self, mobject1: Mobject, mobject2: Mobject):
@@ -1887,9 +1882,6 @@ class Mobject(object):
 
     def get_shader_data(self):
         return self.data
-
-    def refresh_shader_data(self):
-        pass
 
     def get_uniforms(self):
         return self.uniforms

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -181,7 +181,7 @@ class Mobject(object):
     @affects_data
     def set_data(self, data: np.ndarray):
         assert(data.dtype == self.data.dtype)
-        self.data = data
+        self.data = data.copy()
         return self
 
     @affects_data

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -683,7 +683,6 @@ class Mobject(object):
         for attr, value in list(mobject.__dict__.items()):
             if isinstance(value, Mobject) and value in family2:
                 setattr(self, attr, family1[family2.index(value)])
-        self.refresh_bounding_box(recurse_down=True)
         if match_updaters:
             self.match_updaters(mobject)
         return self

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1710,7 +1710,6 @@ class Mobject(object):
 
     # Interpolate
 
-    @affects_data
     def interpolate(
         self,
         mobject1: Mobject,
@@ -1719,6 +1718,8 @@ class Mobject(object):
         path_func: Callable[[np.ndarray, np.ndarray, float], np.ndarray] = straight_path
     ):
         keys = [k for k in self.data.dtype.names if k not in self.locked_data_keys]
+        if keys:
+            self.note_changed_data()
         for key in keys:
             func = path_func if key in self.pointlike_data_keys else interpolate
             md1 = mobject1.data[key]

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1730,6 +1730,8 @@ class Mobject(object):
             self.data[key] = func(md1, md2, alpha)
 
         for key in self.uniforms:
+            if key not in mobject1.uniforms or key not in mobject2.uniforms:
+                continue
             self.uniforms[key] = interpolate(
                 mobject1.uniforms[key],
                 mobject2.uniforms[key],

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1841,7 +1841,7 @@ class Mobject(object):
     def init_shader_data(self, ctx: Context):
         self.shader_indices = np.zeros(0)
         self.shader_wrapper = ShaderWrapper(
-            context=ctx,
+            ctx=ctx,
             vert_data=self.data,
             shader_folder=self.shader_folder,
             texture_paths=self.texture_paths,

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1719,6 +1719,12 @@ class Mobject(object):
         keys = [k for k in self.data.dtype.names if k not in self.locked_data_keys]
         if keys:
             self.note_changed_data()
+            if alpha == 0:
+                self.data[:] = mobject1.data[:]
+                keys = []
+            elif alpha == 1:
+                self.data[:] = mobject2.data[:]
+                keys = []
         for key in keys:
             func = path_func if key in self.pointlike_data_keys else interpolate
             md1 = mobject1.data[key]

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -2048,6 +2048,8 @@ class Group(Mobject):
             raise Exception("All submobjects must be of type Mobject")
         Mobject.__init__(self, **kwargs)
         self.add(*mobjects)
+        if any(m.is_fixed_in_frame for m in mobjects):
+            self.fix_in_frame()
 
     def __add__(self, other: Mobject | Group):
         assert(isinstance(other, Mobject))

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1719,12 +1719,6 @@ class Mobject(object):
         keys = [k for k in self.data.dtype.names if k not in self.locked_data_keys]
         if keys:
             self.note_changed_data()
-            if alpha == 0:
-                self.data[:] = mobject1.data[:]
-                keys = []
-            elif alpha == 1:
-                self.data[:] = mobject2.data[:]
-                keys = []
         for key in keys:
             func = path_func if key in self.pointlike_data_keys else interpolate
             md1 = mobject1.data[key]

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1861,7 +1861,7 @@ class Mobject(object):
 
         self.shader_wrapper.vert_data = self.get_shader_data()
         self.shader_wrapper.vert_indices = self.get_shader_vert_indices()
-        self.shader_wrapper.uniforms = self.get_uniforms()
+        self.shader_wrapper.uniforms.update(self.get_uniforms())
         self.shader_wrapper.depth_test = self.depth_test
         return self.shader_wrapper
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -587,11 +587,9 @@ class Mobject(object):
         return self
 
     def deepcopy(self):
-        try:
-            # Often faster than deepcopy
-            return pickle.loads(pickle.dumps(self))
-        except AttributeError:
-            return copy.deepcopy(self)
+        result = copy.deepcopy(self)
+        result._shaders_initialized = False
+        result._data_has_changed = True
 
     @stash_mobject_pointers
     def copy(self, deep: bool = False):

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -101,6 +101,7 @@ class Mobject(object):
         self.saved_state = None
         self.target = None
         self.bounding_box: Vect3Array = np.zeros((3, 3))
+        self._shaders_initialized: bool = False
 
         self.init_data()
         self._data_defaults = np.ones(1, dtype=self.data.dtype)
@@ -109,7 +110,6 @@ class Mobject(object):
         self.init_event_listners()
         self.init_points()
         self.init_colors()
-        self.init_shader_data()
 
         if self.depth_test:
             self.apply_depth_test()
@@ -1843,7 +1843,6 @@ class Mobject(object):
     # For shader data
 
     def init_shader_data(self):
-        # TODO, only call this when needed?
         self.shader_indices = np.zeros(0)
         self.shader_wrapper = ShaderWrapper(
             vert_data=self.data,
@@ -1854,10 +1853,15 @@ class Mobject(object):
         )
 
     def refresh_shader_wrapper_id(self):
-        self.shader_wrapper.refresh_id()
+        if self._shaders_initialized:
+            self.shader_wrapper.refresh_id()
         return self
 
     def get_shader_wrapper(self) -> ShaderWrapper:
+        if not self._shaders_initialized:
+            self.init_shader_data()
+            self._shaders_initialized = True
+
         self.shader_wrapper.vert_data = self.get_shader_data()
         self.shader_wrapper.vert_indices = self.get_shader_vert_indices()
         self.shader_wrapper.uniforms = self.get_uniforms()

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -320,8 +320,9 @@ class VMobjectFromSVGPath(VMobject):
                 self.set_points(self.get_points_without_null_curves())
             # So triangulation doesn't get messed up
             self.subdivide_intersections()
-            # Always default to orienting outward
-            if self.get_unit_normal()[2] < 0:
+            # Always default to orienting outward, account
+            # for the fact that this will get flipped in SVG.__init__
+            if self.get_unit_normal()[2] > 0:
                 self.reverse_points()
             # Save for future use
             PATH_TO_POINTS[path_string] = self.get_points().copy()

--- a/manimlib/mobject/types/dot_cloud.py
+++ b/manimlib/mobject/types/dot_cloud.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from manimlib.constants import GREY_C, YELLOW
 from manimlib.constants import ORIGIN, NULL_POINTS
+from manimlib.mobject.mobject import Mobject
 from manimlib.mobject.types.point_cloud_mobject import PMobject
 from manimlib.utils.iterables import resize_with_interpolation
 
@@ -94,6 +95,7 @@ class DotCloud(PMobject):
         self.center()
         return self
 
+    @Mobject.affects_data
     def set_radii(self, radii: npt.ArrayLike):
         n_points = self.get_num_points()
         radii = np.array(radii).reshape((len(radii), 1))
@@ -104,6 +106,7 @@ class DotCloud(PMobject):
     def get_radii(self) -> np.ndarray:
         return self.data["radius"]
 
+    @Mobject.affects_data
     def set_radius(self, radius: float):
         data = self.data if self.get_num_points() > 0 else self._data_defaults
         data["radius"][:] = radius

--- a/manimlib/mobject/types/image_mobject.py
+++ b/manimlib/mobject/types/image_mobject.py
@@ -47,6 +47,7 @@ class ImageMobject(Mobject):
         self.set_width(2 * size[0] / size[1], stretch=True)
         self.set_height(self.height)
 
+    @Mobject.affects_data
     def set_opacity(self, opacity: float, recurse: bool = True):
         self.data["opacity"][:, 0] = resize_with_interpolation(
             np.array(listify(opacity)),

--- a/manimlib/mobject/types/point_cloud_mobject.py
+++ b/manimlib/mobject/types/point_cloud_mobject.py
@@ -5,7 +5,6 @@ import numpy as np
 from manimlib.mobject.mobject import Mobject
 from manimlib.utils.color import color_gradient
 from manimlib.utils.color import color_to_rgba
-from manimlib.utils.iterables import resize_array
 from manimlib.utils.iterables import resize_with_interpolation
 
 from typing import TYPE_CHECKING
@@ -52,6 +51,7 @@ class PMobject(Mobject):
         self.add_points([point], rgbas, color, opacity)
         return self
 
+    @Mobject.affects_data
     def set_color_by_gradient(self, *colors: ManimColor):
         self.data["rgba"][:] = np.array(list(map(
             color_to_rgba,
@@ -59,17 +59,20 @@ class PMobject(Mobject):
         )))
         return self
 
+    @Mobject.affects_data
     def match_colors(self, pmobject: PMobject):
         self.data["rgba"][:] = resize_with_interpolation(
             pmobject.data["rgba"], self.get_num_points()
         )
         return self
 
+    @Mobject.affects_data
     def filter_out(self, condition: Callable[[np.ndarray], bool]):
         for mob in self.family_members_with_points():
             mob.data = mob.data[~np.apply_along_axis(condition, 1, mob.get_points())]
         return self
 
+    @Mobject.affects_data
     def sort_points(self, function: Callable[[Vect3], None] = lambda p: p[0]):
         """
         function is any map from R^3 to R
@@ -81,6 +84,7 @@ class PMobject(Mobject):
             mob.data[:] = mob.data[indices]
         return self
 
+    @Mobject.affects_data
     def ingest_submobjects(self):
         self.data = np.vstack([
             sm.data for sm in self.get_family()
@@ -91,6 +95,7 @@ class PMobject(Mobject):
         index = alpha * (self.get_num_points() - 1)
         return self.get_points()[int(index)]
 
+    @Mobject.affects_data
     def pointwise_become_partial(self, pmobject: PMobject, a: float, b: float):
         lower_index = int(a * pmobject.get_num_points())
         upper_index = int(b * pmobject.get_num_points())

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -218,12 +218,10 @@ class Surface(Mobject):
             self.uniforms["clip_plane"][:3] = vect
         if threshold is not None:
             self.uniforms["clip_plane"][3] = threshold
-        self.shader_wrapper.use_clip_plane = True
         return self
 
     def deactivate_clip_plane(self):
         self.uniforms["clip_plane"][:] = 0
-        self.shader_wrapper.use_clip_plane = False
         return self
 
     def get_shader_vert_indices(self) -> np.ndarray:

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -72,6 +72,7 @@ class Surface(Mobject):
         # To be implemented in subclasses
         return (u, v, 0.0)
 
+    @Mobject.affects_data
     def init_points(self):
         dim = self.dim
         nu, nv = self.resolution
@@ -130,6 +131,7 @@ class Surface(Mobject):
         )
         return normalize_along_axis(normals, 1)
 
+    @Mobject.affects_data
     def pointwise_become_partial(
         self,
         smobject: "Surface",
@@ -298,6 +300,7 @@ class TexturedSurface(Surface):
             **kwargs
         )
 
+    @Mobject.affects_data
     def init_points(self):
         surf = self.uv_surface
         nu, nv = surf.resolution
@@ -315,6 +318,7 @@ class TexturedSurface(Surface):
         super().init_uniforms()
         self.uniforms["num_textures"] = self.num_textures
 
+    @Mobject.affects_data
     def set_opacity(self, opacity: float | Iterable[float]):
         op_arr = np.array(listify(opacity))
         self.data["opacity"][:, 0] = resize_with_interpolation(op_arr, len(self.data))

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -940,8 +940,9 @@ class VMobject(Mobject):
     def pointwise_become_partial(self, vmobject: VMobject, a: float, b: float):
         assert(isinstance(vmobject, VMobject))
         vm_points = vmobject.get_points()
+        self.data["joint_product"] = vmobject.data["joint_product"]
         if a <= 0 and b >= 1:
-            self.set_points(vm_points)
+            self.set_points(vm_points, refresh_joints=False)
             return self
         num_curves = vmobject.get_num_curves()
 
@@ -974,7 +975,9 @@ class VMobject(Mobject):
             # Keep new_points i2:i3 as they are
             new_points[i3:i4] = high_tup
             new_points[i4:] = high_tup[2]
-        self.set_points(new_points)
+        self.data["joint_product"][:i1] = [0, 0, 0, 1]
+        self.data["joint_product"][i4:] = [0, 0, 0, 1]
+        self.set_points(new_points, refresh_joints=False)
         return self
 
     def get_subcurve(self, a: float, b: float) -> VMobject:
@@ -1126,11 +1129,12 @@ class VMobject(Mobject):
             return self
         return wrapper
 
-    def set_points(self, points: Vect3Array):
+    def set_points(self, points: Vect3Array, refresh_joints: bool = True):
         assert(len(points) == 0 or len(points) % 2 == 1)
         super().set_points(points)
         self.refresh_triangulation()
-        self.get_joint_products(refresh=True)
+        if refresh_joints:
+            self.get_joint_products(refresh=True)
         return self
 
     @triggers_refreshed_triangulation

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -1196,6 +1196,10 @@ class VMobject(Mobject):
         return self
 
     def get_shader_wrapper_list(self) -> list[ShaderWrapper]:
+        if not self._shaders_initialized:
+            self.init_shader_data()
+            self._shaders_initialized = True
+
         family = self.family_members_with_points()
         if not family:
             return []

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -417,6 +417,7 @@ class VMobject(Mobject):
     def get_joint_type(self) -> float:
         return self.uniforms["joint_type"]
 
+    @Mobject.affects_family_data
     def use_winding_fill(self, value: bool = True, recurse: bool = True):
         for submob in self.get_family(recurse):
             submob._use_winding_fill = value
@@ -835,7 +836,7 @@ class VMobject(Mobject):
             # If both have fill, and they have the same shape, just
             # give them the same triangulation so that it's not recalculated
             # needlessly throughout an animation
-            if self._use_winding_fill and self.has_fill() \
+            if not self._use_winding_fill and self.has_fill() \
                 and vmobject.has_fill() and self.has_same_shape_as(vmobject):
                 vmobject.triangulation = self.triangulation
             return self

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -1244,9 +1244,6 @@ class VMobject(Mobject):
             sw.depth_test = family[0].depth_test
         return [sw for sw in shader_wrappers if len(sw.vert_data) > 0]
 
-    def refresh_shader_data(self):
-        self.get_shader_wrapper_list()
-
 
 class VGroup(VMobject):
     def __init__(self, *vmobjects: VMobject, **kwargs):

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -658,7 +658,7 @@ class VMobject(Mobject):
         return self
 
     def add_subpath(self, points: Vect3Array):
-        assert(len(points) % 2 == 1)
+        assert(len(points) % 2 == 1 or len(points) == 0)
         if not self.has_points():
             self.set_points(points)
             return self

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -1053,8 +1053,10 @@ class VMobject(Mobject):
         null2 = (iti[0::3] - 1 == iti[1::3]) & (iti[0::3] - 2 == iti[2::3])
         inner_tri_indices = iti[~(null1 | null2).repeat(3)]
 
-        outer_tri_indices = self.get_outer_vert_indices()
-        tri_indices = np.hstack([outer_tri_indices, inner_tri_indices])
+        ovi = self.get_outer_vert_indices()
+        # Flip outer triangles with negative orientation
+        ovi[0::3][concave_parts], ovi[2::3][concave_parts] = ovi[2::3][concave_parts], ovi[0::3][concave_parts]
+        tri_indices = np.hstack([ovi, inner_tri_indices])
         self.triangulation = tri_indices
         self.needs_new_triangulation = False
         return tri_indices

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -885,6 +885,8 @@ class VMobject(Mobject):
 
     def invisible_copy(self):
         result = self.copy()
+        if not result.has_fill() or result.get_num_points() == 0:
+            return result
         result.append_vectorized_mobject(self.copy().reverse_points())
         result.set_opacity(0)
         return result

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -40,6 +40,7 @@ from manimlib.utils.space_ops import midpoint
 from manimlib.utils.space_ops import normalize_along_axis
 from manimlib.utils.space_ops import z_to_vector
 from manimlib.shader_wrapper import ShaderWrapper
+from manimlib.shader_wrapper import FillShaderWrapper
 
 from typing import TYPE_CHECKING
 
@@ -1176,16 +1177,15 @@ class VMobject(Mobject):
         )
         fill_data = np.zeros(0, dtype=fill_dtype)
         stroke_data = np.zeros(0, dtype=stroke_dtype)
-        self.fill_shader_wrapper = ShaderWrapper(
-            context=ctx,
+        self.fill_shader_wrapper = FillShaderWrapper(
+            ctx=ctx,
             vert_data=fill_data,
             uniforms=self.uniforms,
             shader_folder=self.fill_shader_folder,
             render_primitive=self.fill_render_primitive,
-            is_fill=True,
         )
         self.stroke_shader_wrapper = ShaderWrapper(
-            context=ctx,
+            ctx=ctx,
             vert_data=stroke_data,
             uniforms=self.uniforms,
             shader_folder=self.stroke_shader_folder,

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -233,6 +233,7 @@ class VMobject(Mobject):
         self.set_stroke(color, width, background=background)
         return self
 
+    @Mobject.affects_family_data
     def set_style(
         self,
         fill_color: ManimColor | Iterable[ManimColor] | None = None,
@@ -1071,6 +1072,7 @@ class VMobject(Mobject):
             return self.data["joint_product"]
 
         self.needs_new_joint_products = False
+        self._data_has_changed = True
 
         points = self.get_points()
 
@@ -1109,6 +1111,11 @@ class VMobject(Mobject):
         self.data["joint_product"][:, 3] = (vect_to_vert * vect_from_vert).sum(1)
         return self.data["joint_product"]
 
+    def lock_matching_data(self, vmobject1: VMobject, vmobject2: VMobject):
+        for mob in [self, vmobject1, vmobject2]:
+            mob.get_joint_products()
+        super().lock_matching_data(vmobject1, vmobject2)
+
     def triggers_refreshed_triangulation(func: Callable):
         @wraps(func)
         def wrapper(self, *args, refresh=True, **kwargs):
@@ -1119,10 +1126,11 @@ class VMobject(Mobject):
             return self
         return wrapper
 
-    @triggers_refreshed_triangulation
     def set_points(self, points: Vect3Array):
         assert(len(points) == 0 or len(points) % 2 == 1)
         super().set_points(points)
+        self.refresh_triangulation()
+        self.get_joint_products(refresh=True)
         return self
 
     @triggers_refreshed_triangulation

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -1250,7 +1250,7 @@ class VMobject(Mobject):
 
         for sw in shader_wrappers:
             # Assume uniforms of the first family member
-            sw.uniforms = family[0].get_uniforms()
+            sw.uniforms.update(family[0].get_uniforms())
             sw.depth_test = family[0].depth_test
         return [sw for sw in shader_wrappers if len(sw.vert_data) > 0]
 

--- a/manimlib/scene/interactive_scene.py
+++ b/manimlib/scene/interactive_scene.py
@@ -317,14 +317,12 @@ class InteractiveScene(Scene):
                 mob.refresh_bounding_box()
             else:
                 self.add_to_selection(mob)
-        self.refresh_static_mobjects()
 
     def clear_selection(self):
         for mob in self.selection:
             mob.set_animating_status(False)
             mob.refresh_bounding_box()
         self.selection.set_submobjects([])
-        self.refresh_static_mobjects()
 
     def disable_interaction(self, *mobjects: Mobject):
         for mob in mobjects:

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -195,7 +195,7 @@ class Scene(object):
     def embed(
         self,
         close_scene_on_exit: bool = True,
-        show_animation_progress: bool = True,
+        show_animation_progress: bool = False,
     ) -> None:
         if not self.preview:
             return  # Embed is only relevant with a preview
@@ -709,7 +709,12 @@ class Scene(object):
             self.undo_stack.append(self.get_state())
             self.restore_state(self.redo_stack.pop())
 
-    def checkpoint_paste(self, skip: bool = False, record: bool = False):
+    def checkpoint_paste(
+        self,
+        skip: bool = False,
+        record: bool = False,
+        progress_bar: bool = True
+    ):
         """
         Used during interactive development to run (or re-run)
         a block of scene code.
@@ -736,6 +741,9 @@ class Scene(object):
         prev_skipping = self.skip_animations
         self.skip_animations = skip
 
+        prev_progress = self.show_animation_progress
+        self.show_animation_progress = progress_bar
+
         if record:
             self.camera.use_window_fbo(False)
             self.file_writer.begin_insert()
@@ -747,6 +755,7 @@ class Scene(object):
             self.camera.use_window_fbo(True)
 
         self.skip_animations = prev_skipping
+        self.show_animation_progress = prev_progress
 
     def checkpoint(self, key: str):
         self.checkpoint_states[key] = self.get_state()

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -575,7 +575,8 @@ class Scene(object):
         self.num_plays += 1
 
     def refresh_static_mobjects(self) -> None:
-        self.camera.refresh_static_mobjects()
+        for mobject in self.mobjects:
+            mobject._data_has_changed = True
 
     def begin_animations(self, animations: Iterable[Animation]) -> None:
         for animation in animations:

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -189,7 +189,6 @@ class Scene(object):
             "Press `command + q` or `esc` to quit"
         )
         self.skip_animations = False
-        self.refresh_static_mobjects()
         while not self.is_window_closing():
             self.update_frame(1 / self.camera.fps)
 
@@ -251,7 +250,6 @@ class Scene(object):
 
         # Operation to run after each ipython command
         def post_cell_func():
-            self.refresh_static_mobjects()
             if not self.is_window_closing():
                 self.update_frame(dt=0, ignore_skipping=True)
             self.save_state()
@@ -562,8 +560,6 @@ class Scene(object):
             self.real_animation_start_time = time.time()
             self.virtual_animation_start_time = self.time
 
-        self.refresh_static_mobjects()
-
     def post_play(self):
         if not self.skip_animations:
             self.file_writer.end_animation()
@@ -573,10 +569,6 @@ class Scene(object):
             self.update_frame(dt=0, ignore_skipping=True)
 
         self.num_plays += 1
-
-    def refresh_static_mobjects(self) -> None:
-        for mobject in self.mobjects:
-            mobject._data_has_changed = True
 
     def begin_animations(self, animations: Iterable[Animation]) -> None:
         for animation in animations:
@@ -652,7 +644,6 @@ class Scene(object):
                 self.emit_frame()
                 if stop_condition is not None and stop_condition():
                     break
-        self.refresh_static_mobjects()
         self.post_play()
 
     def hold_loop(self):
@@ -712,13 +703,11 @@ class Scene(object):
         if self.undo_stack:
             self.redo_stack.append(self.get_state())
             self.restore_state(self.undo_stack.pop())
-        self.refresh_static_mobjects()
 
     def redo(self):
         if self.redo_stack:
             self.undo_stack.append(self.get_state())
             self.restore_state(self.redo_stack.pop())
-        self.refresh_static_mobjects()
 
     def checkpoint_paste(self, skip: bool = False, record: bool = False):
         """

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -737,18 +737,14 @@ class Scene(object):
         self.skip_animations = skip
 
         if record:
-            # Resize window so rendering happens at the appropriate size
-            self.window.size = self.camera.get_pixel_shape()
-            self.window.swap_buffers()
-            self.update_frame()
+            self.camera.use_window_fbo(False)
             self.file_writer.begin_insert()
 
         shell.run_cell(pasted)
 
         if record:
             self.file_writer.end_insert()
-            # Put window back to how it started
-            self.window.to_default_position()
+            self.camera.use_window_fbo(True)
 
         self.skip_animations = prev_skipping
 

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -293,13 +293,10 @@ class SceneFileWriter(object):
         self.write_to_movie = True
         self.init_output_directories()
         movie_path = self.get_movie_file_path()
-        folder, file = os.path.split(movie_path)
-        scene_name, ext = file.split(".")
-        n_inserts = len(list(filter(
-            lambda f: f.startswith(scene_name + "_insert"),
-            os.listdir(folder)
-        )))
-        self.inserted_file_path = movie_path.replace(".", f"_insert_{n_inserts}.")
+        count = 0
+        while os.path.exists(name := movie_path.replace(".", f"_insert_{count}.")):
+            count += 1
+        self.inserted_file_path = name
         self.open_movie_pipe(self.inserted_file_path)
 
     def end_insert(self):

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -333,10 +333,11 @@ class FillShaderWrapper(ShaderWrapper):
         if not winding:
             vao.render(moderngl.TRIANGLES)
             return
+        original_fbo = self.ctx.fbo
         self.fill_fbo.clear()
         self.fill_fbo.use()
         self.ctx.blend_func = (moderngl.ONE, moderngl.ONE)
         vao.render(self.render_primitive)
         self.ctx.blend_func = moderngl.DEFAULT_BLENDING
-        self.ctx.screen.use()
+        original_fbo.use()
         self.fill_texture_vao.render(moderngl.TRIANGLE_STRIP)

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -289,10 +289,9 @@ class FillShaderWrapper(ShaderWrapper):
 
         texture_fbo.clear()
         texture_fbo.use()
-        self.ctx.blend_func = (moderngl.ONE, moderngl.ONE)
-        vao.render(self.render_primitive)
+        vao.render()
 
-        self.ctx.blend_func = (moderngl.ONE, moderngl.ONE_MINUS_SRC_ALPHA)
         original_fbo.use()
+        self.ctx.blend_func = (moderngl.ONE, moderngl.ONE_MINUS_SRC_ALPHA)
         texture_vao.render(moderngl.TRIANGLE_STRIP)
-        self.ctx.blend_func = moderngl.DEFAULT_BLENDING
+        self.ctx.blend_func = (moderngl.DEFAULT_BLENDING)

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 class ShaderWrapper(object):
     def __init__(
         self,
+        context: moderngl.context.Context,
         vert_data: np.ndarray,
         vert_indices: np.ndarray | None = None,
         shader_folder: str | None = None,
@@ -35,6 +36,7 @@ class ShaderWrapper(object):
         render_primitive: int = moderngl.TRIANGLE_STRIP,
         is_fill: bool = False,
     ):
+        self.ctx = context
         self.vert_data = vert_data
         self.vert_indices = (vert_indices or np.zeros(0)).astype(int)
         self.vert_attributes = vert_data.dtype.names

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -32,7 +32,6 @@ class ShaderWrapper(object):
         uniforms: dict[str, float | np.ndarray] | None = None,  # A dictionary mapping names of uniform variables
         texture_paths: dict[str, str] | None = None,  # A dictionary mapping names to filepaths for textures.
         depth_test: bool = False,
-        use_clip_plane: bool = False,
         render_primitive: int = moderngl.TRIANGLE_STRIP,
         is_fill: bool = False,
     ):
@@ -43,7 +42,6 @@ class ShaderWrapper(object):
         self.uniforms = uniforms or dict()
         self.texture_paths = texture_paths or dict()
         self.depth_test = depth_test
-        self.use_clip_plane = use_clip_plane
         self.render_primitive = str(render_primitive)
         self.is_fill = is_fill
         self.init_program_code()
@@ -131,6 +129,11 @@ class ShaderWrapper(object):
                 continue
             code_map[name] = re.sub(old, new, code_map[name])
         self.refresh_id()
+
+    def use_clip_plane(self):
+        if "clip_plane" not in self.uniforms:
+            return False
+        return any(self.uniforms["clip_plane"])
 
     def combine_with(self, *shader_wrappers: ShaderWrapper) -> ShaderWrapper:
         if len(shader_wrappers) > 0:

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -14,7 +14,7 @@ from manimlib.utils.shaders import get_shader_code_from_file
 from manimlib.utils.shaders import get_shader_program
 from manimlib.utils.shaders import image_path_to_texture
 from manimlib.utils.shaders import get_texture_id
-from manimlib.utils.shaders import get_intermediary_palette
+from manimlib.utils.shaders import get_fill_palette
 from manimlib.utils.shaders import release_texture
 
 from typing import TYPE_CHECKING
@@ -284,13 +284,15 @@ class FillShaderWrapper(ShaderWrapper):
             vao.render(moderngl.TRIANGLES)
             return
 
-        texture_fbo, texture_vao = get_intermediary_palette(self.ctx)
-
         original_fbo = self.ctx.fbo
+        texture_fbo, texture_vao = get_fill_palette(self.ctx)
+
         texture_fbo.clear()
         texture_fbo.use()
         self.ctx.blend_func = (moderngl.ONE, moderngl.ONE)
         vao.render(self.render_primitive)
-        self.ctx.blend_func = moderngl.DEFAULT_BLENDING
+
+        self.ctx.blend_func = (moderngl.ONE, moderngl.ONE_MINUS_SRC_ALPHA)
         original_fbo.use()
         texture_vao.render(moderngl.TRIANGLE_STRIP)
+        self.ctx.blend_func = moderngl.DEFAULT_BLENDING

--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -13,13 +13,18 @@ void main() {
     if (color.a == 0) discard;
     frag_color = color;
 
-    if(winding && orientation > 0) frag_color *= -1;
+    // Pre-multiply alphas
+    if(winding) frag_color *= frag_color.a;
+
+    // Give a sign based on orientation so that
+    // additive blending cancels as needed
+    if(winding && orientation < 0) frag_color *= -1;
 
     if (bool(fill_all)) return;
 
     float x = uv_coords.x;
     float y = uv_coords.y;
     float Fxy = (y - x * x);
-    if(!winding && orientation > 0) Fxy *= -1;
+    if(!winding && orientation < 0) Fxy *= -1;
     if(Fxy < 0) discard;
 }

--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -13,12 +13,26 @@ void main() {
     if (color.a == 0) discard;
     frag_color = color;
 
-    // Pre-multiply alphas
-    if(winding) frag_color *= frag_color.a;
+    /*
+    We want negatively oriented triangles to be canceled with positively
+    oriented ones. The easiest way to do this is to give them negative alpha,
+    and change the blend function to just add them. However, this messes with
+    usual blending, so instead the following line is meant to let this canceling
+    work even for the normal blending equation:
 
-    // Give a sign based on orientation so that
-    // additive blending cancels as needed
-    if(winding && orientation < 0) frag_color *= -1;
+    (1 - alpha) * dst + alpha * src
+
+    We want the effect of blending with a positively oriented triangle followed
+    by a negatively oriented one to return to whatever the original frag value
+    was. You can work out this will work if the alpha for negative orientations
+    is changed to -alpha / (1 - alpha). This has a singularity at alpha = 1,
+    so we cap it at a value very close to 1. Effectively, the purpose of this
+    cap is to make sure the original fragment color can be recovered even after
+    blending with an alpha = 1 color.
+    */
+    float a = 0.999 * frag_color.a;
+    if(winding && orientation < 0) a = -a / (1 - a);
+    frag_color.a = a;
 
     if (bool(fill_all)) return;
 

--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -6,13 +6,15 @@ in vec4 color;
 in float fill_all;
 in float orientation;
 in vec2 uv_coords;
+in vec3 point;
 
 out vec4 frag_color;
 
+#INSERT finalize_color.glsl
+
 void main() {
     if (color.a == 0) discard;
-    frag_color = color;
-
+    frag_color = finalize_color(color, point, vec3(0.0, 0.0, 1.0));
     /*
     We want negatively oriented triangles to be canceled with positively
     oriented ones. The easiest way to do this is to give them negative alpha,

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -13,6 +13,7 @@ in float v_vert_index[3];
 out vec4 color;
 out float fill_all;
 out float orientation;
+out vec3 point;
 // uv space is where the curve coincides with y = x^2
 out vec2 uv_coords;
 
@@ -26,7 +27,6 @@ const vec2 SIMPLE_QUADRATIC[3] = vec2[3](
 // Analog of import for manim only
 #INSERT get_gl_Position.glsl
 #INSERT get_unit_normal.glsl
-#INSERT finalize_color.glsl
 
 
 void emit_triangle(vec3 points[3], vec4 v_color[3]){
@@ -35,12 +35,10 @@ void emit_triangle(vec3 points[3], vec4 v_color[3]){
 
     for(int i = 0; i < 3; i++){
         uv_coords = SIMPLE_QUADRATIC[i];
-        color = finalize_color(v_color[i], points[i], unit_normal);
-        if(winding){
-            // Pure black will be used to discard fragments later
-            if(color.rgb == vec3(0.0)) color.rgb += vec3(0.01);
-            // color.a = sqrt(color.a);
-        }
+        color = v_color[i];
+        point = points[i];
+        // Pure black will be used to discard fragments later
+        if(winding && color.rgb == vec3(0.0)) color.rgb += vec3(0.01);
         gl_Position = get_gl_Position(points[i]);
         EmitVertex();
     }

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -31,7 +31,7 @@ const vec2 SIMPLE_QUADRATIC[3] = vec2[3](
 
 void emit_triangle(vec3 points[3], vec4 v_color[3]){
     vec3 unit_normal = get_unit_normal(points[0], points[1], points[2]);
-    orientation = sign(unit_normal.z);
+    orientation = winding ? sign(unit_normal.z) : 1.0;
 
     for(int i = 0; i < 3; i++){
         uv_coords = SIMPLE_QUADRATIC[i];

--- a/manimlib/shaders/quadratic_bezier_fill/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/geom.glsl
@@ -36,6 +36,11 @@ void emit_triangle(vec3 points[3], vec4 v_color[3]){
     for(int i = 0; i < 3; i++){
         uv_coords = SIMPLE_QUADRATIC[i];
         color = finalize_color(v_color[i], points[i], unit_normal);
+        if(winding){
+            // Pure black will be used to discard fragments later
+            if(color.rgb == vec3(0.0)) color.rgb += vec3(0.01);
+            // color.a = sqrt(color.a);
+        }
         gl_Position = get_gl_Position(points[i]);
         EmitVertex();
     }

--- a/manimlib/utils/shaders.py
+++ b/manimlib/utils/shaders.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 from functools import lru_cache
+import moderngl
 
 from manimlib.utils.directories import get_shader_dir
 from manimlib.utils.file_ops import find_file
@@ -10,10 +11,24 @@ from manimlib.utils.file_ops import find_file
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from typing import Sequence, Optional
 
 
-@lru_cache(maxsize=12)
+@lru_cache()
+def get_shader_program(
+        ctx: moderngl.context.Context,
+        vertex_shader: str,
+        fragment_shader: Optional[str] = None,
+        geometry_shader: Optional[str] = None,
+    ) -> moderngl.Program:
+    return ctx.program(
+        vertex_shader=vertex_shader,
+        fragment_shader=fragment_shader,
+        geometry_shader=geometry_shader,
+    )
+
+
+@lru_cache()
 def get_shader_code_from_file(filename: str) -> str | None:
     if not filename:
         return None

--- a/manimlib/utils/shaders.py
+++ b/manimlib/utils/shaders.py
@@ -110,7 +110,7 @@ def get_fill_palette(ctx) -> Tuple[Framebuffer, VertexArray]:
     size = (2 * DEFAULT_PIXEL_WIDTH, 2 * DEFAULT_PIXEL_HEIGHT)
     # Important to make sure dtype is floating point (not fixed point)
     # so that alpha values can be negative and are not clipped
-    texture = ctx.texture(size=size, components=4, dtype='f2')
+    texture = ctx.texture(size=size, components=4, dtype='f4')
     depth_buffer = ctx.depth_renderbuffer(size)  # TODO, currently not used
     texture_fbo = ctx.framebuffer(texture, depth_buffer)
 
@@ -147,8 +147,7 @@ def get_fill_palette(ctx) -> Tuple[Framebuffer, VertexArray]:
                     0.25 * texture(Texture, tc1) +
                     0.25 * texture(Texture, tc2) +
                     0.25 * texture(Texture, tc3);
-                if(frag_color.a == 0) discard;
-                frag_color = abs(frag_color);
+                if(distance(frag_color.rgb, vec3(0.0)) < 1e-3) discard;
                 //TODO, set gl_FragDepth;
             }
         ''',

--- a/manimlib/utils/shaders.py
+++ b/manimlib/utils/shaders.py
@@ -4,6 +4,7 @@ import os
 import re
 from functools import lru_cache
 import moderngl
+from PIL import Image
 
 from manimlib.utils.directories import get_shader_dir
 from manimlib.utils.file_ops import find_file
@@ -12,6 +13,34 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Sequence, Optional
+
+
+ID_TO_TEXTURE: dict[int, moderngl.Texture] = dict()
+
+
+@lru_cache()
+def image_path_to_texture(path: str, ctx: moderngl.Context) -> moderngl.Texture:
+    im = Image.open(path).convert("RGBA")
+    return ctx.texture(
+        size=im.size,
+        components=len(im.getbands()),
+        data=im.tobytes(),
+    )
+
+
+def get_texture_id(texture: moderngl.Texture) -> int:
+    tid = 0
+    while tid in ID_TO_TEXTURE:
+        tid += 1
+    ID_TO_TEXTURE[tid] = texture
+    texture.use(location=tid)
+    return tid
+
+
+def release_texture(texture_id: int):
+    texture = ID_TO_TEXTURE.pop(texture_id, None)
+    if texture is not None:
+        texture.release()
 
 
 @lru_cache()

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -26,12 +26,10 @@ class Window(PygletWindow):
         self,
         scene: Scene,
         size: tuple[int, int] = (1280, 720),
-        full_size: tuple[int, int] = (1920, 1080),
         samples = 0
     ):
-        super().__init__(size=full_size, samples=samples)
+        super().__init__(size=size, samples=samples)
 
-        self.full_size = full_size
         self.default_size = size
         self.default_position = self.find_initial_position(size)
         self.scene = scene


### PR DESCRIPTION
Move the rendering logic away from camera.py and instead move it into the shader wrappers. Previously camera would keep track of which mobjects were actively changing and store a nebulously named dictionary called "render_group" to keep track of data buffers that didn't need to be regenerated. Now, a Mobject will keep track of whether its data has been changed, and buffers are only repopulated as they need to be, without the need for Scene to periodically call "refresh_static_mobjects".

Additionally, this contains a (mildly hacky) fix to ensure that the new fill rendering mode introduced in https://github.com/3b1b/manim/pull/1972 has expected behavior with respect to alpha blending.