### PR TITLE
Enhance Autocompletion for `mobject.animate.` to Display `Mobject` Methods

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -160,7 +160,7 @@ class Mobject(object):
         return self
 
     @property
-    def animate(self) -> _AnimationBuilder:
+    def animate(self) -> _AnimationBuilder | Self:
         """
         Methods called with Mobject.animate.method() can be passed
         into a Scene.play call, as if you were calling

--- a/manimlib/typing.py
+++ b/manimlib/typing.py
@@ -7,9 +7,9 @@ if TYPE_CHECKING:
     import re
 
     try:
-        from typing import Self
-    except ImportError:
         from typing_extensions import Self
+    except ImportError:
+        from typing import Self
 
     # Abbreviations for a common types
     ManimColor = Union[str, Color, None]


### PR DESCRIPTION
## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
Currently the autocompletion for `mobject.animate.` does not display the available methods of `Mobject` (e.g., `.rotate`, `.scale`, `.set_color`, etc.). This PR improves the library by enabling autocompletion for `Mobject` methods after `mobject.animate.`. This enhancement improves the user experience by making it easier to explore and use `Mobject` methods while making animation.

## Proposed changes
<!-- What you changed in those files -->
- Added type hint `Self`: `-> _AnimationBuilder | Self` to the `animate` method in `Mobject`, enabling autocompletion for `Mobject` methods after `mobject.animate.`.
- Prioritized `typing_extensions.Self` over `typing.Self` in imports, so autocompletion of \`Mobject\` methods also works in Python < 3.11.

## Test
Before this change:
![Screenshot 2025-05-02 011906](https://github.com/user-attachments/assets/404a267e-50b2-4f71-a7d1-3008c50fc7b4)

After this change:
![Screenshot 2025-05-02 012034](https://github.com/user-attachments/assets/b44687d5-d83f-4738-82ef-cade9c713a3b)
