### PR TITLE
Add missing dependencies to setup.cfg and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 addict
 appdirs
+audioop-lts
 colour
 diskcache
 ipython>=8.18.0
@@ -20,6 +21,7 @@ pyyaml
 rich
 scipy
 screeninfo
+setuptools
 skia-pathops
 svgelements>=1.8.1
 sympy

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ include_package_data = True
 install_requires =
     addict
     appdirs
+    audioop-lts
     colour
     diskcache
     ipython>=8.18.0
@@ -51,6 +52,7 @@ install_requires =
     rich
     scipy
     screeninfo
+    setuptools
     skia-pathops
     svgelements>=1.8.1
     sympy


### PR DESCRIPTION
## Motivation

There are dependencies not specified in `setup.cfg` and `requirements.txt`.

## Proposed changes
Add them.

## Test
`python -m pip install -e . && run`