### PR TITLE
fix(animation): `time_span` doesn't work for mobjects with submobjects

### DIFF
--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -62,9 +62,6 @@ class Animation(object):
         if self.time_span is not None:
             start, end = self.time_span
             self.run_time = max(end, self.run_time)
-            self.rate_func = squish_rate_func(
-                self.rate_func, start / self.run_time, end / self.run_time,
-            )
         self.mobject.set_animating_status(True)
         self.starting_mobject = self.create_starting_mobject()
         if self.suspend_mobject_updating:
@@ -150,9 +147,15 @@ class Animation(object):
         """
         self.interpolate(alpha)
 
+    def time_spanned_alpha(self, alpha: float) -> float:
+        if self.time_span is not None:
+            start, end = self.time_span
+            return clip(alpha * self.run_time - start, 0, end - start) / (end - start)
+        return alpha
+
     def interpolate_mobject(self, alpha: float) -> None:
         for i, mobs in enumerate(self.families):
-            sub_alpha = self.get_sub_alpha(alpha, i, len(self.families))
+            sub_alpha = self.get_sub_alpha(self.time_spanned_alpha(alpha), i, len(self.families))
             self.interpolate_submobject(*mobs, sub_alpha)
 
     def interpolate_submobject(

--- a/manimlib/animation/rotation.py
+++ b/manimlib/animation/rotation.py
@@ -48,7 +48,7 @@ class Rotating(Animation):
             for key in sm1.pointlike_data_keys:
                 sm1.data[key][:] = sm2.data[key]
         self.mobject.rotate(
-            self.rate_func(alpha) * self.angle,
+            self.rate_func(self.time_spanned_alpha(alpha)) * self.angle,
             axis=self.axis,
             about_point=self.about_point,
             about_edge=self.about_edge,


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation / 修改原因
<!-- Outline your motivation: In what way do your changes improve the library? -->
`time_span` doesn't work for animations of mobjects with submobjects, such as `DashedLine`.
像 `DashedLine` 这样含有多个子物件的图形的动画无法正确处理 `time_span`。

## Proposed changes / 修改内容
<!-- What you changed in those files -->
- add method `time_spanned_alpha` in `Animation` to calculate the animation progress instead of changing `rate_func` when `begin` is called
  在 `Animation` 类中添加了计算动画进度的方法 `time_spanned_alpha`，专门用来计算存在 `time_span` 时的动画进度，而不在调用 `begin` 时改变 `rate_func`
- since `Rotating` also uses `rate_func` to decide the animation progress in `interpolate_mobject`, changes of `rotation.py` are made to correspond
  由于 `Rotating` 类的 `interpolate_mobject` 也是用 `rate_func` 计算动画进度，为了保持一致还修改了 `rotation.py`

## Test / 测试
<!-- How do you test your changes -->
**Code / 代码**:
```python
from manimlib import *


class TestScene(Scene):
    def construct(self) -> None:
        self.play(ShowCreation(Line((-1, 1, 0), (-1, -1, 0)), time_span=(0, 2)),
                  ShowCreation(DashedLine((1, 1, 0), (1, -1, 0)), time_span=(0.7, 2.7)))
        self.wait()
```
We hope the dashed line on the right side start to show later than the solid line on the left side.
右侧动画应比左侧晚开始。

**Result / 结果**:
After this change: (obviously the right one start later)
修改后：（右侧动画开始更晚）
![2](https://github.com/user-attachments/assets/746b64f2-b15d-4f30-86b1-b232d28b67ef)
Before this change: (two animations seem to start at the same time)
修改前：（两侧动画几乎同时开始）
![1](https://github.com/user-attachments/assets/30d7218e-ebca-4e74-b4eb-ee55aee345bb)