### PR TITLE
Remove duplicate items

### DIFF
--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -119,10 +119,12 @@ class Animation(object):
         # The surrounding scene typically handles
         # updating of self.mobject.  Besides, in
         # most cases its updating is suspended anyway
-        return list(filter(
+        items = list(filter(
             lambda m: m is not self.mobject,
             self.get_all_mobjects()
         ))
+        items = list(set(items))
+        return items
 
     def copy(self):
         return deepcopy(self)


### PR DESCRIPTION
# Motivation
In the Animation class, the `get_all_mobjects_to_update` method would cause duplicate Mobjects to be returned, and update was performed on all of them.

# Proposed changes
Add `items = list(set(items))` in the `get_all_mobjects_to_update` method of the Animation class to achieve the purpose of removing duplicate items.

# Code and test
```
class AnimationIssue(ThreeDScene):

    def construct(self) -> None:
        day_texture = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Whole_world_-_land_and_oceans.jpg/1280px-Whole_world_-_land_and_oceans.jpg"
        night_texture = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/The_earth_at_night.jpg/1280px-The_earth_at_night.jpg"
        sphere = Sphere(radius=RADIUS)

        surface = TexturedSurface(sphere, day_texture, night_texture)
        always_rotate(surface)
        self.play(FadeIn(surface, run_time=2))
        self.wait(3)


```


After running the above code, the Earth in the video will first rotate quickly and then decelerate. This is due to the get_all_mobjects_to_update method (TransForm.get_all_mobjects) in the Animation class returning duplicate mobjects(TransForm.get_all_mobjects.target_copy).

https://github.com/3b1b/manim/assets/37145122/0c8b6de7-3908-4260-891d-91961b342272

Therefore, I used the set function in the get_all_mobjects_to_update method of the Animation class to remove duplicate mobjects, which prevented the issue from occurring(fixed video)

https://github.com/3b1b/manim/assets/37145122/344a60b9-e9e5-4207-8ebf-31052eb0d35c




