### PR TITLE
Have autoreload update shell namespace with reloaded module variables

### DIFF
--- a/docs/source/getting_started/configuration.rst
+++ b/docs/source/getting_started/configuration.rst
@@ -63,7 +63,7 @@ flag                                                       abbr   function
 ``--video_dir VIDEO_DIR``                                         Directory to write video
 ``--config_file CONFIG_FILE``                                     Path to the custom configuration file
 ``--log-level LOG_LEVEL``                                         Level of messages to Display, can be DEBUG / INFO / WARNING / ERROR / CRITICAL
-``--autoreload``                                                  Automatically reload Python modules to pick up code changes across different files
+``--autoreload``                                                  Automatically reload Python modules to pick up code changes across during an interactive embedding
 ========================================================== ====== =====================================================================================================================================================================================================
 
 custom_config

--- a/manimlib/scene/scene_embed.py
+++ b/manimlib/scene/scene_embed.py
@@ -143,8 +143,11 @@ class InteractiveSceneEmbed:
 
     def auto_reload(self):
         """Enables IPython autoreload for automatic reloading of modules."""
-        self.shell.magic("load_ext autoreload")
-        self.shell.magic("autoreload all")
+        def pre_cell_func(*args, **kwargs):
+            new_mod = ModuleLoader.get_module(self.shell.user_module.__file__, is_during_reload=True)
+            self.shell.user_ns.update(vars(new_mod))
+
+        self.shell.events.register("pre_run_cell", pre_cell_func)
 
     def checkpoint_paste(
         self,

--- a/manimlib/scene/scene_embed.py
+++ b/manimlib/scene/scene_embed.py
@@ -142,7 +142,7 @@ class InteractiveSceneEmbed:
         self.shell.run_line_magic("exit_raise", "")
 
     def auto_reload(self):
-        """Enables IPython autoreload for automatic reloading of modules."""
+        """Enables reload the shell's module before all calls"""
         def pre_cell_func(*args, **kwargs):
             new_mod = ModuleLoader.get_module(self.shell.user_module.__file__, is_during_reload=True)
             self.shell.user_ns.update(vars(new_mod))


### PR DESCRIPTION
In response to https://github.com/3b1b/manim/issues/2275

When --autoreload is set, during the interactive mode, before each cell execution the user's module will be reloaded.

@Splines, is this what you had in mind? At the moment I removed the calls to shell.magic("autoreload all") because it feels like this accomplishes the same, but it's very possible I'm missing something.