### PR TITLE
Allow add two or more ImageMobjects and TextureSurfaces

### DIFF
--- a/manimlib/mobject/types/image_mobject.py
+++ b/manimlib/mobject/types/image_mobject.py
@@ -34,7 +34,9 @@ class ImageMobject(Mobject):
         self.height = height
         self.image_path = get_full_raster_image_path(filename)
         self.image = Image.open(self.image_path)
-        super().__init__(texture_paths={"Texture": self.image_path}, **kwargs)
+        _id = id(self)
+        key = "T%d" % (_id)
+        super().__init__(texture_paths={key: self.image_path}, **kwargs)
 
     def init_data(self) -> None:
         super().init_data(length=4)

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -302,9 +302,12 @@ class TexturedSurface(Surface):
         else:
             self.num_textures = 2
 
+        _id = id(self)
+        key_light = "L%d"%(_id)
+        key_dark = "D%d"%(_id)
         texture_paths = {
-            "LightTexture": get_full_raster_image_path(image_file),
-            "DarkTexture": get_full_raster_image_path(dark_image_file),
+            key_light: get_full_raster_image_path(image_file),
+            key_dark: get_full_raster_image_path(dark_image_file),
         }
 
         self.uv_surface = uv_surface

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -69,14 +69,14 @@ class ShaderWrapper(object):
                 os.path.join(self.shader_folder, f"{name}.glsl")
             )
             
-            if self.texture_paths is not None:
+            if code is not None and self.texture_paths is not None:
                 for k in self.texture_paths:
                     if k.startswith("L"):
-                        code = code.replace("LightTexture","k")
+                        code = code.replace("LightTexture",k)
                     elif k.startswith("D"):
-                        code = code.replace("DarkTexture","k")
+                        code = code.replace("DarkTexture",k)
                     elif k.startswith("T"):
-                        code = code.replace("Texture","k")
+                        code = code.replace("Texture",k)
             
             return code
 

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -50,6 +50,8 @@ class ShaderWrapper(object):
         self.shader_folder = shader_folder
         self.depth_test = depth_test
         self.render_primitive = render_primitive
+        
+        self.texture_paths = texture_paths
 
         self.program_uniform_mirror: UniformDict = dict()
         self.bind_to_mobject_uniforms(mobject_uniforms or dict())
@@ -63,9 +65,20 @@ class ShaderWrapper(object):
 
     def init_program_code(self) -> None:
         def get_code(name: str) -> str | None:
-            return get_shader_code_from_file(
+            code = get_shader_code_from_file(
                 os.path.join(self.shader_folder, f"{name}.glsl")
             )
+            
+            if self.texture_paths is not None:
+                for k in self.texture_paths:
+                    if k.startswith("L"):
+                        code = code.replace("LightTexture","k")
+                    elif k.startswith("D"):
+                        code = code.replace("DarkTexture","k")
+                    elif k.startswith("T"):
+                        code = code.replace("Texture","k")
+            
+            return code
 
         self.program_code: dict[str, str | None] = {
             "vertex_shader": get_code("vert"),


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
[Adding two or more images with ImageMobject showing the recent image in the Scene. ](https://github.com/3b1b/manim/issues/2010)

The same problem also occurs in TextureSurface, and this PR is meant to solve this problem.

## Proposed changes
<!-- What you changed in those files -->
- image_mobject.py
- surface.py
- shader_wrapper.py

## Test
<!-- How do you test your changes -->
**Code**:
```python
from manimlib import *


class Video(Scene):
    
    def construct(self):
        
        image_file1 = "resources/barter-1.png"
        image_file2 = "resources/measure.png"
        image_file3 = "resources/Thales.jpg"
        image_file4 = "resources/Oheaviside.jpg"
        
        im1 = ImageMobject(image_file1)
        im2 = ImageMobject(image_file2)
        
        im1.set_width(3)
        im2.set_width(3)
        
        self.play(FadeIn(im1))
        self.play(im1.animate.shift(3*LEFT))
        
        self.play(FadeIn(im2))
        self.play(im2.animate.shift(3*RIGHT))
        
        
        surf1 = Sphere(radius=1)
        surf2 = Sphere(radius=1)
        
        surf2.move_to(np.array([2,3,1]))
        
        ts1 = TexturedSurface(surf1,image_file3)
        ts2 = TexturedSurface(surf2,image_file4)
        self.play(ShowCreation(ts1))
        self.play(ShowCreation(ts2))
        
        frame = self.camera.frame
        frame.set_euler_angles(
            theta=-30 * DEGREES,
            phi=70 * DEGREES,
        )
        
        frame.add_updater(lambda m, dt: m.increment_theta(-0.1 * dt))
        self.wait(5)
```
**Result**:

https://github.com/3b1b/manim/assets/15604323/6d222864-99dc-4ba9-b7ec-6cc469ec9807

