### PR TITLE
Add `focus()` command

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -234,6 +234,7 @@ class Scene(object):
             add=self.add,
             remove=self.remove,
             clear=self.clear,
+            focus=self.focus,
             save_state=self.save_state,
             undo=self.undo,
             redo=self.redo,
@@ -984,6 +985,11 @@ class Scene(object):
 
     def on_close(self) -> None:
         pass
+
+    def focus(self) -> None:
+        if not self.window:
+            return
+        self.window.focus()
 
 
 class SceneState():

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -987,6 +987,9 @@ class Scene(object):
         pass
 
     def focus(self) -> None:
+        """
+        Puts focus on the ManimGL window.
+        """
         if not self.window:
             return
         self.window.focus()

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -49,6 +49,18 @@ class Window(PygletWindow):
 
         self.to_default_position()
 
+    def focus(self):
+        """
+        Puts focus on this window by hiding and showing it again.
+
+        Note that the pyglet `activate()` method didn't work as expected here,
+        so that's why we have to use this workaround. This will produce a small
+        flicker on the window but at least reliably focuses it. It may also
+        offset the window position slightly.
+        """
+        self._window.set_visible(False)
+        self._window.set_visible(True)
+
     def to_default_position(self):
         self.position = self.default_position
         # Hack. Sometimes, namely when configured to open in a separate window,


### PR DESCRIPTION
## Motivation

When working in the interactive mode, the OpenGL window might be hidden behind other programs. Therefore, we introduce a new `focus()` command here to focus the window. This could also be very beneficial to our [`Manim Notebook`](https://github.com/Manim-Notebook/manim-notebook) VSCode extension (in construction) allowing to automatically focus when previewing a Manim Cell.

## Proposed changes
- Add a `focus()` method to the scene.
- Implement the focus mechanism in the window.

Unfortunately, the pyglet [`activate()`](https://pyglet.readthedocs.io/en/latest/modules/window.html#pyglet.window.Window.activate) method did not work for me (using WSL) while the proposed solution works, but produces a small flickering and also offsets the window by a small amount in the upper left direction. Maybe you know a better approach?

## Test

Just take any Manim code and get into the interactive mode.

```py
from manimlib import *


class ReloadTest(Scene):
    def construct(self):
        ## Circle creation
        circle = Circle()
        self.play(ShowCreation(circle))

        ## Circle movement
        self.play(circle.animate.shift(2 * UP + 2 * RIGHT))
```

```
manimgl ./reload_sample.py ReloadTest -se 6
```

Then issue the `reload()` command.