### PR TITLE
Fix error when using `VFadeIn` (and its subclasses)

### DIFF
--- a/manimlib/animation/fading.py
+++ b/manimlib/animation/fading.py
@@ -164,10 +164,10 @@ class VFadeIn(Animation):
         alpha: float
     ) -> None:
         submob.set_stroke(
-            opacity=float(interpolate(0, start.get_stroke_opacity(), alpha))
+            opacity=interpolate(0, start.get_stroke_opacity(), alpha)
         )
         submob.set_fill(
-            opacity=float(interpolate(0, start.get_fill_opacity(), alpha))
+            opacity=interpolate(0, start.get_fill_opacity(), alpha)
         )
 
 

--- a/manimlib/animation/fading.py
+++ b/manimlib/animation/fading.py
@@ -164,10 +164,10 @@ class VFadeIn(Animation):
         alpha: float
     ) -> None:
         submob.set_stroke(
-            opacity=interpolate(0, start.get_stroke_opacity(), alpha)
+            opacity=float(interpolate(0, start.get_stroke_opacity(), alpha))
         )
         submob.set_fill(
-            opacity=interpolate(0, start.get_fill_opacity(), alpha)
+            opacity=float(interpolate(0, start.get_fill_opacity(), alpha))
         )
 
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -1361,7 +1361,7 @@ class Mobject(object):
                     rgbs = resize_with_interpolation(rgbs, len(data))
                 data[name][:, :3] = rgbs
             if opacity is not None:
-                if not isinstance(opacity, (float, int)):
+                if not isinstance(opacity, (float, int, np.floating)):
                     opacity = resize_with_interpolation(np.array(opacity), len(data))
                 data[name][:, 3] = opacity
         return self

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -185,7 +185,7 @@ class VMobject(Mobject):
         if width is not None:
             for mob in self.get_family(recurse):
                 data = mob.data if mob.get_num_points() > 0 else mob._data_defaults
-                if isinstance(width, (float, int)):
+                if isinstance(width, (float, int, np.floating)):
                     data['stroke_width'][:, 0] = width
                 else:
                     data['stroke_width'][:, 0] = resize_with_interpolation(


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation

Fix error when using `VFadeIn` (and its subclasses).

### Explanation of Issue
The `VFadeIn` animation uses `.set_stroke` and `.set_fill` (see: [source](https://github.com/3b1b/manim/blob/f4737828f65999252c0cab9824d9d34cfabf4341/manimlib/animation/fading.py#L166-L171)), but these methods cause an error when the `opacity` is of type `np.float32`. This happens because `np.float32` is handled differently from a regular `float`.

**Note:**  
In `VFadeIn.interpolate_submobject`, the `.set_stroke` and `.set_fill` methods receive `opacity` values from `.get_stroke_opacity` and `.get_fill_opacity`, which return `np.float32`, and this causes the error.
  
## Proposed changes
<!-- What you changed in those files -->
1. Add `np.floating` when checking input type for `opacity` instead of just `float` and `int`, so it becomes: `if not isinstance(opacity, (float, int, np.floating))`. This ensures numpy float is treated the same as regular `float`.  
2. The changes are implemented in `.set_rgba_array_by_color` (used internally by `.set_stroke` and `.set_fill`) and `.set_stroke` (so we can also pass numpy float to `width`).


## Test
<!-- How do you test your changes -->
The following test to verify the fix:
```python
class TestVFading(InteractiveScene):
    def construct(self):
        sq = Square(fill_color=BLUE,fill_opacity=1,stroke_color=RED)
        self.play(VFadeIn(sq))
        self.play(VFadeOut(sq))
```

https://github.com/user-attachments/assets/73b12895-f36c-444f-8c69-c4c5cba4156f

## Additional Information: Reproducing the Error
The following minimal example demonstrates the issue before applying the fix:
```python
from manimlib import Square
import numpy as np
sq = Square()
sq.set_stroke(opacity=np.float32(0.5))  # This causes an error
```
Error message: `TypeError: len() of unsized object`
<details>
<summary>Click to view full error</summary>

```python
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 sq.set_stroke(opacity=np.float32(0.5))
        sq = <manimlib.mobject.geometry.Square object at 0x000002120A312C20>
        np = <module 'numpy' from 'D:\\Manim Project\\manimgl\\.venvManimGLgithub\\lib\\site-packages\\numpy\\__init__.py'>

File D:\Manim Project\manimgl\manim\manimlib\mobject\types\vectorized_mobject.py:183, in VMobject.set_stroke(self=<manimlib.mobject.geometry.Square object>, color=None, width=None, opacity=np.float32(0.5), behind=None, flat=None, recurse=True)
    174 def set_stroke(
    175     self,
    176     color: ManimColor | Iterable[ManimColor] = None,
   (...)
    181     recurse: bool = True
    182 ) -> Self:
--> 183     self.set_rgba_array_by_color(color, opacity, 'stroke_rgba', recurse)
        self = <manimlib.mobject.geometry.Square object at 0x000002120A312C20>
        color = None
        opacity = np.float32(0.5)
        recurse = True
    185     if width is not None:
    186         for mob in self.get_family(recurse):

File D:\Manim Project\manimgl\manim\manimlib\mobject\mobject.py:225, in Mobject.affects_family_data.<locals>.wrapper(self=<manimlib.mobject.geometry.Square object>, *args=(None, np.float32(0.5), 'stroke_rgba', True), **kwargs={})
    223 @wraps(func)
    224 def wrapper(self, *args, **kwargs):
--> 225     result = func(self, *args, **kwargs)
        func = <function Mobject.set_rgba_array_by_color at 0x000002121297A7A0>
        self = <manimlib.mobject.geometry.Square object at 0x000002120A312C20>
        args = (None, np.float32(0.5), 'stroke_rgba', True)
        kwargs = {}
    226     for mob in self.family_members_with_points():
    227         mob.note_changed_data()

File D:\Manim Project\manimgl\manim\manimlib\mobject\mobject.py:1368, in Mobject.set_rgba_array_by_color(self=<manimlib.mobject.geometry.Square object>, color=None, opacity=np.float32(0.5), name='stroke_rgba', recurse=True)
   1366     if opacity is not None:
   1367         if not isinstance(opacity, (float, int)):
-> 1368             opacity = resize_with_interpolation(np.array(opacity), len(data))
        data = array([([ 1.,  1.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([ 0.,  1.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([-1.,  1.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([-1.,  0.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([-1., -1.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([ 0., -1.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([ 1., -1.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([ 1.,  0.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.]),
       ([ 1.,  1.,  0.], [0.9882353 , 0.38431373, 0.33333334, 1.        ], [4.], [1.], [0.34509805, 0.76862746, 0.8666667 , 1.        ], [1., 1., 1.], [0.])],
      dtype=[('point', '<f4', (3,)), ('stroke_rgba', '<f4', (4,)), ('stroke_width', '<f4', (1,)), ('joint_angle', '<f4', (1,)), ('fill_rgba', '<f4', (4,)), ('base_normal', '<f4', (3,)), ('fill_border_width', '<f4', (1,))])
        np = <module 'numpy' from 'D:\\Manim Project\\manimgl\\.venvManimGLgithub\\lib\\site-packages\\numpy\\__init__.py'>          np = <modu                       np = <module 'nump        np = <module 'numpy' from 'D:\\Manim Project\\manimgl\\.venvManimGLgithub\\lib\\site-packages\\numpy\\__init__.py'>
        np = <module 'numpy' from 'D:\\Manim Project\\manimgl\\.venvManimGLgithub\\lib\\site           np = <module 'numpy' from 'D:\\Manim Project\\manimgl\\.venvManimGLgithub\\lib\\site-packages\\numpy\\__init__.py'>
   1369         data[name][:, 3] = opacity
   1370 return self

File D:\Manim Project\manimgl\manim\manimlib\utils\iterables.py:109, in resize_with_interpolation(nparray=array(0.5, dtype=float32), length=9)
    108 def resize_with_interpolation(nparray: np.ndarray, length: int) -> np.ndarray:
--> 109     if len(nparray) == length:
        length = 9
        nparray = array(0.5, dtype=float32)
    110         return nparray
    111     if len(nparray) == 1 or array_is_constant(nparray):

TypeError: len() of unsized object
```
</details>