### PR TITLE
Incorrect arg injection in get_riemann_rectangles

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -405,7 +405,7 @@ class CoordinateSystem(ABC):
             stroke_width=stroke_width,
             stroke_color=stroke_color,
             fill_opacity=fill_opacity,
-            stroke_background=stroke_background
+            stroke_behind=stroke_background
         )
         for rect in result:
             if not rect.positive:


### PR DESCRIPTION
## Motivation
As it stands, `get_riemann_rectangles` raises an error when called. It is using a keyword arg named `stroke_background` when internally calling `set_style`, but it does not exist.

## Proposed changes
In order to preserve the interface of `get_riemann_rectangles`, I've just renamed the keyword arg when it calls `set_style`, using the expected one `stroke_behind`.


## Test
<!-- How do you test your changes -->
**Code**:
```
axes = Axes()
graph = axes.get_graph(lambda x: x)
rectangles = axes.get_riemann_rectangles(graph)
```

**Result**:
It works fine. Prior to the change, it would raise an error

```bash
TypeError: VMobject.set_style() got an unexpected keyword argument 'stroke_background'
```