### PR TITLE
Using the new GitHub Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Manim is an engine for precise programmatic animations, designed for creating ex
 Note, there are two versions of manim.  This repository began as a personal project by the author of [3Blue1Brown](https://www.3blue1brown.com/) for the purpose of animating those videos, with video-specific code available [here](https://github.com/3b1b/videos).  In 2020 a group of developers forked it into what is now the [community edition](https://github.com/ManimCommunity/manim/), with a goal of being more stable, better tested, quicker to respond to community contributions, and all around friendlier to get started with. See [this page](https://docs.manim.community/en/stable/faq/installation.html#different-versions) for more details.
 
 ## Installation
-> **WARNING:** These instructions are for ManimGL _only_. Trying to use these instructions to install [ManimCommunity/manim](https://github.com/ManimCommunity/manim) or instructions there to install this version will cause problems. You should first decide which version you wish to install, then only follow the instructions for your desired version.
-> 
-> **Note**: To install manim directly through pip, please pay attention to the name of the installed package. This repository is ManimGL of 3b1b. The package name is `manimgl` instead of `manim` or `manimlib`. Please use `pip install manimgl` to install the version in this repository.
+> [!WARNING]
+> These instructions are for ManimGL _only_. Trying to use these instructions to install [ManimCommunity/manim](https://github.com/ManimCommunity/manim) or instructions there to install this version will cause problems. You should first decide which version you wish to install, then only follow the instructions for your desired version.
+
+> [!Note]
+> To install manim directly through pip, please pay attention to the name of the installed package. This repository is ManimGL of 3b1b. The package name is `manimgl` instead of `manim` or `manimlib`. Please use `pip install manimgl` to install the version in this repository.
 
 Manim runs on Python 3.7 or higher.
 


### PR DESCRIPTION
See: https://github.com/orgs/community/discussions/16925

## Proposed changes
I have changed the syntax in the [Readme.md](./Readme.md) to the new GitHub Readme syntax. 

## Test
Only the readme has been changed. Since no executable code was changed, no test was executed. You can also view the changes in the fork at https://github.com/eskopp/manim?tab=readme-ov-file#installation.