### PR TITLE
Automatically identify the class name based on the specified line number.

### DIFF
--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -5,13 +5,13 @@
 # you are running manim. For 3blue1brown, for instance, mind is
 # here: https://github.com/3b1b/videos/blob/master/custom_config.yml
 
-# Alternatively, you can create it whereever you like, and on running
+# Alternatively, you can create it where ever you like, and on running
 # manim, pass in `--config_file /path/to/custom/config/file.yml`
 
 directories:
   # Set this to true if you want the path to video files
   # to match the directory structure of the path to the
-  # sourcecode generating that video
+  # source code generating that video
   mirror_module_path: False
   # Manim may write to and read from the file system, e.g.
   # to render videos and to look for svg/png assets. This
@@ -44,7 +44,7 @@ window:
   # If not full screen, the default to give it half the screen width
   full_screen: False
   # Other optional specifications that override the above include:
-  # position: (500, 500)  # Specific position, in pixel coordiantes, for upper right corner
+  # position: (500, 500)  # Specific position, in pixel coordinates, for upper right corner
   # size: (1920, 1080)  # Specific size, in pixels
 camera:
   resolution: (1920, 1080)

--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -5,7 +5,7 @@
 # you are running manim. For 3blue1brown, for instance, mind is
 # here: https://github.com/3b1b/videos/blob/master/custom_config.yml
 
-# Alternatively, you can create it where ever you like, and on running
+# Alternatively, you can create it wherever you like, and on running
 # manim, pass in `--config_file /path/to/custom/config/file.yml`
 
 directories:

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -158,17 +158,19 @@ def insert_embed_line_to_module(module: Module, run_config: Dict) -> None:
     lines.insert(line_number, indent + "self.embed()")
     new_code = "\n".join(lines)
 
-    # When the user executes the `-e <line_number>` command,
-    # it should automatically identify the nearest class
-    # defined above `<line_number>` as 'scene_names'.
-    classes = list(filter(lambda line: line.startswith("class"), lines[:line_number]))
-    if classes:
-        from re import search
+    # When the user executes the `-e <line_number>` command
+    # without specifying scene_names, the nearest class name above
+    # `<line_number>` will be automatically used as 'scene_names'.
 
-        name_search = search(r"(\w+)\(", classes[-1])
-        run_config.update(scene_names=[name_search.group(1)])
-    else:
-        log.error(f"No 'class' has been found above {line_number}!")
+    if not run_config.scene_names:
+        classes = list(filter(lambda line: line.startswith("class"), lines[:line_number]))
+        if classes:
+            from re import search
+
+            scene_name = search(r"(\w+)\(", classes[-1])
+            run_config.update(scene_names=[scene_name.group(1)])
+        else:
+            log.error(f"No 'class' found above {line_number}!")
 
     # Execute the code, which presumably redefines the user's
     # scene to include this embed line, within the relevant module.

--- a/manimlib/extract_scene.py
+++ b/manimlib/extract_scene.py
@@ -159,7 +159,7 @@ def insert_embed_line_to_module(module: Module, run_config: Dict) -> None:
     new_code = "\n".join(lines)
 
     # When the user executes the `-e <line_number>` command,
-    # it should automatically identifies the nearest class
+    # it should automatically identify the nearest class
     # defined above `<line_number>` as 'scene_names'.
     classes = list(filter(lambda line: line.startswith("class"), lines[:line_number]))
     if classes:

--- a/manimlib/mobject/probability.py
+++ b/manimlib/mobject/probability.py
@@ -43,6 +43,7 @@ class SampleSpace(Rectangle):
             fill_opacity=fill_opacity,
             stroke_width=stroke_width,
             stroke_color=stroke_color,
+            **kwargs
         )
         self.default_label_scale_val = default_label_scale_val
 

--- a/manimlib/mobject/svg/string_mobject.py
+++ b/manimlib/mobject/svg/string_mobject.py
@@ -122,8 +122,8 @@ class StringMobject(SVGMobject, ABC):
         # of submobject which are and use those for labels
         unlabelled_submobs = submobs
         labelled_content = self.get_content(is_labelled=True)
-        labelled_file = self.get_file_path_by_content(labelled_content)
-        labelled_submobs = super().mobjects_from_file(labelled_file)
+        labelled_file = self.get_svg_string_by_content(labelled_content)
+        labelled_submobs = super().mobjects_from_svg_string(labelled_file)
         self.labelled_submobs = labelled_submobs
         self.unlabelled_submobs = unlabelled_submobs
 

--- a/manimlib/mobject/svg/text_mobject.py
+++ b/manimlib/mobject/svg/text_mobject.py
@@ -176,9 +176,6 @@ class MarkupText(StringMobject):
         self.disable_ligatures = disable_ligatures
         self.isolate = isolate
 
-        if not isinstance(self, Text):
-            self.validate_markup_string(text)
-
         super().__init__(text, height=height, **kwargs)
 
         if self.t2g:


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

### Motivation
Whenever some user passes the command `-e <line_number>`, it feels redundant to specify the class name.

The closest class name (above the specified `<line_number>`) should automatically be identified by the program, and updates the value of `scene_names` key in the `run_config` dict.

### Proposed Changes
I couldn't find a better position to insert the code than in the `insert_embed_line_to_module` function. As it ensures that the `scene_names` updates only when the `e` flag is passed, and also the module lines can be used to determine the class name.

Also, resolving minor bugs in `text_mobject` and `string_mobject` files.