### PR TITLE
A necessary tips for using latex added in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ manim-render example_scenes.py OpeningManimExample
 
 Before using functions that need LaTeX, please change the  
 temporary directory for intermediate files (which will lead to "LaTeX compilation failed")
-you can change the `tex_file_writing.py` in `manimlib/utils':  
+you can change the `tex_file_writing.py` in `manimlib/utils`:  
   ```tex_file_writing.py in full_tex_to_svg
   # Write intermediate files to a temporary directory
   with tempfile.TemporaryDirectory() as temp_dir:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ manim-render example_scenes.py OpeningManimExample
     manimgl example_scenes.py OpeningManimExample
     ```
 
+#### Tips for using LaTeX
+
+Before using functions that need LaTeX, please change the  
+temporary directory for intermediate files (which will lead to "LaTeX compilation failed")
+you can change the `tex_file_writing.py` in `manimlib/utils':  
+  ```tex_file_writing.py in full_tex_to_svg
+  # Write intermediate files to a temporary directory
+  with tempfile.TemporaryDirectory() as temp_dir:
+  
+  ```
+add a `dir=your/path` into the brackets.
+(If you're using Linux or Mac OSX, please don't use path containing "~".)
+
+
 ## Anaconda Install
 
 1. Install LaTeX as above.
@@ -99,7 +113,7 @@ When running in the CLI, some useful flags include:
 * `-w` to write the scene to a file
 * `-o` to write the scene to a file and open the result
 * `-s` to skip to the end and just show the final frame.
-    * `-so` will save the final frame to an image and show it
+* `-so` will save the final frame to an image and show it
 * `-n <number>` to skip ahead to the `n`'th animation of a scene.
 * `-f` to make the playback window fullscreen
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ you can change the `tex_file_writing.py` in `manimlib/utils':
   with tempfile.TemporaryDirectory() as temp_dir:
   
   ```
-add a `dir=your/path` into the brackets.
+add a `dir="your/path"` into the brackets.
 (If you're using Linux or Mac OSX, please don't use path containing "~".)
 
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ When running in the CLI, some useful flags include:
 * `-w` to write the scene to a file
 * `-o` to write the scene to a file and open the result
 * `-s` to skip to the end and just show the final frame.
-* `-so` will save the final frame to an image and show it
+    * `-so` will save the final frame to an image and show it
 * `-n <number>` to skip ahead to the `n`'th animation of a scene.
 * `-f` to make the playback window fullscreen
 


### PR DESCRIPTION
## Motivation
When I first tried to use the LaTeX in my video, I constantly ran into a "LaTeX compilation failed" error. After read the `tex_file_writing.py` in `manimlib/utils`, I figured out that there is a necessary change for temporary file path, which is not obvious for users with their first trial. So I think it's better if it could be add to the README

## Proposed changes
```README.md
#### Tips for using LaTeX

Before using functions that need LaTeX, please change the  
temporary directory for intermediate files (which will lead to "LaTeX compilation failed")
you can change the `tex_file_writing.py` in `manimlib/utils':  
  ```tex_file_writing.py in full_tex_to_svg
  # Write intermediate files to a temporary directory
  with tempfile.TemporaryDirectory() as temp_dir:

```