### PR TITLE
Fix issues in number_line.py that changes in decimal_number_config["font_size"] get rewritten by number_config

### DIFF
--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -164,7 +164,7 @@ class NumberLine(Line):
         **number_config
     ) -> DecimalNumber:
         number_config = merge_dicts_recursively(
-            self.decimal_number_config, number_config,
+            number_config, self.decimal_number_config,
         )
         if direction is None:
             direction = self.line_to_number_direction


### PR DESCRIPTION
Fix the issue that changes in `decimal_number_config["font_size"]` get rewritten by `number_config`

## Motivation
When working with `NumberLine` in manim v1.7.2, I found that the decimal number label's size doesn't change with different `font_size` setting.

## Proposed changes
Swaping the position of `self.decimal_number_config` and `number_config` in `merge_dicts_recursively`.
(Which gives `self.decimal_number_config` a higher priority, fixing the issue.)

## Test
**Code**:
```python
class BugDemo(Scene):
    def construct(self):
        NumberLines = VGroup(
            NumberLine(decimal_number_config=dict(num_decimal_places=0, font_size=48), include_numbers=True),
            NumberLine(decimal_number_config=dict(num_decimal_places=0, font_size=36), include_numbers=True),
            NumberLine(decimal_number_config=dict(num_decimal_places=0, font_size=24), include_numbers=True),
            NumberLine(decimal_number_config=dict(num_decimal_places=0, font_size=12), include_numbers=True)
        ).arrange(DOWN)

        self.add(NumberLines)
```
**Result**:

Before the change:
![BugDemo](https://github.com/user-attachments/assets/4e51f24c-401f-46f4-9b30-a30ca6827bc0)

After the change:
![BugDemo](https://github.com/user-attachments/assets/24db5627-77fa-410f-8aeb-ce56cc8a0360)
