### PR TITLE
Update scene.py to make scene.time more accurate

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -552,7 +552,7 @@ class Scene(object):
         if self.skip_animations and not override_skip_animations:
             return [run_time]
 
-        times = np.arange(0, run_time, 1 / self.camera.fps)
+        times = np.arange(0, run_time, 1 / self.camera.fps) + 1 / self.camera.fps
 
         self.file_writer.set_progress_display_description(sub_desc=desc)
 


### PR DESCRIPTION
When the time intervals are (0, dt, 2dt, ...), during the first frame processing, only the video is inserted, but the update parameter is 0, which causes scene.time to be inaccurate. The correct time intervals should be (dt, 2dt, ...)

<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

## Proposed changes
<!-- What you changed in those files -->
- 
- 
- 

## Test
<!-- How do you test your changes -->
**Code**:

**Result**: