### PR TITLE
Fix --fps type conversion to int

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -174,6 +174,7 @@ def parse_cli():
         parser.add_argument(
             "--fps",
             help="Frame rate, as an integer",
+            type=int,
         )
         parser.add_argument(
             "-c", "--color",


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
I'm using a variety of frame rates, and it's inconvenient to change the value in `default_config` each time.

## Proposed changes
<!-- What you changed in those files -->
Fixed type conversion for the `--fps` argument as an integer to improve convenience.

## Test
<!-- How do you test your changes -->
**Code**:
Ran the command `manimgl example.py SceneName --fps 240`

**Result**:
The fps value is now passed as an integer without any errors, making it easier to adjust frame rates dynamically.