### PR TITLE
Several minor fixes

### DIFF
--- a/manimlib/animation/fading.py
+++ b/manimlib/animation/fading.py
@@ -36,7 +36,7 @@ class Fade(Transform):
 
 class FadeIn(Fade):
     def create_target(self) -> Mobject:
-        return self.mobject
+        return self.mobject.copy()
 
     def create_starting_mobject(self) -> Mobject:
         start = super().create_starting_mobject()

--- a/manimlib/animation/growing.py
+++ b/manimlib/animation/growing.py
@@ -26,7 +26,7 @@ class GrowFromPoint(Transform):
         super().__init__(mobject, **kwargs)
 
     def create_target(self) -> Mobject:
-        return self.mobject
+        return self.mobject.copy()
 
     def create_starting_mobject(self) -> Mobject:
         start = super().create_starting_mobject()

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -54,12 +54,16 @@ class Transform(Animation):
     def begin(self) -> None:
         self.target_mobject = self.create_target()
         self.check_target_mobject_validity()
-        # Use a copy of target_mobject for the align_data_and_family
-        # call so that the actual target_mobject stays
-        # preserved, since calling allign_data will potentially
-        # change the structure of both arguments
-        self.target_copy = self.target_mobject.copy()
-        self.mobject.align_data_and_family(self.target_copy)
+
+        if self.mobject.is_aligned_with(self.target_mobject):
+            self.target_copy = self.target_mobject
+        else:
+            # Use a copy of target_mobject for the align_data_and_family
+            # call so that the actual target_mobject stays
+            # preserved, since calling align_data will potentially
+            # change the structure of both arguments
+            self.target_copy = self.target_mobject.copy()
+            self.mobject.align_data_and_family(self.target_copy)
         super().begin()
         if not self.mobject.has_updaters:
             self.mobject.lock_matching_data(

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -182,7 +182,8 @@ class Mobject(object):
     @affects_data
     def set_data(self, data: np.ndarray) -> Self:
         assert(data.dtype == self.data.dtype)
-        self.data = data.copy()
+        self.resize_points(len(data))
+        self.data[:] = data
         return self
 
     @affects_data

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1812,13 +1812,14 @@ class Mobject(object):
                 lambda name: arrays_match(sm1.data[name], sm2.data[name]),
                 names,
             ))
-            sm.const_data_keys = set(filter(
-                lambda name: all(
+            sm.const_data_keys = set(
+                name for name in names
+                if name not in sm.locked_data_keys
+                if all(
                     array_is_constant(mob.data[name])
                     for mob in (sm, sm1, sm2)
-                ),
-                names
-            ))
+                )
+            )
 
         return self
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -97,6 +97,7 @@ class Mobject(object):
         self.family: list[Mobject] = [self]
         self.locked_data_keys: set[str] = set()
         self.const_data_keys: set[str] = set()
+        self.locked_uniform_keys: set[str] = set()
         self.needs_new_bounding_box: bool = True
         self._is_animating: bool = False
         self.saved_state = None
@@ -1771,7 +1772,8 @@ class Mobject(object):
                 md2 = md2[0]
             self.data[key] = func(md1, md2, alpha)
 
-        for key in self.uniforms:
+        keys = [k for k in self.uniforms if k not in self.locked_uniform_keys]
+        for key in keys:
             if key not in mobject1.uniforms or key not in mobject2.uniforms:
                 continue
             self.uniforms[key] = interpolate(
@@ -1805,8 +1807,14 @@ class Mobject(object):
         read into the shader_wrapper objects needlessly
         """
         if self.has_updaters:
-            return
+            return self
         self.locked_data_keys = set(keys)
+        return self
+
+    def lock_uniforms(self, keys: Iterable[str]) -> Self:
+        if self.has_updaters:
+            return self
+        self.locked_uniform_keys = set(keys)
         return self
 
     def lock_matching_data(self, mobject1: Mobject, mobject2: Mobject) -> Self:
@@ -1818,16 +1826,19 @@ class Mobject(object):
         for sm, sm1, sm2 in tuples:
             if not sm.data.dtype == sm1.data.dtype == sm2.data.dtype:
                 continue
-            names = sm.data.dtype.names
-            sm.lock_data(filter(
-                lambda name: arrays_match(sm1.data[name], sm2.data[name]),
-                names,
-            ))
+            sm.lock_data(
+                key for key in sm.data.dtype.names
+                if arrays_match(sm1.data[key], sm2.data[key])
+            )
+            sm.lock_uniforms(
+                key for key in self.uniforms
+                if all(listify(mobject1.uniforms.get(key, 0) == mobject2.uniforms.get(key, 0)))
+            )
             sm.const_data_keys = set(
-                name for name in names
-                if name not in sm.locked_data_keys
+                key for key in sm.data.dtype.names
+                if key not in sm.locked_data_keys
                 if all(
-                    array_is_constant(mob.data[name])
+                    array_is_constant(mob.data[key])
                     for mob in (sm, sm1, sm2)
                 )
             )
@@ -1838,6 +1849,7 @@ class Mobject(object):
         for mob in self.get_family():
             mob.locked_data_keys = set()
             mob.const_data_keys = set()
+            mob.locked_uniform_keys = set()
         return self
 
     # Operations touching shader uniforms

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1672,6 +1672,16 @@ class Mobject(object):
 
     # Alignment
 
+    def is_aligned_with(self, mobject: Mobject) -> bool:
+        if len(self.data) != len(mobject.data):
+            return False
+        if len(self.submobjects) != len(mobject.submobjects):
+            return False
+        return all(
+            sm1.is_aligned_with(sm2)
+            for sm1, sm2 in zip(self.submobjects, mobject.submobjects)
+        )
+
     def align_data_and_family(self, mobject: Mobject) -> Self:
         self.align_family(mobject)
         self.align_data(mobject)

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -998,7 +998,7 @@ class VMobject(Mobject):
         self._has_stroke = mobject1._has_stroke or mobject2._has_stroke
         self._has_fill = mobject1._has_fill or mobject2._has_fill
 
-        if self.has_fill() and not self._use_winding_fill:
+        if self._has_fill and not self._use_winding_fill:
             tri1 = mobject1.get_triangulation()
             tri2 = mobject2.get_triangulation()
             if not arrays_match(tri1, tri2):
@@ -1309,6 +1309,11 @@ class VMobject(Mobject):
             wrapper.refresh_id()
         return self
 
+    def get_uniforms(self):
+        # TODO, account for submob uniforms separately?
+        self.uniforms.update(self.family_members_with_points()[0].uniforms)
+        return self.uniforms
+
     def get_shader_wrapper_list(self, ctx: Context) -> list[ShaderWrapper]:
         if not self._shaders_initialized:
             self.init_shader_data(ctx)
@@ -1359,8 +1364,6 @@ class VMobject(Mobject):
             self.fill_shader_wrapper.read_in(fill_datas, fill_indices or None),
             self.stroke_shader_wrapper.read_in(stroke_datas),
         ]
-        # TODO, account for submob uniforms separately?
-        self.uniforms.update(family[0].uniforms)
         return [sw for sw in shader_wrappers if len(sw.vert_data) > 0]
 
 


### PR DESCRIPTION
- Don't copy Transform.target_mobject if it already aligns with Transform.mobject
- Lock uniform keys, analogous to how data keys lock, during Transform
- Use resize_points in Mobject.set_data (which in turns makes sure outer_vert_indices are always correct)