### PR TITLE
Resolving minor bug in StreamLines

### DIFF
--- a/manimlib/config.py
+++ b/manimlib/config.py
@@ -257,7 +257,7 @@ def update_camera_config(config: Dict, args: Namespace):
     if args.color:
         try:
             camera_config.background_color = colour.Color(args.color)
-        except Exception:
+        except Exception as err:
             log.error("Please use a valid color")
             log.error(err)
             sys.exit(2)

--- a/manimlib/mobject/vector_field.py
+++ b/manimlib/mobject/vector_field.py
@@ -422,7 +422,7 @@ class StreamLines(VGroup):
             cs = self.coordinate_system
             for line in self.submobjects:
                 norms = [
-                    get_norm(self.func(*cs.p2c(point)))
+                    get_norm(self.func(cs.p2c(point)))
                     for point in line.get_points()
                 ]
                 rgbs = values_to_rgbs(norms)
@@ -467,7 +467,7 @@ class AnimatedStreamLines(VGroup):
 
         self.add_updater(lambda m, dt: m.update(dt))
 
-    def update(self, dt: float) -> None:
+    def update(self, dt: float = 0) -> None:
         stream_lines = self.stream_lines
         for line in stream_lines:
             line.time += dt

--- a/manimlib/mobject/vector_field.py
+++ b/manimlib/mobject/vector_field.py
@@ -386,7 +386,6 @@ class StreamLines(VGroup):
 
     def draw_lines(self) -> None:
         lines = []
-        origin = self.coordinate_system.get_origin()
 
         # Todo, it feels like coordinate system should just have
         # the ODE solver built into it, no?


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Proposed changes
<!-- What you changed in those files -->
- Getting different input parameter in `self.init_style()` from `self.draw_lines()`, by removing the asterisk (*), the parameter `coords` would be passed as a numpy array in both functions.
- Setting a default value to 0 in `AnimatedStreamLines`. As `update()` function is called (with no arguments) in `mobject.py` (L845)