### PR TITLE
remove include_background_rectangle

### DIFF
--- a/example_scenes.py
+++ b/example_scenes.py
@@ -26,7 +26,7 @@ class OpeningManimExample(Scene):
         matrix = [[1, 1], [0, 1]]
         linear_transform_words = VGroup(
             Text("This is what the matrix"),
-            IntegerMatrix(matrix, include_background_rectangle=True),
+            IntegerMatrix(matrix),
             Text("looks like")
         )
         linear_transform_words.arrange(RIGHT)


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
When running `manimgl example_scenes.py OpeningManimExample` I noticed: there is no **include_background_rectangle** argument in **IntegerMatrix** class, so I removed it. Otherwise, it will raise an error.
## Proposed changes
<!-- What you changed in those files -->

`IntegerMatrix(matrix, include_background_rectangle=True) --> IntegerMatrix(matrix)`

## Test
<!-- How do you test your changes -->
Launched `manimgl example_scenes.py OpeningManimExample`. No errors.