### PR TITLE
Error effect when rendering the same ImageMobject

### DIFF
--- a/manimlib/mobject/types/image_mobject.py
+++ b/manimlib/mobject/types/image_mobject.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from PIL import Image
+from moderngl import TRIANGLES
 
 from manimlib.constants import DL, DR, UL, UR
 from manimlib.mobject.mobject import Mobject
@@ -24,6 +25,7 @@ class ImageMobject(Mobject):
         ('im_coords', np.float32, (2,)),
         ('opacity', np.float32, (1,)),
     ]
+    render_primitive: int = TRIANGLES
 
     def __init__(        
         self,
@@ -37,9 +39,9 @@ class ImageMobject(Mobject):
         super().__init__(texture_paths={"Texture": self.image_path}, **kwargs)
 
     def init_data(self) -> None:
-        super().init_data(length=4)
-        self.data["point"][:] = [UL, DL, UR, DR]
-        self.data["im_coords"][:] = [(0, 0), (0, 1), (1, 0), (1, 1)]
+        super().init_data(length=6)
+        self.data["point"][:] = [UL, DL, UR, DR, UR, DL]
+        self.data["im_coords"][:] = [(0, 0), (0, 1), (1, 0), (1, 1), (1, 0), (0, 1)]
         self.data["opacity"][:] = self.opacity
 
     def init_points(self) -> None:


### PR DESCRIPTION
## Motivation
Triggered when rendering the same texture consecutively.
Mobject default render mode is TRIANGLE_STRIP, which will outputs extra triangles;
Use TRIANGLES mode and add vertices to fix this.

## Proposed changes
- image_mobject.py

## Test
**Code**:
```python
class Test(Scene):
    def construct(self):
        image = ImageMobject("res/bili.png").scale(0.2)
        a = Group(*[image.copy() for _ in range(25)]).arrange_in_grid(5, 5)
        self.add(a)
```

**Result**:
![Test](https://github.com/3b1b/manim/assets/72070458/70e556cc-fefe-4dee-b67e-31eefa1fc66a)
![Test_f](https://github.com/3b1b/manim/assets/72070458/600adaf3-0f52-4489-a3ab-d4b52a6c005b)
