### PR TITLE
Fix No matching distribution found for audioop-lts (python < 3.13) (#2283)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 addict
 appdirs
-audioop-lts
+audioop-lts; python_version>='3.13'
 colour
 diskcache
 ipython>=8.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = True
 install_requires =
     addict
     appdirs
-    audioop-lts
+    audioop-lts; python_version >= "3.13"
     colour
     diskcache
     ipython>=8.18.0


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

## Proposed changes
<!-- What you changed in those files -->
- pip-requirements
```
audioop-lts; python_version>='3.13'
```
- install_requires
```
audioop-lts; python_version >= "3.13"
```

## Test
<!-- How do you test your changes -->
**Code**:

**Result**: