### PR TITLE
Energy savings

### DIFF
--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -124,6 +124,8 @@ class Camera(object):
 
     def clear(self) -> None:
         self.fbo.clear(*self.background_rgba)
+        if self.window:
+            self.window.clear()
 
     def blit(self, src_fbo, dst_fbo):
         """
@@ -227,8 +229,11 @@ class Camera(object):
         self.fbo.use()
         for mobject in mobjects:
             mobject.render(self.ctx, self.uniforms)
-        if self.window is not None and self.fbo is not self.window_fbo:
-            self.blit(self.fbo, self.window_fbo)
+
+        if self.window:
+            self.window.swap_buffers()
+            if self.fbo is not self.window_fbo:
+                self.blit(self.fbo, self.window_fbo)
 
     def refresh_uniforms(self) -> None:
         frame = self.frame

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -269,8 +269,7 @@ class Scene(object):
         # Operation to run after each ipython command
         def post_cell_func(*args, **kwargs):
             if not self.is_window_closing():
-                self.window._has_undrawn_event = True
-                self.update_frame(dt=0, ignore_skipping=True)
+                self.update_frame(dt=0, force_draw=True)
 
         shell.events.register("post_run_cell", post_cell_func)
 
@@ -314,19 +313,19 @@ class Scene(object):
         return image
 
     def show(self) -> None:
-        self.update_frame(ignore_skipping=True)
+        self.update_frame(force_draw=True)
         self.get_image().show()
 
-    def update_frame(self, dt: float = 0, ignore_skipping: bool = False) -> None:
+    def update_frame(self, dt: float = 0, force_draw: bool = False) -> None:
         self.increment_time(dt)
         self.update_mobjects(dt)
-        if self.skip_animations and not ignore_skipping:
+        if self.skip_animations and not force_draw:
             return
 
         if self.is_window_closing():
             raise EndScene()
 
-        if self.window and dt == 0 and not self.window.has_undrawn_event():
+        if self.window and dt == 0 and not self.window.has_undrawn_event() and not force_draw:
             # In this case, there's no need for new rendering, but we
             # shoudl still listen for new events
             self.window._window.dispatch_events()
@@ -609,7 +608,7 @@ class Scene(object):
 
         if self.skip_animations and self.window is not None:
             # Show some quick frames along the way
-            self.update_frame(dt=0, ignore_skipping=True)
+            self.update_frame(dt=0, force_draw=True)
 
         self.num_plays += 1
 

--- a/manimlib/utils/shaders.py
+++ b/manimlib/utils/shaders.py
@@ -182,7 +182,7 @@ def get_fill_canvas(ctx: moderngl.Context) -> Tuple[Framebuffer, VertexArray]:
                 if(color.a == 0) discard;
 
                 // Counteract scaling in fill frag
-                color.a *= 1.06;
+                color *= 1.06;
 
                 gl_FragDepth = texture(DepthTexture, uv)[0];
             }


### PR DESCRIPTION
Previously, during interactive development, rendering would happen continuously regardless of whether the scene was animating or being interacted with. This change has the scene only render in this mode when it needs to.