### PR TITLE
Use typing_extensions to import Self for python versions <3.11

### DIFF
--- a/manimlib/mobject/changing.py
+++ b/manimlib/mobject/changing.py
@@ -11,8 +11,8 @@ from manimlib.utils.rate_functions import smooth
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable, List, Iterable, Self
-    from manimlib.typing import ManimColor, Vect3
+    from typing import Callable, List, Iterable
+    from manimlib.typing import ManimColor, Vect3, Self
 
 
 class AnimatedBoundary(VGroup):

--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -32,9 +32,9 @@ from manimlib.utils.space_ops import normalize
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterable, Sequence, Type, TypeVar, Optional, Self
+    from typing import Callable, Iterable, Sequence, Type, TypeVar, Optional
     from manimlib.mobject.mobject import Mobject
-    from manimlib.typing import ManimColor, Vect3, Vect3Array, VectN, RangeSpecifier
+    from manimlib.typing import ManimColor, Vect3, Vect3Array, VectN, RangeSpecifier, Self
 
     T = TypeVar("T", bound=Mobject)
 

--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -30,8 +30,8 @@ from manimlib.utils.space_ops import rotation_matrix_transpose
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, Self, Optional
-    from manimlib.typing import ManimColor, Vect3, Vect3Array
+    from typing import Iterable, Optional
+    from manimlib.typing import ManimColor, Vect3, Vect3Array, Self
 
 
 DEFAULT_DOT_RADIUS = 0.08

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -18,10 +18,10 @@ from manimlib.mobject.types.vectorized_mobject import VMobject
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Sequence, Self
+    from typing import Sequence
     import numpy.typing as npt
     from manimlib.mobject.mobject import Mobject
-    from manimlib.typing import ManimColor, Vect3
+    from manimlib.typing import ManimColor, Vect3, Self
 
 
 VECTOR_LABEL_SCALE_FACTOR = 0.8

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -48,9 +48,9 @@ from manimlib.utils.space_ops import rotation_matrix_transpose
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterable, Iterator, Union, Tuple, Optional, Self
+    from typing import Callable, Iterable, Iterator, Union, Tuple, Optional
     import numpy.typing as npt
-    from manimlib.typing import ManimColor, Vect3, Vect4, Vect3Array, UniformDict
+    from manimlib.typing import ManimColor, Vect3, Vect4, Vect3Array, UniformDict, Self
     from moderngl.context import Context
 
     TimeBasedUpdater = Callable[["Mobject", float], "Mobject" | None]

--- a/manimlib/mobject/numbers.py
+++ b/manimlib/mobject/numbers.py
@@ -11,8 +11,8 @@ from manimlib.mobject.types.vectorized_mobject import VMobject
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import TypeVar, Self
-    from manimlib.typing import ManimColor, Vect3
+    from typing import TypeVar
+    from manimlib.typing import ManimColor, Vect3, Self
 
     T = TypeVar("T", bound=VMobject)
 

--- a/manimlib/mobject/shape_matchers.py
+++ b/manimlib/mobject/shape_matchers.py
@@ -14,9 +14,9 @@ from manimlib.utils.customization import get_customization
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Sequence, Self
+    from typing import Sequence
     from manimlib.mobject.mobject import Mobject
-    from manimlib.typing import ManimColor
+    from manimlib.typing import ManimColor, Self
 
 
 class SurroundingRectangle(Rectangle):

--- a/manimlib/mobject/types/dot_cloud.py
+++ b/manimlib/mobject/types/dot_cloud.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-    from typing import Sequence, Tuple, Self
-    from manimlib.typing import ManimColor, Vect3, Vect3Array
+    from typing import Sequence, Tuple
+    from manimlib.typing import ManimColor, Vect3, Vect3Array, Self
 
 
 DEFAULT_DOT_RADIUS = 0.05

--- a/manimlib/mobject/types/point_cloud_mobject.py
+++ b/manimlib/mobject/types/point_cloud_mobject.py
@@ -10,8 +10,8 @@ from manimlib.utils.iterables import resize_with_interpolation
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable, Self
-    from manimlib.typing import ManimColor, Vect3, Vect3Array, Vect4Array
+    from typing import Callable
+    from manimlib.typing import ManimColor, Vect3, Vect3Array, Vect4Array, Self
 
 
 class PMobject(Mobject):

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -17,10 +17,10 @@ from manimlib.utils.space_ops import cross
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterable, Sequence, Tuple, Self
+    from typing import Callable, Iterable, Sequence, Tuple
 
     from manimlib.camera.camera import Camera
-    from manimlib.typing import ManimColor, Vect3, Vect3Array
+    from manimlib.typing import ManimColor, Vect3, Vect3Array, Self
 
 
 class Surface(Mobject):

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -45,8 +45,8 @@ from manimlib.shader_wrapper import FillShaderWrapper
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterable, Tuple, Any, Self
-    from manimlib.typing import ManimColor, Vect3, Vect4, Vect3Array, Vect4Array
+    from typing import Callable, Iterable, Tuple, Any
+    from manimlib.typing import ManimColor, Vect3, Vect4, Vect3Array, Vect4Array, Self
     from moderngl.context import Context
 
 DEFAULT_STROKE_COLOR = GREY_A

--- a/manimlib/mobject/value_tracker.py
+++ b/manimlib/mobject/value_tracker.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import numpy as np
-from typing import Self
 from manimlib.mobject.mobject import Mobject
 from manimlib.utils.iterables import listify
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from manimlib.typing import Self
 
 
 class ValueTracker(Mobject):

--- a/manimlib/typing.py
+++ b/manimlib/typing.py
@@ -5,6 +5,11 @@ if TYPE_CHECKING:
     from colour import Color
     import numpy as np
     import re
+    
+    try:
+        from typing import Self
+    except ImportError:
+        from typing_extensions import Self
 
     # Abbreviations for a common types
     ManimColor = Union[str, Color, None]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ skia-pathops
 svgelements>=1.8.1
 sympy
 tqdm
+typing-extensions; python_version < "3.11"
 validators


### PR DESCRIPTION
In response to @TonyCrane's [suggestion](https://github.com/3b1b/manim/pull/1981#issuecomment-1413882723)