### PR TITLE
Cleaner winding fill

### DIFF
--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -309,6 +309,8 @@ class VMobjectFromSVGPath(VMobject):
         path_string = self.path_obj.d()
         if path_string not in PATH_TO_POINTS:
             self.handle_commands()
+            if not self._use_winding_fill:
+                self.subdivide_intersections()
             # Save for future use
             PATH_TO_POINTS[path_string] = self.get_points().copy()
         else:

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -867,8 +867,10 @@ class VMobject(Mobject):
     # Alignment
     def align_points(self, vmobject: VMobject) -> Self:
         winding = self._use_winding_fill and vmobject._use_winding_fill
-        self.use_winding_fill(winding)
-        vmobject.use_winding_fill(winding)
+        if winding != self._use_winding_fill:
+            self.use_winding_fill(winding)
+        if winding != vmobject._use_winding_fill:
+            vmobject.use_winding_fill(winding)
         if self.get_num_points() == len(vmobject.get_points()):
             # If both have fill, and they have the same shape, just
             # give them the same triangulation so that it's not recalculated

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -287,24 +287,22 @@ class FillShaderWrapper(ShaderWrapper):
             return
 
         original_fbo = self.ctx.fbo
-        texture_fbo, texture_vao, null_rgb = self.fill_canvas
+        texture_fbo, texture_vao = self.fill_canvas
 
-        texture_fbo.clear(*null_rgb, 0.0)
+        texture_fbo.clear()
         texture_fbo.use()
         gl.glBlendFuncSeparate(
             # Ordinary blending for colors
             gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA,
-            # Just take the max of the alphas, given the shenanigans
-            # with how alphas are being used to compute winding numbers
-            gl.GL_ONE, gl.GL_ONE,
+            # The effect of blending with -a / (1 - a)
+            # should be to cancel out
+            gl.GL_ONE_MINUS_DST_ALPHA, gl.GL_ONE,
         )
-        gl.glBlendEquationSeparate(gl.GL_FUNC_ADD, gl.GL_MAX)
 
         super().render()
 
         original_fbo.use()
         gl.glBlendFunc(gl.GL_ONE, gl.GL_ONE_MINUS_SRC_ALPHA)
-        gl.glBlendEquation(gl.GL_FUNC_ADD)
 
         texture_vao.render()
 

--- a/manimlib/shaders/quadratic_bezier_fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier_fill/frag.glsl
@@ -33,7 +33,7 @@ void main() {
     cap is to make sure the original fragment color can be recovered even after
     blending with an (alpha = 1) color.
     */
-    float a = 0.99 * frag_color.a;
+    float a = 0.95 * frag_color.a;
     if(winding && orientation < 0) a = -a / (1 - a);
     frag_color.a = a;
 


### PR DESCRIPTION
This fixes some issues with alpha-blending when using winding fill, namely strange shadow effects when something with higher opacity is blended one something with lower opacity. In doing so, it offers a cleaner approach to the whole algorithm, essentially just using a certain alpha blending function, which makes it no longer necessary to clear the fill canvas with a negative color.