### PR TITLE
Rereload session modules during `reload()`

### DIFF
--- a/manimlib/reload_manager.py
+++ b/manimlib/reload_manager.py
@@ -2,6 +2,18 @@ from typing import Any
 from IPython.terminal.embed import KillEmbedded
 
 
+def restart_entirely():
+    """
+    Restarts the Python interpreter. The whole state will be lost as this is
+    equivalent to exiting the terminal, then issuing the ManimGL command again.
+    """
+    import os
+    import sys
+    print("Restarting...")
+    python = sys.executable
+    os.execv(python, [python] + sys.argv)
+
+
 class ReloadManager:
     """
     Manages the loading and running of scenes and is called directly from the
@@ -43,6 +55,8 @@ class ReloadManager:
                     scene.tear_down()
 
                 self.scenes = []
+
+                restart_entirely()
 
             except KeyboardInterrupt:
                 break

--- a/manimlib/reload_manager.py
+++ b/manimlib/reload_manager.py
@@ -35,6 +35,9 @@ class ReloadManager:
         modules that were loaded when ManimGL was started. I.e. we delete
         modules that the user imported in their own Python files such that
         any changes to these files are reflected in the next scene run.
+
+        One can think of this "deletion" as "unloading" the modules to force
+        a proper re-reload of them later on.
         """
         current_modules = set(sys.modules.keys())
         session_modules = current_modules - initial_modules

--- a/manimlib/reload_manager.py
+++ b/manimlib/reload_manager.py
@@ -29,7 +29,7 @@ class ReloadManager:
 
     def delete_newly_loaded_modules(self, initial_modules):
         """
-        Deletes the modules that were loaded during the last scene run.
+        Deletes the modules that were loaded during the last scene run(s).
 
         These are the modules that were not present in the initial set of
         modules that were loaded when ManimGL was started. I.e. we delete


### PR DESCRIPTION
## 🎈 Motivation

In #2240, I've added a `reload()` command that will reuse the OpenGL window to speed up reloading (instead of having to quit the active ManimGL Python interpreter session, then starting it again). Unfortunately, I've missed out on the following point [from this comment](https://github.com/3b1b/manim/pull/2240#issuecomment-2501620383).

> In fact, for **code changes outside the file of the scene**, from what I can tell the reload call does not incorporate those, whereas the command+A, command+R on that file would.

While in theory the `reload()` command will perform every single step that we also do when entering ManimGL for the very first time (except for parsing arg params), in practice we observe some module caching which this PR addresses.

See also the test example down below. Before this PR, any changes to file `b.py` won't be reflected, even when using the `reload()` command.


## 💻 Proposed changes

**All changes discussed here only affect Manim when the `reload()` command is called, everything else remains the same** (except for the additional `import sys` which really shouldn't be too much overhead).

This is a bit delicate since we have to distinguish between
- modules that we rely on in ManimGL itself before spawning an [`InteractiveShellEmbed`](https://ipython.readthedocs.io/en/stable/api/generated/IPython.terminal.embed.html#IPython.terminal.embed.InteractiveShellEmbed)
- modules that the user loads in their Python files that define the scene

Both of these modules are somehow managed globally by the Python interpreter. What I do in this PR is
- before running the first scene, store a set of modules that were loaded so far
- when the user triggers the `reload()` command, we "unload" all modules that were added to this set in the meantime

Therefore, those user-defined "session modules" will be reloaded again when the next scene starts by means of [this already existing Manim code line](https://github.com/Splines/manim-fork/blob/626dd1fe3343de0da366f9fd827fbc88f7b99024/manimlib/config.py#L213).


## 🧪 Test

```py
# file a.py
import sys

sys.path.append(".")
from manimlib import *

from b import B

class AScene(Scene):
    def construct(self):
        ## Starting
        print("Hello from AScene")

        ## B
        b = B()
        print(b.answer_to_life())
```

```py
# file b.py
class B:
    def answer_to_life(self):
        return 10
```

```bash
# Line 13 is where the comment "##B" is
manimgl "/path/to/a.py" AScene -se 13
```

- Preview by starting from the second comment (`##B`) and get `10` printed to the console.
- Change `10` to `42` in `b.py` and save the file
- Preview again, still see `10` in the console.
- Do a `reload(13)`
- Preview again, now see the `42` in the console 🎉
