### PR TITLE
add zorder to mobject

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -83,6 +83,7 @@ class Mobject(object):
         # If true, the mobject will not get rotated according to camera position
         is_fixed_in_frame: bool = False,
         depth_test: bool = False,
+        zorder: int = 0,
     ):
         self.color = color
         self.opacity = opacity
@@ -90,6 +91,8 @@ class Mobject(object):
         self.texture_paths = texture_paths
         self._is_fixed_in_frame = is_fixed_in_frame
         self.depth_test = depth_test
+        self.zorder = zorder
+        self._scene_order = 0
 
         # Internal state
         self.submobjects: list[Mobject] = []

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -83,7 +83,7 @@ class Mobject(object):
         # If true, the mobject will not get rotated according to camera position
         is_fixed_in_frame: bool = False,
         depth_test: bool = False,
-        zorder: int = 0,
+        z_index: int = 0,
     ):
         self.color = color
         self.opacity = opacity

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -91,7 +91,7 @@ class Mobject(object):
         self.texture_paths = texture_paths
         self._is_fixed_in_frame = is_fixed_in_frame
         self.depth_test = depth_test
-        self.zorder = zorder
+        self.z_index = z_index
         self._scene_order = 0
 
         # Internal state

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -414,7 +414,13 @@ class Scene(object):
         foreground in the order with which they are added.
         """
         self.remove(*new_mobjects)
+        idx = 0
+        scene_order = len(self.mobjects)
+        for m in new_mobjects:
+            m._scene_order = scene_order+idx
+            idx += 1
         self.mobjects += new_mobjects
+        self.mobjects = [self.mobjects[0]]+sorted(self.mobjects[1:], key=lambda m:(m.zorder,m._scene_order))
         self.id_to_mobject_map.update({
             id(sm): sm
             for m in new_mobjects

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -420,7 +420,7 @@ class Scene(object):
             m._scene_order = scene_order+idx
             idx += 1
         self.mobjects += new_mobjects
-        self.mobjects = [self.mobjects[0]]+sorted(self.mobjects[1:], key=lambda m:(m.zorder,m._scene_order))
+        self.mobjects = [self.mobjects[0]]+sorted(self.mobjects[1:], key=lambda m:(m.z_index, m._scene_order))
         self.id_to_mobject_map.update({
             id(sm): sm
             for m in new_mobjects


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
[Suggestion: Using z-order to define layer for Mobjects.](https://github.com/3b1b/manim/issues/852)

## Proposed changes
<!-- What you changed in those files -->
- mobject.py
- scene.py
- 

## Test
<!-- How do you test your changes -->
**Code**:
```python
from manimlib import *


class Video(Scene):
    
    def construct(self):
        s = Square(zorder=1).set_fill(RED,opacity=1)
        c = Circle(zorder=2).set_fill(BLUE,opacity=1)
        t = Triangle(zorder=0).scale(2).set_fill(GREEN,opacity=1)
        r = Rectangle(width=4,height=2,zorder=0).set_fill(PINK,opacity=1)
        self.play(ShowCreation(c))
        self.play(ShowCreation(s))
        self.play(ShowCreation(t))
        self.play(ShowCreation(r))
```

**Result**:

https://github.com/3b1b/manim/assets/15604323/cc51b03b-db30-41ea-8050-9e00922151fa

