### PR TITLE
Cleaner local caching of Tex/Text data, and partially cleaned up configuration

### DIFF
--- a/manimlib/__init__.py
+++ b/manimlib/__init__.py
@@ -64,7 +64,6 @@ from manimlib.utils.bezier import *
 from manimlib.utils.cache import *
 from manimlib.utils.color import *
 from manimlib.utils.dict_ops import *
-from manimlib.utils.customization import *
 from manimlib.utils.debug import *
 from manimlib.utils.directories import *
 from manimlib.utils.file_ops import *

--- a/manimlib/__init__.py
+++ b/manimlib/__init__.py
@@ -61,6 +61,7 @@ from manimlib.scene.interactive_scene import *
 from manimlib.scene.scene import *
 
 from manimlib.utils.bezier import *
+from manimlib.utils.cache import *
 from manimlib.utils.color import *
 from manimlib.utils.dict_ops import *
 from manimlib.utils.customization import *

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -311,10 +311,6 @@ def load_yaml(file_path: str):
 def get_global_config():
     args = parse_cli()
     global_defaults_file = os.path.join(get_manim_dir(), "manimlib", "default_config.yml")
-
-    print(f"global_defaults_file = {global_defaults_file}")
-    print(f"args.config_file = {args.config_file}")
-
     return merge_dicts_recursively(
         load_yaml(global_defaults_file),
         load_yaml("custom_config.yml"),  # From current working directory

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -317,11 +317,18 @@ def load_yaml(file_path: str):
 def get_global_config():
     args = parse_cli()
     global_defaults_file = os.path.join(get_manim_dir(), "manimlib", "default_config.yml")
-    return merge_dicts_recursively(
+    config = merge_dicts_recursively(
         load_yaml(global_defaults_file),
         load_yaml("custom_config.yml"),  # From current working directory
         load_yaml(args.config_file) if args.config_file else {},
     )
+
+    # Set the subdirectories
+    base = config['directories']['base']
+    for key, subdir in config['directories']['subdirs'].items():
+        config['directories'][key] = os.path.join(base, subdir)
+
+    return config
 
 
 def get_file_ext(args: Namespace) -> str:

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -435,7 +435,8 @@ def get_window_config(args: Namespace, custom_config: dict, camera_config: dict)
     try:
         monitors = screeninfo.get_monitors()
     except screeninfo.ScreenInfoError:
-        pass
+        # Default fallback
+        monitors = [screeninfo.Monitor(width=1920, height=1080)]
     mon_index = custom_config["window_monitor"]
     monitor = monitors[min(mon_index, len(monitors) - 1)]
     aspect_ratio = camera_config["pixel_width"] / camera_config["pixel_height"]

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -461,20 +461,19 @@ def get_camera_config(args: Optional[Namespace] = None, custom_config: Optional[
     return camera_config
 
 
-def get_configuration(args: Namespace) -> dict:
+def get_scene_config(args: Namespace) -> dict:
+    """
+    Returns a dictionary to be used as key word arguments for Scene
+    """
     global_config = get_global_config()
     camera_config = get_camera_config(args, global_config)
     window_config = get_window_config(args, global_config, camera_config)
     start, end = get_animations_numbers(args)
 
     return {
-        "module": get_scene_module(args),
-        "scene_names": args.scene_names,
         "file_writer_config": get_file_writer_config(args, global_config),
         "camera_config": camera_config,
         "window_config": window_config,
-        "quiet": args.quiet or args.write_all,
-        "write_all": args.write_all,
         "skip_animations": args.skip_animations,
         "start_at_animation_number": start,
         "end_at_animation_number": end,
@@ -482,7 +481,16 @@ def get_configuration(args: Namespace) -> dict:
         "presenter_mode": args.presenter_mode,
         "leave_progress_bars": args.leave_progress_bars,
         "show_animation_progress": args.show_animation_progress,
-        "prerun": args.prerun,
         "embed_exception_mode": global_config["embed_exception_mode"],
         "embed_error_sound": global_config["embed_error_sound"],
+    }
+
+
+def get_run_config(args: Namespace):
+    return {
+        "module": get_scene_module(args),
+        "prerun": args.prerun,
+        "scene_names": args.scene_names,
+        "quiet": args.quiet or args.write_all,
+        "write_all": args.write_all,
     }

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -19,6 +19,12 @@ from manimlib.utils.init_config import init_customization
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     Module = importlib.util.types.ModuleType
+    from typing import Optional
+
+
+# This has to be here instead of in constants.py
+# due to its use in creating the camera configuration
+FRAME_HEIGHT: float = 8.0
 
 
 def parse_cli():
@@ -400,8 +406,13 @@ def get_window_config(args: Namespace, custom_config: dict, camera_config: dict)
     return dict(size=(window_width, window_height))
 
 
-def get_camera_config(args: Namespace, custom_config: dict) -> dict:
-    camera_config = {}
+def get_camera_config(args: Optional[Namespace] = None, custom_config: Optional[dict] = None) -> dict:
+    if args is None:
+        args = parse_cli()
+    if custom_config is None:
+        custom_config = get_global_config()
+
+    camera_config = dict()
     camera_resolutions = custom_config["camera_resolutions"]
     if args.resolution:
         resolution = args.resolution
@@ -429,7 +440,7 @@ def get_camera_config(args: Namespace, custom_config: dict) -> dict:
         "pixel_width": width,
         "pixel_height": height,
         "frame_config": {
-            "frame_shape": ((width / height) * get_frame_height(), get_frame_height()),
+            "frame_shape": ((width / height) * FRAME_HEIGHT, FRAME_HEIGHT),
         },
         "fps": fps,
     })
@@ -475,22 +486,3 @@ def get_configuration(args: Namespace) -> dict:
         "embed_exception_mode": global_config["embed_exception_mode"],
         "embed_error_sound": global_config["embed_error_sound"],
     }
-
-
-def get_frame_height():
-    return 8.0
-
-
-def get_aspect_ratio():
-    cam_config = get_camera_config(parse_cli(), get_global_config())
-    return cam_config['pixel_width'] / cam_config['pixel_height']
-
-
-def get_default_pixel_width():
-    cam_config = get_camera_config(parse_cli(), get_global_config())
-    return cam_config['pixel_width']
-
-
-def get_default_pixel_height():
-    cam_config = get_camera_config(parse_cli(), get_global_config())
-    return cam_config['pixel_height']

--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -10,6 +10,8 @@ import screeninfo
 import sys
 import yaml
 
+from functools import lru_cache
+
 from manimlib.logger import log
 from manimlib.utils.dict_ops import merge_dicts_recursively
 from manimlib.utils.init_config import init_customization
@@ -17,9 +19,6 @@ from manimlib.utils.init_config import init_customization
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     Module = importlib.util.types.ModuleType
-
-
-__config_file__ = "custom_config.yml"
 
 
 def parse_cli():
@@ -300,69 +299,27 @@ def get_scene_module(args: Namespace) -> Module:
         )
 
 
-def get_custom_config():
-    global __config_file__
+def load_yaml(file_path: str):
+    try:
+        with open(file_path, "r") as file:
+            return yaml.safe_load(file) or {}
+    except FileNotFoundError:
+        return {}
 
+
+@lru_cache
+def get_global_config():
+    args = parse_cli()
     global_defaults_file = os.path.join(get_manim_dir(), "manimlib", "default_config.yml")
 
-    if os.path.exists(global_defaults_file):
-        with open(global_defaults_file, "r") as file:
-            custom_config = yaml.safe_load(file)
+    print(f"global_defaults_file = {global_defaults_file}")
+    print(f"args.config_file = {args.config_file}")
 
-        if os.path.exists(__config_file__):
-            with open(__config_file__, "r") as file:
-                local_defaults = yaml.safe_load(file)
-            if local_defaults:
-                custom_config = merge_dicts_recursively(
-                    custom_config,
-                    local_defaults,
-                )
-    else:
-        with open(__config_file__, "r") as file:
-            custom_config = yaml.safe_load(file)
-
-    # Check temporary storage(custom_config)
-    if custom_config["directories"]["temporary_storage"] == "" and sys.platform == "win32":
-        log.warning(
-            "You may be using Windows platform and have not specified the path of" + \
-            " `temporary_storage`, which may cause OSError. So it is recommended" + \
-            " to specify the `temporary_storage` in the config file (.yml)"
-        )
-
-    return custom_config
-
-
-def init_global_config(config_file):
-    global __config_file__
-
-    # ensure __config_file__ always exists
-    if config_file is not None:
-        if not os.path.exists(config_file):
-            log.error(f"Can't find {config_file}.")
-            if sys.platform == 'win32':
-                log.info(f"Copying default configuration file to {config_file}...")
-                os.system(f"copy default_config.yml {config_file}")
-            elif sys.platform in ["linux2", "darwin"]:
-                log.info(f"Copying default configuration file to {config_file}...")
-                os.system(f"cp default_config.yml {config_file}")
-            else:
-                log.info("Please create the configuration file manually.")
-            log.info("Read configuration from default_config.yml.")
-        else:
-            __config_file__ = config_file
-
-    global_defaults_file = os.path.join(get_manim_dir(), "manimlib", "default_config.yml")
-
-    if not (os.path.exists(global_defaults_file) or os.path.exists(__config_file__)):
-        log.info("There is no configuration file detected. Switch to the config file initializer:")
-        init_customization()
-
-    elif not os.path.exists(__config_file__):
-        log.info(f"Using the default configuration file, which you can modify in `{global_defaults_file}`")
-        log.info(
-            "If you want to create a local configuration file, you can create a file named" + \
-            f" `{__config_file__}`, or run `manimgl --config`"
-        )
+    return merge_dicts_recursively(
+        load_yaml(global_defaults_file),
+        load_yaml("custom_config.yml"),  # From current working directory
+        load_yaml(args.config_file) if args.config_file else {},
+    )
 
 
 def get_file_ext(args: Namespace) -> str:
@@ -498,16 +455,15 @@ def get_camera_config(args: Namespace, custom_config: dict) -> dict:
 
 
 def get_configuration(args: Namespace) -> dict:
-    init_global_config(args.config_file)
-    custom_config = get_custom_config()
-    camera_config = get_camera_config(args, custom_config)
-    window_config = get_window_config(args, custom_config, camera_config)
+    global_config = get_global_config()
+    camera_config = get_camera_config(args, global_config)
+    window_config = get_window_config(args, global_config, camera_config)
     start, end = get_animations_numbers(args)
 
     return {
         "module": get_scene_module(args),
         "scene_names": args.scene_names,
-        "file_writer_config": get_file_writer_config(args, custom_config),
+        "file_writer_config": get_file_writer_config(args, global_config),
         "camera_config": camera_config,
         "window_config": window_config,
         "quiet": args.quiet or args.write_all,
@@ -520,8 +476,8 @@ def get_configuration(args: Namespace) -> dict:
         "leave_progress_bars": args.leave_progress_bars,
         "show_animation_progress": args.show_animation_progress,
         "prerun": args.prerun,
-        "embed_exception_mode": custom_config["embed_exception_mode"],
-        "embed_error_sound": custom_config["embed_error_sound"],
+        "embed_exception_mode": global_config["embed_exception_mode"],
+        "embed_error_sound": global_config["embed_error_sound"],
     }
 
 
@@ -530,15 +486,15 @@ def get_frame_height():
 
 
 def get_aspect_ratio():
-    cam_config = get_camera_config(parse_cli(), get_custom_config())
+    cam_config = get_camera_config(parse_cli(), get_global_config())
     return cam_config['pixel_width'] / cam_config['pixel_height']
 
 
 def get_default_pixel_width():
-    cam_config = get_camera_config(parse_cli(), get_custom_config())
+    cam_config = get_camera_config(parse_cli(), get_global_config())
     return cam_config['pixel_width']
 
 
 def get_default_pixel_height():
-    cam_config = get_camera_config(parse_cli(), get_custom_config())
+    cam_config = get_camera_config(parse_cli(), get_global_config())
     return cam_config['pixel_height']

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -11,13 +11,12 @@ if TYPE_CHECKING:
 
 
 # TODO, it feels a bit unprincipled to have some global constants
-# depend on the output of this function, all for all that configuration
-# code to be run merely upon importing from this file
+# depend on the output of this function, and for all that configuration
+# code to be run merely upon importing from this file.
 CAMERA_CONFIG = get_camera_config()
 
 # Sizes relevant to default camera frame
 ASPECT_RATIO: float = CAMERA_CONFIG['pixel_width'] / CAMERA_CONFIG['pixel_height']
-# FRAME_HEIGHT: float = 8.0
 FRAME_WIDTH: float = FRAME_HEIGHT * ASPECT_RATIO
 FRAME_SHAPE: tuple[float, float] = (FRAME_WIDTH, FRAME_HEIGHT)
 FRAME_Y_RADIUS: float = FRAME_HEIGHT / 2

--- a/manimlib/constants.py
+++ b/manimlib/constants.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 import numpy as np
 
-from manimlib.config import get_aspect_ratio
-from manimlib.config import get_default_pixel_width
-from manimlib.config import get_default_pixel_height
-from manimlib.config import get_frame_height
+from manimlib.config import get_camera_config
+from manimlib.config import FRAME_HEIGHT
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -12,16 +10,21 @@ if TYPE_CHECKING:
     from manimlib.typing import ManimColor, Vect3
 
 
+# TODO, it feels a bit unprincipled to have some global constants
+# depend on the output of this function, all for all that configuration
+# code to be run merely upon importing from this file
+CAMERA_CONFIG = get_camera_config()
+
 # Sizes relevant to default camera frame
-ASPECT_RATIO: float = get_aspect_ratio()
-FRAME_HEIGHT: float = get_frame_height()
+ASPECT_RATIO: float = CAMERA_CONFIG['pixel_width'] / CAMERA_CONFIG['pixel_height']
+# FRAME_HEIGHT: float = 8.0
 FRAME_WIDTH: float = FRAME_HEIGHT * ASPECT_RATIO
 FRAME_SHAPE: tuple[float, float] = (FRAME_WIDTH, FRAME_HEIGHT)
 FRAME_Y_RADIUS: float = FRAME_HEIGHT / 2
 FRAME_X_RADIUS: float = FRAME_WIDTH / 2
 
-DEFAULT_PIXEL_HEIGHT: int = get_default_pixel_height()
-DEFAULT_PIXEL_WIDTH: int = get_default_pixel_width()
+DEFAULT_PIXEL_HEIGHT: int = CAMERA_CONFIG['pixel_height']
+DEFAULT_PIXEL_WIDTH: int = CAMERA_CONFIG['pixel_width']
 DEFAULT_FPS: int = 30
 
 SMALL_BUFF: float = 0.1

--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -10,7 +10,7 @@ directories:
   vector_images: ""
   # If you want to use sounds, manim will look here to find it.
   sounds: ""
-  temporary_storage: ""
+  downloads: ""
   # For certain object types, especially Tex and Text, manim will save information
   # to file to prevent the need to re-compute, e.g. recompiling the latex. By default,
   # it stores this saved data to whatever directory appdirs.user_cache_dir("manim") returns,

--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -3,14 +3,23 @@ directories:
   # to match the directory structure of the path to the
   # sourcecode generating that video
   mirror_module_path: False
-  # Where should manim output video and image files?
-  output: ""
-  # If you want to use images, manim will look to these folders to find them
-  raster_images: ""
-  vector_images: ""
-  # If you want to use sounds, manim will look here to find it.
-  sounds: ""
-  downloads: ""
+  # Manim may write to and read from teh file system, e.g.
+  # to render videos and to look for svg/png assets. This
+  # will specify where those assets live, with a base directory,
+  # and various subdirectory names within it
+  base: ""
+  subdirs:
+    # Where should manim output video and image files?
+    output: "videos"
+    # If you want to use images, manim will look to these folders to find them
+    raster_images: "raster_images"
+    vector_images: "vector_images"
+    # If you want to use sounds, manim will look here to find it.
+    sounds: "sounds"
+    # Place for other forms of data relevant to any projects, like csv's
+    data: "data"
+    # When downloading, say an image, where will it go?
+    downloads: "downloads"
   # For certain object types, especially Tex and Text, manim will save information
   # to file to prevent the need to re-compute, e.g. recompiling the latex. By default,
   # it stores this saved data to whatever directory appdirs.user_cache_dir("manim") returns,

--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -10,12 +10,12 @@ directories:
   vector_images: ""
   # If you want to use sounds, manim will look here to find it.
   sounds: ""
-  # Manim often generates tex_files or other kinds of serialized data
-  # to keep from having to generate the same thing too many times.  By
-  # default, these will be stored at tempfile.gettempdir(), e.g. this might
-  # return whatever is at to the TMPDIR environment variable.  If you want to
-  # specify them elsewhere,
   temporary_storage: ""
+  # For certain object types, especially Tex and Text, manim will save information
+  # to file to prevent the need to re-compute, e.g. recompiling the latex. By default,
+  # it stores this saved data to whatever directory appdirs.user_cache_dir("manim") returns,
+  # but here a user can specify a different cache location
+  cache: ""
 universal_import_line: "from manimlib import *"
 style:
   tex_template: "default"

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -82,7 +82,7 @@ def get_scenes_to_render(all_scene_classes, scene_config, run_config):
     if run_config["write_all"]:
         return [sc(**scene_config) for sc in all_scene_classes]
 
-    names_to_classes = {sc.__name__ : sc for sc in all_scene_classes}
+    names_to_classes = {sc.__name__: sc for sc in all_scene_classes}
     scene_names = run_config["scene_names"]
 
     for name in set.difference(set(scene_names), names_to_classes):
@@ -116,11 +116,9 @@ def get_scene_classes_from_module(module):
 
 
 def main(scene_config, run_config):
-    module = run_config["module"]
-    if module is None:
+    if run_config["module"] is None:
         # If no module was passed in, just play the blank scene
         return [BlankScene(**scene_config)]
 
-    all_scene_classes = get_scene_classes_from_module(module)
-    scenes = get_scenes_to_render(all_scene_classes, scene_config, run_config)
-    return scenes
+    all_scene_classes = get_scene_classes_from_module(run_config["module"])
+    return get_scenes_to_render(all_scene_classes, scene_config, run_config)

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -2,7 +2,7 @@ import copy
 import inspect
 import sys
 
-from manimlib.config import get_custom_config
+from manimlib.config import get_global_config
 from manimlib.logger import log
 from manimlib.scene.interactive_scene import InteractiveScene
 from manimlib.scene.scene import Scene
@@ -10,7 +10,7 @@ from manimlib.scene.scene import Scene
 
 class BlankScene(InteractiveScene):
     def construct(self):
-        exec(get_custom_config()["universal_import_line"])
+        exec(get_global_config()["universal_import_line"])
         self.embed()
 
 

--- a/manimlib/mobject/shape_matchers.py
+++ b/manimlib/mobject/shape_matchers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from colour import Color
 
+from manimlib.config import get_global_config
 from manimlib.constants import BLACK, RED, YELLOW, WHITE
 from manimlib.constants import DL, DOWN, DR, LEFT, RIGHT, UL, UR
 from manimlib.constants import SMALL_BUFF
@@ -9,7 +10,6 @@ from manimlib.mobject.geometry import Line
 from manimlib.mobject.geometry import Rectangle
 from manimlib.mobject.types.vectorized_mobject import VGroup
 from manimlib.mobject.types.vectorized_mobject import VMobject
-from manimlib.utils.customization import get_customization
 
 from typing import TYPE_CHECKING
 
@@ -57,7 +57,7 @@ class BackgroundRectangle(SurroundingRectangle):
         **kwargs
     ):
         if color is None:
-            color = get_customization()['style']['background_color']
+            color = get_global_config()['style']['background_color']
         super().__init__(
             mobject,
             color=color,

--- a/manimlib/mobject/svg/old_tex_mobject.py
+++ b/manimlib/mobject/svg/old_tex_mobject.py
@@ -77,11 +77,7 @@ class SingleStringTex(SVGMobject):
         )
 
     def get_svg_string_by_content(self, content: str) -> str:
-        return get_cached_value(
-            key=hash_string(str((content, self.template, self.additional_preamble))),
-            value_func=lambda: latex_to_svg(content, self.template, self.additional_preamble),
-            message=f"Writing {self.tex_string}..."
-        )
+        return latex_to_svg(content, self.template, self.additional_preamble)
 
     def get_tex_file_body(self, tex_string: str) -> str:
         new_tex = self.get_modified_expression(tex_string)

--- a/manimlib/mobject/svg/old_tex_mobject.py
+++ b/manimlib/mobject/svg/old_tex_mobject.py
@@ -7,7 +7,7 @@ import re
 from manimlib.constants import BLACK, WHITE
 from manimlib.mobject.svg.svg_mobject import SVGMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
-from manimlib.utils.tex_file_writing import tex_content_to_svg_file
+from manimlib.utils.tex_file_writing import tex_to_svg
 
 from typing import TYPE_CHECKING
 
@@ -76,12 +76,12 @@ class SingleStringTex(SVGMobject):
             self.additional_preamble
         )
 
-    def get_file_path(self) -> str:
-        content = self.get_tex_file_body(self.tex_string)
-        file_path = tex_content_to_svg_file(
-            content, self.template, self.additional_preamble, self.tex_string
+    def get_svg_string_by_content(self, content: str) -> str:
+        return get_cached_value(
+            key=hash_string(str((content, self.template, self.additional_preamble))),
+            value_func=lambda: tex_to_svg(content, self.template, self.additional_preamble),
+            message=f"Writing {self.tex_string}..."
         )
-        return file_path
 
     def get_tex_file_body(self, tex_string: str) -> str:
         new_tex = self.get_modified_expression(tex_string)

--- a/manimlib/mobject/svg/old_tex_mobject.py
+++ b/manimlib/mobject/svg/old_tex_mobject.py
@@ -7,7 +7,7 @@ import re
 from manimlib.constants import BLACK, WHITE
 from manimlib.mobject.svg.svg_mobject import SVGMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
-from manimlib.utils.tex_file_writing import tex_to_svg
+from manimlib.utils.tex_file_writing import latex_to_svg
 
 from typing import TYPE_CHECKING
 
@@ -79,7 +79,7 @@ class SingleStringTex(SVGMobject):
     def get_svg_string_by_content(self, content: str) -> str:
         return get_cached_value(
             key=hash_string(str((content, self.template, self.additional_preamble))),
-            value_func=lambda: tex_to_svg(content, self.template, self.additional_preamble),
+            value_func=lambda: latex_to_svg(content, self.template, self.additional_preamble),
             message=f"Writing {self.tex_string}..."
         )
 

--- a/manimlib/mobject/svg/string_mobject.py
+++ b/manimlib/mobject/svg/string_mobject.py
@@ -66,17 +66,18 @@ class StringMobject(SVGMobject, ABC):
         self.use_labelled_svg = use_labelled_svg
 
         self.parse()
-        super().__init__(**kwargs)
+        svg_string = self.get_svg_string()
+        super().__init__(svg_string=svg_string, **kwargs)
         self.set_stroke(stroke_color, stroke_width)
         self.set_fill(fill_color, border_width=fill_border_width)
         self.labels = [submob.label for submob in self.submobjects]
 
-    def get_file_path(self, is_labelled: bool = False) -> str:
-        is_labelled = is_labelled or self.use_labelled_svg
-        return self.get_file_path_by_content(self.get_content(is_labelled))
+    def get_svg_string(self, is_labelled: bool = False) -> str:
+        content = self.get_content(is_labelled or self.use_labelled_svg)
+        return self.get_svg_string_by_content(content)
 
     @abstractmethod
-    def get_file_path_by_content(self, content: str) -> str:
+    def get_svg_string_by_content(self, content: str) -> str:
         return ""
 
     def assign_labels_by_color(self, mobjects: list[VMobject]) -> None:
@@ -109,8 +110,8 @@ class StringMobject(SVGMobject, ABC):
                 )
             )
 
-    def mobjects_from_file(self, file_path: str) -> list[VMobject]:
-        submobs = super().mobjects_from_file(file_path)
+    def mobjects_from_svg_string(self, svg_string: str) -> list[VMobject]:
+        submobs = super().mobjects_from_svg_string(svg_string)
 
         if self.use_labelled_svg:
             # This means submobjects are colored according to spans

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -20,7 +20,6 @@ from manimlib.mobject.types.vectorized_mobject import VMobject
 from manimlib.utils.directories import get_mobject_data_dir
 from manimlib.utils.images import get_full_vector_image_path
 from manimlib.utils.iterables import hash_obj
-from manimlib.utils.simple_functions import hash_string
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -6,6 +6,7 @@ from xml.etree import ElementTree as ET
 import numpy as np
 import svgelements as se
 import io
+from pathlib import Path
 
 from manimlib.constants import RIGHT
 from manimlib.logger import log
@@ -43,6 +44,7 @@ class SVGMobject(VMobject):
     def __init__(
         self,
         file_name: str = "",
+        svg_string: str = "",
         should_center: bool = True,
         height: float | None = None,
         width: float | None = None,
@@ -67,11 +69,19 @@ class SVGMobject(VMobject):
         path_string_config: dict = dict(),
         **kwargs
     ):
-        self.file_name = file_name or self.file_name
+        if svg_string != "":
+            self.svg_string = svg_string
+        elif file_name != "":
+            self.svg_string = self.file_name_to_svg_string(file_name)
+        elif self.file_name != "":
+            self.file_name_to_svg_string(self.file_name)
+        else:
+            raise Exception("Must specify either a file_name or svg_string SVGMobject")
+
         self.svg_default = dict(svg_default)
         self.path_string_config = dict(path_string_config)
 
-        super().__init__(**kwargs )
+        super().__init__(**kwargs)
         self.init_svg_mobject()
         self.ensure_positive_orientation()
 
@@ -101,7 +111,7 @@ class SVGMobject(VMobject):
         if hash_val in SVG_HASH_TO_MOB_MAP:
             submobs = [sm.copy() for sm in SVG_HASH_TO_MOB_MAP[hash_val]]
         else:
-            submobs = self.mobjects_from_file(self.get_file_path())
+            submobs = self.mobjects_from_svg_string(self.svg_string)
             SVG_HASH_TO_MOB_MAP[hash_val] = [sm.copy() for sm in submobs]
 
         self.add(*submobs)
@@ -115,11 +125,11 @@ class SVGMobject(VMobject):
             self.__class__.__name__,
             self.svg_default,
             self.path_string_config,
-            self.file_name
+            self.svg_string
         )
 
-    def mobjects_from_file(self, file_path: str) -> list[VMobject]:
-        element_tree = ET.parse(file_path)
+    def mobjects_from_svg_string(self, svg_string: str) -> list[VMobject]:
+        element_tree = ET.ElementTree(ET.fromstring(svg_string))
         new_tree = self.modify_xml_tree(element_tree)
 
         # New svg based on tree contents
@@ -131,10 +141,8 @@ class SVGMobject(VMobject):
 
         return self.mobjects_from_svg(svg)
 
-    def get_file_path(self) -> str:
-        if self.file_name is None:
-            raise Exception("Must specify file for SVGMobject")
-        return get_full_vector_image_path(self.file_name)
+    def file_name_to_svg_string(self, file_name: str) -> str:
+        return Path(get_full_vector_image_path(file_name)).read_text()
 
     def modify_xml_tree(self, element_tree: ET.ElementTree) -> ET.ElementTree:
         config_style_attrs = self.generate_config_style_dict()

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -17,7 +17,6 @@ from manimlib.mobject.geometry import Polyline
 from manimlib.mobject.geometry import Rectangle
 from manimlib.mobject.geometry import RoundedRectangle
 from manimlib.mobject.types.vectorized_mobject import VMobject
-from manimlib.utils.directories import get_mobject_data_dir
 from manimlib.utils.images import get_full_vector_image_path
 from manimlib.utils.iterables import hash_obj
 

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -9,7 +9,7 @@ from manimlib.mobject.types.vectorized_mobject import VMobject
 from manimlib.utils.cache import get_cached_value
 from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import hex_to_int
-from manimlib.utils.tex_file_writing import tex_to_svg
+from manimlib.utils.tex_file_writing import latex_to_svg
 from manimlib.utils.tex import num_tex_symbols
 from manimlib.utils.simple_functions import hash_string
 from manimlib.logger import log
@@ -88,7 +88,7 @@ class Tex(StringMobject):
     def get_svg_string_by_content(self, content: str) -> str:
         return get_cached_value(
             key=hash_string(str((content, self.template, self.additional_preamble))),
-            value_func=lambda: tex_to_svg(content, self.template, self.additional_preamble),
+            value_func=lambda: latex_to_svg(content, self.template, self.additional_preamble),
             message=f"Writing {self.tex_string}..."
         )
 

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 from manimlib.mobject.svg.string_mobject import StringMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
@@ -82,10 +83,12 @@ class Tex(StringMobject):
             self.additional_preamble
         )
 
-    def get_file_path_by_content(self, content: str) -> str:
-        return tex_content_to_svg_file(
+    def get_svg_string_by_content(self, content: str) -> str:
+        # TODO, implement this without writing to a file
+        file_path = tex_content_to_svg_file(
             content, self.template, self.additional_preamble, self.tex_string
         )
+        return Path(file_path).read_text() 
 
     def _handle_scale_side_effects(self, scale_factor: float) -> Self:
         self.font_size *= scale_factor

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from manimlib.mobject.svg.string_mobject import StringMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
 from manimlib.mobject.types.vectorized_mobject import VMobject
+from manimlib.utils.cache import get_cached_value
 from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import hex_to_int
-from manimlib.utils.tex_file_writing import tex_content_to_svg_file
+from manimlib.utils.tex_file_writing import tex_to_svg
 from manimlib.utils.tex import num_tex_symbols
+from manimlib.utils.simple_functions import hash_string
 from manimlib.logger import log
 
 from typing import TYPE_CHECKING
@@ -84,11 +86,11 @@ class Tex(StringMobject):
         )
 
     def get_svg_string_by_content(self, content: str) -> str:
-        # TODO, implement this without writing to a file
-        file_path = tex_content_to_svg_file(
-            content, self.template, self.additional_preamble, self.tex_string
+        return get_cached_value(
+            key=hash_string(str((content, self.template, self.additional_preamble))),
+            value_func=lambda: tex_to_svg(content, self.template, self.additional_preamble),
+            message=f"Writing {self.tex_string}..."
         )
-        return Path(file_path).read_text() 
 
     def _handle_scale_side_effects(self, scale_factor: float) -> Self:
         self.font_size *= scale_factor

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from manimlib.mobject.svg.string_mobject import StringMobject
 from manimlib.mobject.types.vectorized_mobject import VGroup
 from manimlib.mobject.types.vectorized_mobject import VMobject
-from manimlib.utils.cache import get_cached_value
 from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import hex_to_int
 from manimlib.utils.tex_file_writing import latex_to_svg
@@ -86,11 +85,7 @@ class Tex(StringMobject):
         )
 
     def get_svg_string_by_content(self, content: str) -> str:
-        return get_cached_value(
-            key=hash_string(str((content, self.template, self.additional_preamble))),
-            value_func=lambda: latex_to_svg(content, self.template, self.additional_preamble),
-            message=f"Writing {self.tex_string}..."
-        )
+        return latex_to_svg(content, self.template, self.additional_preamble, short_tex=self.tex_string)
 
     def _handle_scale_side_effects(self, scale_factor: float) -> Self:
         self.font_size *= scale_factor

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -67,23 +67,6 @@ class Tex(StringMobject):
         self.set_color_by_tex_to_color_map(self.tex_to_color_map)
         self.scale(SCALE_FACTOR_PER_FONT_POINT * font_size)
 
-    @property
-    def hash_seed(self) -> tuple:
-        return (
-            self.__class__.__name__,
-            self.svg_default,
-            self.path_string_config,
-            self.base_color,
-            self.isolate,
-            self.protect,
-            self.tex_string,
-            self.alignment,
-            self.tex_environment,
-            self.tex_to_color_map,
-            self.template,
-            self.additional_preamble
-        )
-
     def get_svg_string_by_content(self, content: str) -> str:
         return latex_to_svg(content, self.template, self.additional_preamble, short_tex=self.tex_string)
 

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -21,7 +21,6 @@ from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import int_to_hex
 from manimlib.utils.customization import get_customization
 from manimlib.utils.directories import get_downloads_dir
-from manimlib.utils.directories import get_text_dir
 from manimlib.utils.simple_functions import hash_string
 
 from typing import TYPE_CHECKING

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -16,9 +16,10 @@ from manimlib.constants import DEFAULT_PIXEL_WIDTH, FRAME_WIDTH
 from manimlib.constants import NORMAL
 from manimlib.logger import log
 from manimlib.mobject.svg.string_mobject import StringMobject
-from manimlib.utils.customization import get_customization
+from manimlib.utils.cache import get_cached_value
 from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import int_to_hex
+from manimlib.utils.customization import get_customization
 from manimlib.utils.directories import get_downloads_dir
 from manimlib.utils.directories import get_text_dir
 from manimlib.utils.simple_functions import hash_string
@@ -172,17 +173,14 @@ class MarkupText(StringMobject):
         )
 
     def get_svg_string_by_content(self, content: str) -> str:
-        # TODO, check the cache
-        hash_content = str((
+        key = hash_string(str((
             content,
             self.justify,
             self.indent,
             self.alignment,
             self.line_width
-        ))
-        # hash_string(hash_content)
-        key = hashlib.sha256(hash_content.encode()).hexdigest()
-        return self.markup_to_svg_string(content)
+        )))
+        return get_cached_value(key, lambda: self.markup_to_svg_string(content))
 
     def markup_to_svg_string(self, markup_str: str) -> str:
         self.validate_markup_string(markup_str)

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -197,34 +197,6 @@ class MarkupText(StringMobject):
         if height is None:
             self.scale(TEXT_MOB_SCALE_FACTOR)
 
-    @property
-    def hash_seed(self) -> tuple:
-        return (
-            self.__class__.__name__,
-            self.svg_default,
-            self.path_string_config,
-            self.base_color,
-            self.isolate,
-            self.protect,
-            self.text,
-            self.font_size,
-            self.lsh,
-            self.justify,
-            self.indent,
-            self.alignment,
-            self.line_width,
-            self.font,
-            self.slant,
-            self.weight,
-            self.t2c,
-            self.t2f,
-            self.t2s,
-            self.t2w,
-            self.global_config,
-            self.local_configs,
-            self.disable_ligatures
-        )
-
     def get_svg_string_by_content(self, content: str) -> str:
         self.content = content
         return markup_to_svg(

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -12,6 +12,7 @@ import pygments
 import pygments.formatters
 import pygments.lexers
 
+from manimlib.config import get_global_config
 from manimlib.constants import DEFAULT_PIXEL_WIDTH, FRAME_WIDTH
 from manimlib.constants import NORMAL
 from manimlib.logger import log
@@ -19,7 +20,6 @@ from manimlib.mobject.svg.string_mobject import StringMobject
 from manimlib.utils.cache import cache_on_disk
 from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import int_to_hex
-from manimlib.utils.customization import get_customization
 from manimlib.utils.directories import get_downloads_dir
 from manimlib.utils.simple_functions import hash_string
 
@@ -155,13 +155,14 @@ class MarkupText(StringMobject):
         isolate: Selector = re.compile(r"\w+", re.U),
         **kwargs
     ):
+        default_style = get_global_config()["style"]
         self.text = text
         self.font_size = font_size
         self.justify = justify
         self.indent = indent
-        self.alignment = alignment or get_customization()["style"]["text_alignment"]
+        self.alignment = alignment or default_style["text_alignment"]
         self.line_width = line_width
-        self.font = font or get_customization()["style"]["font"]
+        self.font = font or default_style["font"]
         self.slant = slant
         self.weight = weight
 

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -21,7 +21,6 @@ from manimlib.mobject.svg.string_mobject import StringMobject
 from manimlib.utils.cache import cache_on_disk
 from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import int_to_hex
-from manimlib.utils.directories import get_downloads_dir
 from manimlib.utils.simple_functions import hash_string
 
 from typing import TYPE_CHECKING
@@ -493,20 +492,10 @@ def register_font(font_file: str | Path):
         method with previous releases will raise an :class:`AttributeError` on macOS.
     """
 
-    input_folder = Path(get_downloads_dir()).parent.resolve()
-    possible_paths = [
-        Path(font_file),
-        input_folder / font_file,
-    ]
-    for path in possible_paths:
-        path = path.resolve()
-        if path.exists():
-            file_path = path
-            break
-    else:
-        error = f"Can't find {font_file}." f"Tried these : {possible_paths}"
+    file_path = Path(font_file).resolve()
+    if not file_path.exists():
+        error = f"Can't find {font_file}."
         raise FileNotFoundError(error)
-
     try:
         assert manimpango.register_font(str(file_path))
         yield

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import re
 import tempfile
 import hashlib
+from functools import lru_cache
 
 import manimpango
 import pygments
@@ -51,6 +52,7 @@ class _Alignment:
         self.value = _Alignment.VAL_DICT[s.upper()]
 
 
+@lru_cache(maxsize=128)
 @cache_on_disk
 def markup_to_svg(
     markup_str: str,

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -52,11 +52,11 @@ class _Alignment:
 
 
 @cache_on_disk
-def markup_to_svg_string(
+def markup_to_svg(
     markup_str: str,
     justify: bool = False,
     indent: float = 0,
-    alignment: str = "",
+    alignment: str = "CENTER",
     line_width: float | None = None,
 ) -> str:
     validate_error = manimpango.MarkupUtils.validate(markup_str)
@@ -225,7 +225,7 @@ class MarkupText(StringMobject):
 
     def get_svg_string_by_content(self, content: str) -> str:
         self.content = content
-        return markup_to_svg_string(
+        return markup_to_svg(
             content,
             justify=self.justify,
             indent=self.indent,

--- a/manimlib/reload_manager.py
+++ b/manimlib/reload_manager.py
@@ -59,12 +59,14 @@ class ReloadManager:
             self.args.embed = str(overwrite_start_at_line)
 
         # Args to Config
-        config = manimlib.config.get_configuration(self.args)
+        scene_config = manimlib.config.get_scene_config(self.args)
         if self.window:
-            config["existing_window"] = self.window  # see scene initialization
+            scene_config["existing_window"] = self.window  # see scene initialization
+
+        run_config = manimlib.config.get_run_config(self.args)
 
         # Scenes
-        self.scenes = manimlib.extract_scene.main(config)
+        self.scenes = manimlib.extract_scene.main(scene_config, run_config)
         if len(self.scenes) == 0:
             print("No scenes found to run")
             return

--- a/manimlib/reload_manager.py
+++ b/manimlib/reload_manager.py
@@ -37,8 +37,6 @@ class ReloadManager:
             except KillEmbedded:
                 # Requested via the `exit_raise` IPython runline magic
                 # by means of our scene.reload() command
-                print("Reloading...")
-
                 for scene in self.scenes:
                     scene.tear_down()
 

--- a/manimlib/reload_manager.py
+++ b/manimlib/reload_manager.py
@@ -78,7 +78,13 @@ class ReloadManager:
                 break
 
         for scene in self.scenes:
+            if self.args.embed:
+                print(" ".join([
+                    "Loading interactive session for",
+                    f"\033[96m{self.args.scene_names[0]}\033[0m",
+                    f"in \033[96m{self.args.file}\033[0m",
+                    f"at line \033[96m{self.args.embed}\033[0m"
+                ]))
             scene.run()
-
 
 reload_manager = ReloadManager()

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -232,7 +232,11 @@ class Scene(object):
         # the local namespace of the caller
         caller_frame = inspect.currentframe().f_back
         module = get_module(caller_frame.f_globals["__file__"])
-        shell = InteractiveShellEmbed(user_module=module)
+        shell = InteractiveShellEmbed(
+            user_module=module,
+            display_banner=False,
+            xmode=self.embed_exception_mode
+        )
         self.shell = shell
 
         # Add a few custom shortcuts to that local namespace
@@ -287,9 +291,6 @@ class Scene(object):
             self.play(VFadeInThenOut(rect, run_time=0.5))
 
         shell.set_custom_exc((Exception,), custom_exc)
-
-        # Set desired exception mode
-        shell.magic(f"xmode {self.embed_exception_mode}")
 
         # Launch shell
         shell()

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -10,7 +10,7 @@ import numpy as np
 from functools import lru_cache
 
 from manimlib.config import parse_cli
-from manimlib.config import get_configuration
+from manimlib.config import get_camera_config
 from manimlib.utils.iterables import resize_array
 from manimlib.utils.shaders import get_shader_code_from_file
 from manimlib.utils.shaders import get_shader_program
@@ -409,7 +409,7 @@ class VShaderWrapper(ShaderWrapper):
         which can display that texture as a simple quad onto a screen,
         along with the rgb value which is meant to be discarded.
         """
-        cam_config = get_configuration(parse_cli())['camera_config']
+        cam_config = get_camera_config()
         size = (cam_config['pixel_width'], cam_config['pixel_height'])
         double_size = (2 * size[0], 2 * size[1])
 

--- a/manimlib/utils/cache.py
+++ b/manimlib/utils/cache.py
@@ -21,10 +21,9 @@ _cache = Cache(get_cache_dir(), size_limit=CACHE_SIZE)
 def cache_on_disk(func: Callable[..., T]) -> Callable[..., T]:
     @wraps(func)
     def wrapper(*args, **kwargs):
-        key = hash_string("".join(map(str, [func.__name__, args, kwargs])))
+        key = hash_string(f"{func.__name__}{args}{kwargs}")
         value = _cache.get(key)
         if value is None:
-            # print(f"Executing {func.__name__}({args[0]}, ...)")
             value = func(*args, **kwargs)
             _cache.set(key, value)
         return value
@@ -33,17 +32,3 @@ def cache_on_disk(func: Callable[..., T]) -> Callable[..., T]:
 
 def clear_cache():
     _cache.clear()
-
-
-@contextmanager
-def display_during_execution(message: str):
-    # Merge into a single line
-    to_print = message.replace("\n", " ")
-    max_characters = os.get_terminal_size().columns - 1
-    if len(to_print) > max_characters:
-        to_print = to_print[:max_characters - 3] + "..."
-    try:
-        print(to_print, end="\r")
-        yield
-    finally:
-        print(" " * len(to_print), end="\r")

--- a/manimlib/utils/cache.py
+++ b/manimlib/utils/cache.py
@@ -1,22 +1,38 @@
+from __future__ import annotations
+
 import os
 from diskcache import Cache
 from contextlib import contextmanager
+from functools import wraps
 
 from manimlib.utils.directories import get_cache_dir
+from manimlib.utils.simple_functions import hash_string
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    T = TypeVar('T')
 
 
 CACHE_SIZE = 1e9  # 1 Gig
+_cache = Cache(get_cache_dir(), size_limit=CACHE_SIZE)
 
 
-def get_cached_value(key, value_func, message=""):
-    cache = Cache(get_cache_dir(), size_limit=CACHE_SIZE)
+def cache_on_disk(func: Callable[..., T]) -> Callable[..., T]:
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        key = hash_string("".join(map(str, [func.__name__, args, kwargs])))
+        value = _cache.get(key)
+        if value is None:
+            # print(f"Executing {func.__name__}({args[0]}, ...)")
+            value = func(*args, **kwargs)
+            _cache.set(key, value)
+        return value
+    return wrapper
 
-    value = cache.get(key)
-    if value is None:
-        with display_during_execution(message):
-            value = value_func()
-        cache.set(key, value)
-    return value
+
+def clear_cache():
+    _cache.clear()
 
 
 @contextmanager

--- a/manimlib/utils/cache.py
+++ b/manimlib/utils/cache.py
@@ -1,15 +1,15 @@
-import appdirs
 import os
 from diskcache import Cache
 from contextlib import contextmanager
+
+from manimlib.utils.directories import get_cache_dir
 
 
 CACHE_SIZE = 1e9  # 1 Gig
 
 
 def get_cached_value(key, value_func, message=""):
-    cache_dir = appdirs.user_cache_dir("manim")
-    cache = Cache(cache_dir, size_limit=CACHE_SIZE)
+    cache = Cache(get_cache_dir(), size_limit=CACHE_SIZE)
 
     value = cache.get(key)
     if value is None:

--- a/manimlib/utils/cache.py
+++ b/manimlib/utils/cache.py
@@ -1,0 +1,33 @@
+import appdirs
+import os
+from diskcache import Cache
+from contextlib import contextmanager
+
+
+CACHE_SIZE = 1e9  # 1 Gig
+
+
+def get_cached_value(key, value_func, message=""):
+    cache_dir = appdirs.user_cache_dir("manim")
+    cache = Cache(cache_dir, size_limit=CACHE_SIZE)
+
+    value = cache.get(key)
+    if value is None:
+        with display_during_execution(message):
+            value = value_func()
+        cache.set(key, value)
+    return value
+
+
+@contextmanager
+def display_during_execution(message: str):
+    # Merge into a single line
+    to_print = message.replace("\n", " ")
+    max_characters = os.get_terminal_size().columns - 1
+    if len(to_print) > max_characters:
+        to_print = to_print[:max_characters - 3] + "..."
+    try:
+        print(to_print, end="\r")
+        yield
+    finally:
+        print(" " * len(to_print), end="\r")

--- a/manimlib/utils/customization.py
+++ b/manimlib/utils/customization.py
@@ -11,9 +11,7 @@ CUSTOMIZATION = {}
 
 def get_customization():
     if not CUSTOMIZATION:
-        print(CUSTOMIZATION)
         CUSTOMIZATION.update(get_custom_config())
-        print(CUSTOMIZATION)
         directories = CUSTOMIZATION["directories"]
         # Unless user has specified otherwise, use the system default temp
         # directory for storing tex files, mobject_data, etc.

--- a/manimlib/utils/customization.py
+++ b/manimlib/utils/customization.py
@@ -1,5 +1,0 @@
-from manimlib.config import get_global_config
-
-
-def get_customization():
-    return get_global_config()

--- a/manimlib/utils/customization.py
+++ b/manimlib/utils/customization.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import appdirs
 
 from manimlib.config import get_custom_config
 from manimlib.config import get_manim_dir
@@ -16,6 +17,9 @@ def get_customization():
         # directory for storing tex files, mobject_data, etc.
         if not directories["temporary_storage"]:
             directories["temporary_storage"] = tempfile.gettempdir()
+
+        if not directories["cache"]:
+            directories["cache"] = appdirs.user_cache_dir("manim")
 
         # Assumes all shaders are written into manimlib/shaders
         directories["shaders"] = os.path.join(

--- a/manimlib/utils/customization.py
+++ b/manimlib/utils/customization.py
@@ -1,28 +1,5 @@
-import os
-import tempfile
-import appdirs
-
-from manimlib.config import get_custom_config
-from manimlib.config import get_manim_dir
-
-
-CUSTOMIZATION = {}
+from manimlib.config import get_global_config
 
 
 def get_customization():
-    if not CUSTOMIZATION:
-        CUSTOMIZATION.update(get_custom_config())
-        directories = CUSTOMIZATION["directories"]
-        # Unless user has specified otherwise, use the system default temp
-        # directory for storing tex files, mobject_data, etc.
-        if not directories["temporary_storage"]:
-            directories["temporary_storage"] = tempfile.gettempdir()
-
-        if not directories["cache"]:
-            directories["cache"] = appdirs.user_cache_dir("manim")
-
-        # Assumes all shaders are written into manimlib/shaders
-        directories["shaders"] = os.path.join(
-            get_manim_dir(), "manimlib", "shaders"
-        )
-    return CUSTOMIZATION
+    return get_global_config()

--- a/manimlib/utils/customization.py
+++ b/manimlib/utils/customization.py
@@ -11,7 +11,9 @@ CUSTOMIZATION = {}
 
 def get_customization():
     if not CUSTOMIZATION:
+        print(CUSTOMIZATION)
         CUSTOMIZATION.update(get_custom_config())
+        print(CUSTOMIZATION)
         directories = CUSTOMIZATION["directories"]
         # Unless user has specified otherwise, use the system default temp
         # directory for storing tex files, mobject_data, etc.

--- a/manimlib/utils/directories.py
+++ b/manimlib/utils/directories.py
@@ -14,14 +14,6 @@ def get_temp_dir() -> str:
     return get_directories()["temporary_storage"]
 
 
-def get_tex_dir() -> str:
-    return guarantee_existence(os.path.join(get_temp_dir(), "Tex"))
-
-
-def get_text_dir() -> str:
-    return guarantee_existence(os.path.join(get_temp_dir(), "Text"))
-
-
 def get_mobject_data_dir() -> str:
     return guarantee_existence(os.path.join(get_temp_dir(), "mobject_data"))
 

--- a/manimlib/utils/directories.py
+++ b/manimlib/utils/directories.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import os
+import tempfile
+import appdirs
 
+
+from manimlib.config import get_manim_dir
 from manimlib.utils.customization import get_customization
 from manimlib.utils.file_ops import guarantee_existence
 
@@ -11,11 +15,11 @@ def get_directories() -> dict[str, str]:
 
 
 def get_cache_dir() -> str:
-    return get_directories()["cache"]
+    return get_directories()["cache"] or appdirs.user_cache_dir("manim")
 
 
 def get_temp_dir() -> str:
-    return get_directories()["temporary_storage"]
+    return get_directories()["temporary_storage"] or tempfile.gettempdir()
 
 
 def get_mobject_data_dir() -> str:
@@ -43,4 +47,4 @@ def get_sound_dir() -> str:
 
 
 def get_shader_dir() -> str:
-    return get_directories()["shaders"]
+    return os.path.join(get_manim_dir(), "manimlib", "shaders")

--- a/manimlib/utils/directories.py
+++ b/manimlib/utils/directories.py
@@ -10,6 +10,10 @@ def get_directories() -> dict[str, str]:
     return get_customization()["directories"]
 
 
+def get_cache_dir() -> str:
+    return get_directories()["cache"]
+
+
 def get_temp_dir() -> str:
     return get_directories()["temporary_storage"]
 

--- a/manimlib/utils/directories.py
+++ b/manimlib/utils/directories.py
@@ -23,7 +23,7 @@ def get_temp_dir() -> str:
 
 
 def get_downloads_dir() -> str:
-    return guarantee_existence(os.path.join(get_temp_dir(), "manim_downloads"))
+    return get_directories()["downloads"] or appdirs.user_cache_dir("manim_downloads")
 
 
 def get_output_dir() -> str:

--- a/manimlib/utils/directories.py
+++ b/manimlib/utils/directories.py
@@ -22,10 +22,6 @@ def get_temp_dir() -> str:
     return get_directories()["temporary_storage"] or tempfile.gettempdir()
 
 
-def get_mobject_data_dir() -> str:
-    return guarantee_existence(os.path.join(get_temp_dir(), "mobject_data"))
-
-
 def get_downloads_dir() -> str:
     return guarantee_existence(os.path.join(get_temp_dir(), "manim_downloads"))
 

--- a/manimlib/utils/directories.py
+++ b/manimlib/utils/directories.py
@@ -5,13 +5,13 @@ import tempfile
 import appdirs
 
 
+from manimlib.config import get_global_config
 from manimlib.config import get_manim_dir
-from manimlib.utils.customization import get_customization
 from manimlib.utils.file_ops import guarantee_existence
 
 
 def get_directories() -> dict[str, str]:
-    return get_customization()["directories"]
+    return get_global_config()["directories"]
 
 
 def get_cache_dir() -> str:

--- a/manimlib/utils/file_ops.py
+++ b/manimlib/utils/file_ops.py
@@ -6,6 +6,10 @@ import hashlib
 
 import numpy as np
 import validators
+import urllib.request
+
+import manimlib.utils.directories
+from manimlib.utils.simple_functions import hash_string
 
 from typing import TYPE_CHECKING
 
@@ -35,11 +39,9 @@ def find_file(
     # Check if this is a file online first, and if so, download
     # it to a temporary directory
     if validators.url(file_name):
-        import urllib.request
-        from manimlib.utils.directories import get_downloads_dir
         suffix = Path(file_name).suffix
-        file_hash = hashlib.sha256(file_name.encode('utf-8')).hexdigest()[:32]
-        folder = get_downloads_dir()
+        file_hash = hash_string(file_name)
+        folder = manimlib.utils.directories.get_downloads_dir()
 
         path = Path(folder, file_hash).with_suffix(suffix)
         urllib.request.urlretrieve(file_name, path)

--- a/manimlib/utils/init_config.py
+++ b/manimlib/utils/init_config.py
@@ -36,11 +36,15 @@ def init_customization() -> None:
     configuration = {
         "directories": {
             "mirror_module_path": False,
-            "output": "",
-            "raster_images": "",
-            "vector_images": "",
-            "sounds": "",
-            "temporary_storage": "",
+            "base": "",
+            "subdirs": {
+                "output": "videos",
+                "raster_images": "raster_images",
+                "vector_images": "vector_images",
+                "sounds": "sounds",
+                "data": "data",
+                "downloads": "downloads",
+            }
         },
         "universal_import_line": "from manimlib import *",
         "style": {
@@ -74,33 +78,39 @@ def init_customization() -> None:
 
         console.print("[bold]Directories:[/bold]")
         dir_config = configuration["directories"]
-        dir_config["output"] = Prompt.ask(
-            "  Where should manim [bold]output[/bold] video and image files place [prompt.default](optional, default is none)",
+        dir_config["base"] = Prompt.ask(
+            "  What base directory should manim use for reading/writing video and images? [prompt.default](optional, default is none)",
             default="",
             show_default=False
         )
-        dir_config["raster_images"] = Prompt.ask(
-            "  Which folder should manim find [bold]raster images[/bold] (.jpg .png .gif) in " + \
-            "[prompt.default](optional, default is none)",
-            default="",
+        dir_config["subdirs"]["output"] = Prompt.ask(
+            "  Within that base directory, which subdirectory should manim [bold]output[/bold] video and image files to?" + \
+            " [prompt.default](optional, default is \"videos\")",
+            default="videos",
             show_default=False
         )
-        dir_config["vector_images"] = Prompt.ask(
-            "  Which folder should manim find [bold]vector images[/bold] (.svg .xdv) in " + \
-            "[prompt.default](optional, default is none)",
-            default="",
+        dir_config["subdirs"]["raster_images"] = Prompt.ask(
+            "  Within that base directory, which subdirectory should manim look for raster images (.png, .jpg)" + \
+            " [prompt.default](optional, default is \"raster_images\")",
+            default="raster_images",
             show_default=False
         )
-        dir_config["sounds"] = Prompt.ask(
-            "  Which folder should manim find [bold]sound files[/bold] (.mp3 .wav) in " + \
-            "[prompt.default](optional, default is none)",
-            default="",
+        dir_config["subdirs"]["vector_images"] = Prompt.ask(
+            "  Within that base directory, which subdirectory should manim look for raster images (.svg, .xdv)" + \
+            " [prompt.default](optional, default is \"vector_images\")",
+            default="vector_images",
             show_default=False
         )
-        dir_config["temporary_storage"] = Prompt.ask(
-            "  Which folder should manim storage [bold]temporary files[/bold] " + \
-            "[prompt.default](recommended, use system temporary folder by default)",
-            default="",
+        dir_config["subdirs"]["sounds"] = Prompt.ask(
+            "  Within that base directory, which subdirectory should manim look for sound files (.mp3, .wav)" + \
+            " [prompt.default](optional, default is \"sounds\")",
+            default="sounds",
+            show_default=False
+        )
+        dir_config["subdirs"]["downloads"] = Prompt.ask(
+            "  Within that base directory, which subdirectory should manim output downloaded files" + \
+            " [prompt.default](optional, default is \"downloads\")",
+            default="downloads",
             show_default=False
         )
 

--- a/manimlib/utils/simple_functions.py
+++ b/manimlib/utils/simple_functions.py
@@ -96,7 +96,6 @@ def binary_search(function: Callable[[float], float],
     return mh
 
 
-def hash_string(string: str) -> str:
-    # Truncating at 16 bytes for cleanliness
+def hash_string(string: str, n_bytes=16) -> str:
     hasher = hashlib.sha256(string.encode())
-    return hasher.hexdigest()[:16]
+    return hasher.hexdigest()[:n_bytes]

--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -4,6 +4,7 @@ import os
 import re
 import yaml
 import subprocess
+from functools import lru_cache
 
 from pathlib import Path
 import tempfile
@@ -63,6 +64,7 @@ def get_full_tex(content: str, preamble: str = ""):
     )) + "\n"
 
 
+@lru_cache(maxsize=128)
 @cache_on_disk
 def latex_to_svg(
     latex: str,

--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import tempfile
 
 from manimlib.utils.cache import cache_on_disk
-from manimlib.config import get_custom_config
+from manimlib.config import get_global_config
 from manimlib.config import get_manim_dir
 from manimlib.logger import log
 from manimlib.utils.simple_functions import hash_string
@@ -43,7 +43,7 @@ def get_tex_config() -> dict[str, str]:
     """
     # Only load once, then save thereafter
     if not SAVED_TEX_CONFIG:
-        template_name = get_custom_config()["style"]["tex_template"]
+        template_name = get_global_config()["style"]["tex_template"]
         template_config = get_tex_template_config(template_name)
         SAVED_TEX_CONFIG.update({
             "template": template_name,

--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import yaml
+import subprocess
 
 from pathlib import Path
 import tempfile
@@ -19,9 +20,8 @@ SAVED_TEX_CONFIG = {}
 
 def get_tex_template_config(template_name: str) -> dict[str, str]:
     name = template_name.replace(" ", "_").lower()
-    with open(os.path.join(
-        get_manim_dir(), "manimlib", "tex_templates.yml"
-    ), encoding="utf-8") as tex_templates_file:
+    template_path = os.path.join(get_manim_dir(), "manimlib", "tex_templates.yml")
+    with open(template_path, encoding="utf-8") as tex_templates_file:
         templates_dict = yaml.safe_load(tex_templates_file)
     if name not in templates_dict:
         log.warning(
@@ -53,23 +53,8 @@ def get_tex_config() -> dict[str, str]:
     return SAVED_TEX_CONFIG
 
 
-def tex_to_svg(
-    content: str,
-    template: str,
-    additional_preamble: str,
-) -> str:
-    tex_config = get_tex_config()
-    if not template or template == tex_config["template"]:
-        compiler = tex_config["compiler"]
-        preamble = tex_config["preamble"]
-    else:
-        config = get_tex_template_config(template)
-        compiler = config["compiler"]
-        preamble = config["preamble"]
-
-    if additional_preamble:
-        preamble += "\n" + additional_preamble
-    full_tex = "\n\n".join((
+def get_full_tex(content: str, preamble: str = ""):
+    return "\n\n".join((
         "\\documentclass[preview]{standalone}",
         preamble,
         "\\begin{document}",
@@ -77,14 +62,32 @@ def tex_to_svg(
         "\\end{document}"
     )) + "\n"
 
-    with tempfile.NamedTemporaryFile(suffix='.svg', mode='r+') as tmp:
-        create_tex_svg(full_tex, tmp.name, compiler)
-        # Read the contents
-        tmp.seek(0)
-        return tmp.read()
 
+def latex_to_svg(
+    latex: str,
+    template: str = "",
+    additional_preamble: str = ""
+) -> str:
+    """Convert LaTeX string to SVG string.
 
-def create_tex_svg(full_tex: str, svg_file: str, compiler: str) -> None:
+    Args:
+        latex: LaTeX source code
+        template: Path to a template LaTeX file
+        additional_preamble: String including any added "\\usepackage{...}" style imports
+
+    Returns:
+        str: SVG source code
+
+    Raises:
+        LatexError: If LaTeX compilation fails
+        NotImplementedError: If compiler is not supported
+    """
+    tex_config = get_tex_config()
+    if template and template != tex_config["template"]:
+        tex_config = get_tex_template_config(template)
+
+    compiler = tex_config["compiler"]
+
     if compiler == "latex":
         program = "latex"
         dvi_ext = ".dvi"
@@ -92,57 +95,60 @@ def create_tex_svg(full_tex: str, svg_file: str, compiler: str) -> None:
         program = "xelatex -no-pdf"
         dvi_ext = ".xdv"
     else:
-        raise NotImplementedError(
-            f"Compiler '{compiler}' is not implemented"
+        raise NotImplementedError(f"Compiler '{compiler}' is not implemented")
+
+    preamble = tex_config["preamble"] + "\n" + additional_preamble
+    full_tex = get_full_tex(latex, preamble)
+
+    # Write intermediate files to a temporary directory
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base_path = os.path.join(temp_dir, "working")
+        tex_path = base_path + ".tex"
+        dvi_path = base_path + dvi_ext
+
+        # Write tex file
+        with open(tex_path, "w", encoding="utf-8") as tex_file:
+            tex_file.write(full_tex)
+
+        # Run latex compiler
+        process = subprocess.run(
+            [
+                program.split()[0],  # Split for xelatex case
+                "-interaction=batchmode",
+                "-halt-on-error",
+                "-output-directory=" + temp_dir,
+                tex_path
+            ] + (["--no-pdf"] if compiler == "xelatex" else []),
+            capture_output=True,
+            text=True
         )
 
-    # Write tex file
-    root, _ = os.path.splitext(svg_file)
-    with open(root + ".tex", "w", encoding="utf-8") as tex_file:
-        tex_file.write(full_tex)
+        if process.returncode != 0:
+            # Handle error
+            error_str = ""
+            log_path = base_path + ".log"
+            if os.path.exists(log_path):
+                with open(log_path, "r", encoding="utf-8") as log_file:
+                    content = log_file.read()
+                    error_match = re.search(r"(?<=\n! ).*\n.*\n", content)
+                    if error_match:
+                        error_str = error_match.group()
+            raise LatexError(error_str or "LaTeX compilation failed")
 
-    # tex to dvi
-    if os.system(" ".join((
-        program,
-        "-interaction=batchmode",
-        "-halt-on-error",
-        f"-output-directory=\"{os.path.dirname(svg_file)}\"",
-        f"\"{root}.tex\"",
-        ">",
-        os.devnull
-    ))):
-        log.error(
-            "LaTeX Error!  Not a worry, it happens to the best of us."
+        # Run dvisvgm and capture output directly
+        process = subprocess.run(
+            [
+                "dvisvgm",
+                dvi_path,
+                "-n",  # no fonts
+                "-v", "0",  # quiet
+                "--stdout",  # output to stdout instead of file
+            ],
+            capture_output=True
         )
-        error_str = ""
-        with open(root + ".log", "r", encoding="utf-8") as log_file:
-            error_match_obj = re.search(r"(?<=\n! ).*\n.*\n", log_file.read())
-            if error_match_obj:
-                error_str = error_match_obj.group()
-                log.debug(
-                    f"The error could be:\n`{error_str}`",
-                )
-        raise LatexError(error_str)
 
-    # dvi to svg
-    os.system(" ".join((
-        "dvisvgm",
-        f"\"{root}{dvi_ext}\"",
-        "-n",
-        "-v",
-        "0",
-        "-o",
-        f"\"{svg_file}\"",
-        ">",
-        os.devnull
-    )))
-
-    # Cleanup superfluous documents
-    for ext in (".tex", dvi_ext, ".log", ".aux"):
-        try:
-            os.remove(root + ext)
-        except FileNotFoundError:
-            pass
+        # Return SVG string
+        return process.stdout.decode('utf-8')
 
 
 class LatexError(Exception):

--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -11,7 +11,6 @@ import tempfile
 from manimlib.config import get_custom_config
 from manimlib.config import get_manim_dir
 from manimlib.logger import log
-from manimlib.utils.directories import get_tex_dir
 from manimlib.utils.simple_functions import hash_string
 
 

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -8,8 +8,8 @@ from moderngl_window.timers.clock import Timer
 from screeninfo import get_monitors
 from functools import wraps
 
+from manimlib.config import get_global_config
 from manimlib.constants import FRAME_SHAPE
-from manimlib.utils.customization import get_customization
 
 from typing import TYPE_CHECKING
 
@@ -83,9 +83,10 @@ class Window(PygletWindow):
         self.size = (w, h)
 
     def find_initial_position(self, size: tuple[int, int]) -> tuple[int, int]:
-        custom_position = get_customization()["window_position"]
+        global_config = get_global_config()
+        custom_position = global_config["window_position"]
+        mon_index = global_config["window_monitor"]
         monitors = get_monitors()
-        mon_index = get_customization()["window_monitor"]
         monitor = monitors[min(mon_index, len(monitors) - 1)]
         window_width, window_height = size
         # Position might be specified with a string of the form

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+appdirs
 colour
+diskcache
 ipython>=8.18.0
 isosurfaces
 fontTools
@@ -21,6 +23,7 @@ screeninfo
 skia-pathops
 svgelements>=1.8.1
 sympy
+tempfile
 tqdm
 typing-extensions; python_version < "3.11"
 validators


### PR DESCRIPTION
Previously, in generating Tex and Text mobjects, manim would write to and read from various svg files on disk, to prevent the need to regenerate that data on each run, which is especially relevant in rendering LaTeX.

With this PR, we instead use the cache functionality from the disk_cache library to locally cache the relevant svg strings. This makes it easier to consolidate code, and to clear the cache or limit how much disk space it uses.

This also involved refactoring SVGMobject to optionally take in an svg_string, and to update Tex and Text accordingly.

---

Separately, this PR also includes a fair bit of cleaning up for within config.py.  It remains somewhat messy, in particular it's very ambiguous what "config" exactly refers to throughout, but this is an attempt to simply how the default_config and custom_config yaml files are loaded, and how they interface with the CLI arguments. 