### PR TITLE
Fixing a Cairo Bug on Windows OS

### DIFF
--- a/manimlib/mobject/boolean_ops.py
+++ b/manimlib/mobject/boolean_ops.py
@@ -7,7 +7,7 @@ from manimlib.mobject.types.vectorized_mobject import VMobject
 
 
 # Boolean operations between 2D mobjects
-# Borrowed from from https://github.com/ManimCommunity/manim/
+# Borrowed from https://github.com/ManimCommunity/manim/
 
 def _convert_vmobject_to_skia_path(vmobject: VMobject) -> pathops.Path:
     path = pathops.Path()

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -10,7 +10,6 @@ from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import hex_to_int
 from manimlib.utils.tex_file_writing import latex_to_svg
 from manimlib.utils.tex import num_tex_symbols
-from manimlib.utils.simple_functions import hash_string
 from manimlib.logger import log
 
 from typing import TYPE_CHECKING

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 import re
 import tempfile
-import hashlib
 from functools import lru_cache
 
 import manimpango
@@ -21,7 +20,6 @@ from manimlib.mobject.svg.string_mobject import StringMobject
 from manimlib.utils.cache import cache_on_disk
 from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import int_to_hex
-from manimlib.utils.simple_functions import hash_string
 
 from typing import TYPE_CHECKING
 
@@ -77,7 +75,10 @@ def markup_to_svg(
 
     # Write the result to a temporary svg file, and return it's contents.
     # TODO, better would be to have this not write to file at all
-    with tempfile.NamedTemporaryFile(suffix='.svg', mode='r+') as tmp:
+    #
+    # To avoid CAIRO_STATUS_WRITE_ERROR: b'error while writing to
+    # output stream' on Windows, we need to pass 'delete=False'.
+    with tempfile.NamedTemporaryFile(suffix='.svg', mode='r+', delete=False) as tmp:
         manimpango.MarkupUtils.text2svg(
             text=markup_str,
             font="",                     # Already handled

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from functools import wraps
 
-import moderngl
 import numpy as np
-import operator as op
-import itertools as it
 
 from manimlib.constants import GREY_A, GREY_C, GREY_E
 from manimlib.constants import BLACK
@@ -35,10 +32,7 @@ from manimlib.utils.iterables import make_even
 from manimlib.utils.iterables import resize_array
 from manimlib.utils.iterables import resize_with_interpolation
 from manimlib.utils.iterables import resize_preserving_order
-from manimlib.utils.iterables import arrays_match
-from manimlib.utils.simple_functions import fdiv
 from manimlib.utils.space_ops import angle_between_vectors
-from manimlib.utils.space_ops import cross
 from manimlib.utils.space_ops import cross2d
 from manimlib.utils.space_ops import earclip_triangulation
 from manimlib.utils.space_ops import get_norm
@@ -49,7 +43,6 @@ from manimlib.utils.space_ops import rotation_between_vectors
 from manimlib.utils.space_ops import rotation_matrix_transpose
 from manimlib.utils.space_ops import poly_line_length
 from manimlib.utils.space_ops import z_to_vector
-from manimlib.shader_wrapper import ShaderWrapper
 from manimlib.shader_wrapper import VShaderWrapper
 
 from typing import TYPE_CHECKING
@@ -57,8 +50,8 @@ from typing import Generic, TypeVar, Iterable
 SubVmobjectType = TypeVar('SubVmobjectType', bound='VMobject')
 
 if TYPE_CHECKING:
-    from typing import Callable, Tuple, Any
-    from manimlib.typing import ManimColor, Vect3, Vect4, Vect3Array, Vect4Array, Self
+    from typing import Callable, Tuple, Any, Optional
+    from manimlib.typing import ManimColor, Vect3, Vect4, Vect3Array, Self
     from moderngl.context import Context
 
 DEFAULT_STROKE_COLOR = GREY_A


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

### Cairo Error
<!-- What you changed in those files -->
While creating the temporary svg file in `text_mobject.py`, Cairo throws an error `b'error while writing to output stream'` on Windows OS.

### Proposed Changes
To avoid that, `delete=False` should be passed in `NamedTemporaryFile` function of the `tempfile` package.

Also, minor cleaning up the imports.