### PR TITLE
Modifying requirements.txt to include the latest version of IPython.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colour
-ipython
+ipython>=8.18.0
 isosurfaces
 fontTools
 manimpango>=0.4.0.post0,<0.5.0


### PR DESCRIPTION
## Motivation
I opened cmd and typed `manimgl`, as expected, a window was created. However, while typing any python code in the shell, the following error was raised:

![image](https://github.com/3b1b/manim/assets/116425738/10b3b295-41b8-455d-9da6-7960328e865b)

While digging into the issue, i found that the manim library is not compatible with some versions of IPython (i got the error with version 8.14.0 and 8.16.0).
a past [question ](https://stackoverflow.com/questions/76519814/manim-community-interactive-embed-causes-ipython-curruption-sqlite3-progra)at stackoverflow also confirmed the same. 
The solution was to simply upgrade IPython to the latest version `pip install ipython --upgrade` 

## Proposed changes
<!-- What you changed in those files -->
- Changed requirements.txt to include `ipython>=8.18.0`. This makes sure that the compatible version of ipython is installed with the manimgl library.

## Test
open cmd and type `pip install ipython==8.14.0`.
after the process is complete, install the modified version of manimgl
while the package is being installed, notice that in one of the steps, the latest version of ipython is also installed.