### PR TITLE
Performance improved in `set_color_by_rgba_func`

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -770,13 +770,6 @@ class ComplexPlane(NumberPlane):
                 axis = self.get_x_axis()
                 value = z.real
             number_mob = axis.get_number_mobject(value, font_size=font_size, **kwargs)
-            # For -i, remove the "1"
-            if z.imag == -1:
-                number_mob.remove(number_mob[1])
-                number_mob[0].next_to(
-                    number_mob[1], LEFT,
-                    buff=number_mob[0].get_width() / 4
-                )
             self.coordinate_labels.add(number_mob)
         self.add(self.coordinate_labels)
         return self

--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -182,9 +182,13 @@ class NumberLine(Line):
         if x < 0 and direction[0] == 0:
             # Align without the minus sign
             num_mob.shift(num_mob[0].get_width() * LEFT / 2)
-        if x == unit and unit_tex:
+        if abs(x) == unit and unit_tex:
             center = num_mob.get_center()
-            num_mob.remove(num_mob[0])
+            if x > 0:
+                num_mob.remove(num_mob[0])
+            else:
+                num_mob.remove(num_mob[1])
+                num_mob[0].next_to(num_mob[1], LEFT, buff=num_mob[0].get_width() / 4)
             num_mob.move_to(center)
         return num_mob
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Proposed changes
1. If `unit_tex` is specified in coordinate labels, "1" is now omitted on both positive and negative axis.
2. While setting the color using rgba (or rgb) func, performance can be improved by assinging colors to all points at once (using NumPy indexing) instead of iterating through them.
 
   However, this change would break the existing code for users who rely on rgba (or rgb) function to set colors for rendering animations.