### PR TITLE
Fixed pylint warning `unspecified-encoding`

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -228,7 +228,7 @@ def get_module_with_inserted_embed_line(
     construct method. If there is an argument passed in, it will insert the line after
     the last line in the sourcefile which includes that string.
     """
-    with open(file_name, 'r') as fp:
+    with open(file_name, 'r', encoding='utf-8') as fp:
         lines = fp.readlines()
 
     try:
@@ -279,7 +279,7 @@ def get_module_with_inserted_embed_line(
     new_lines.insert(prev_line_num + 1, inserted_line)
     new_file = file_name.replace(".py", "_insert_embed.py")
 
-    with open(new_file, 'w') as fp:
+    with open(new_file, 'w', encoding='utf-8') as fp:
         fp.writelines(new_lines)
 
     module = get_module(new_file)
@@ -307,11 +307,11 @@ def get_custom_config():
     global_defaults_file = os.path.join(get_manim_dir(), "manimlib", "default_config.yml")
 
     if os.path.exists(global_defaults_file):
-        with open(global_defaults_file, "r") as file:
+        with open(global_defaults_file, "r", encoding="utf-8") as file:
             custom_config = yaml.safe_load(file)
 
         if os.path.exists(__config_file__):
-            with open(__config_file__, "r") as file:
+            with open(__config_file__, "r", encoding="utf-8") as file:
                 local_defaults = yaml.safe_load(file)
             if local_defaults:
                 custom_config = merge_dicts_recursively(
@@ -319,7 +319,7 @@ def get_custom_config():
                     local_defaults,
                 )
     else:
-        with open(__config_file__, "r") as file:
+        with open(__config_file__, "r", encoding="utf-8") as file:
             custom_config = yaml.safe_load(file)
 
     # Check temporary storage(custom_config)

--- a/manimlib/scene/scene_file_writer.py
+++ b/manimlib/scene/scene_file_writer.py
@@ -376,7 +376,7 @@ class SceneFileWriter(object):
             self.partial_movie_directory,
             "partial_movie_file_list.txt"
         )
-        with open(file_list, 'w') as fp:
+        with open(file_list, 'w', encoding='utf-8') as fp:
             for pf_path in partial_movie_files:
                 if os.name == 'nt':
                     pf_path = pf_path.replace('\\', '/')
@@ -448,7 +448,7 @@ class SceneFileWriter(object):
     def open_file(self) -> None:
         if self.quiet:
             curr_stdout = sys.stdout
-            sys.stdout = open(os.devnull, "w")
+            sys.stdout = open(os.devnull, "w", encoding="utf-8")
 
         current_os = platform.system()
         file_paths = []
@@ -475,9 +475,8 @@ class SceneFileWriter(object):
 
                 commands.append(file_path)
 
-                FNULL = open(os.devnull, 'w')
-                sp.call(commands, stdout=FNULL, stderr=sp.STDOUT)
-                FNULL.close()
+                with open(os.devnull, 'w', encoding="utf-8") as FNULL:
+                    sp.call(commands, stdout=FNULL, stderr=sp.STDOUT)
 
         if self.quiet:
             sys.stdout.close()

--- a/manimlib/utils/shaders.py
+++ b/manimlib/utils/shaders.py
@@ -111,7 +111,7 @@ def get_shader_code_from_file(filename: str) -> str | None:
     except IOError:
         return None
 
-    with open(filepath, "r") as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         result = f.read()
 
     # To share functionality between shaders, some functions are read in


### PR DESCRIPTION
Dear contributors of  manim,

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.
Changes Made:

- Applied automated fixes for the pylint warning unspecified-encoding.
"It is better to specify an encoding when opening documents. Using the system default implicitly can create problems on other operating systems. See [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)"

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.