### PR TITLE
Fix checkpoint paste after reload

### DIFF
--- a/manimlib/scene/scene_embed.py
+++ b/manimlib/scene/scene_embed.py
@@ -157,7 +157,8 @@ class InteractiveSceneEmbed:
 
 
 class CheckpointManager:
-    checkpoint_states: dict[str, list[tuple[Mobject, Mobject]]] = dict()
+    def __init__(self):
+        self.checkpoint_states: dict[str, list[tuple[Mobject, Mobject]]] = dict()
 
     def checkpoint_paste(self, shell, scene):
         """


### PR DESCRIPTION
Addressing https://github.com/3b1b/manim/issues/2272

Previously, CheckpointManager.checkpoint_states was shared across multiple instances, which caused issues after reloading. It should be unique to each instance.