### PR TITLE
Fix typos in GLSL comments

### DIFF
--- a/manimlib/shaders/inserts/emit_gl_Position.glsl
+++ b/manimlib/shaders/inserts/emit_gl_Position.glsl
@@ -6,7 +6,7 @@ uniform vec4 clip_plane;
 
 void emit_gl_Position(vec3 point){
     vec4 result = vec4(point, 1.0);
-    // This allow for smooth transitions between objects fixed and unfixed from frame
+    // This allows for smooth transitions between objects fixed and unfixed from frame
     result = mix(view * result, result, is_fixed_in_frame);
     // Essentially a projection matrix
     result.xyz *= frame_rescale_factors;

--- a/manimlib/shaders/inserts/finalize_color.glsl
+++ b/manimlib/shaders/inserts/finalize_color.glsl
@@ -27,7 +27,7 @@ vec4 add_light(vec4 color, vec3 point, vec3 unit_normal){
     float light_to_normal = dot(to_light, unit_normal);
     // When unit normal points towards light, brighten
     float bright_factor = max(light_to_normal, 0) * reflectiveness;
-    // For glossy surface, add extra shine if light beam go towards camera
+    // For glossy surface, add extra shine if light beam goes towards camera
     vec3 light_reflection = reflect(-to_light, unit_normal);
     float light_to_cam = dot(light_reflection, to_camera);
     float shine = gloss * exp(-3 * pow(1 - light_to_cam, 2));

--- a/manimlib/shaders/true_dot/frag.glsl
+++ b/manimlib/shaders/true_dot/frag.glsl
@@ -13,7 +13,7 @@ in vec2 uv_coords;
 
 out vec4 frag_color;
 
-// This include a declaration of uniform vec3 shading
+// This includes a declaration of uniform vec3 shading
 #INSERT finalize_color.glsl
 
 void main() {

--- a/manimlib/shaders/true_dot/frag.glsl
+++ b/manimlib/shaders/true_dot/frag.glsl
@@ -13,7 +13,7 @@ in vec2 uv_coords;
 
 out vec4 frag_color;
 
-// This include a delaration of uniform vec3 shading
+// This include a declaration of uniform vec3 shading
 #INSERT finalize_color.glsl
 
 void main() {


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
This PR fixes some typos found in GLSL shader comments:
- "delaration" → "declaration", etc.