### PR TITLE
Move resizing out of Window.focus, and into Window.init_for_scene

### DIFF
--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -69,7 +69,8 @@ class Window(PygletWindow):
         mglw.activate_context(window=self, ctx=self.ctx)
         self.timer.start()
 
-        self.focus()
+        # This line seems to resync the viewport
+        self.on_resize(*self.size)
 
     def get_monitor(self, index):
         try:
@@ -106,8 +107,6 @@ class Window(PygletWindow):
         """
         self._window.set_visible(False)
         self._window.set_visible(True)
-        # This line seems to resync the viewport
-        self.on_resize(*self.size)
 
     def to_default_position(self):
         self.position = self.default_position


### PR DESCRIPTION
Somewhat confusingly, the window viewport can get offset on initialization, and on reload, in a way that simply resizing the window (even to its current size) fixes.

Previously I had added this to Window.focus, while also calling focus in Window.init_for_scene.  Better is to not necessarily focus on init, and to put the sync line in there directly.  This should partially address the annoyance in https://github.com/3b1b/manim/issues/2271