### PR TITLE
Added an option to rotate the numbers shown on NumberLine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,3 @@ dmypy.json
 # For manim
 /videos
 /custom_config.yml
-test.py

--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -39,6 +39,7 @@ class NumberLine(Line):
         include_numbers: bool = False,
         line_to_number_direction: Vect3 = DOWN,
         line_to_number_buff: float = MED_SMALL_BUFF,
+        number_orientation: float = 0,      # Number rotation in radians
         include_tip: bool = False,
         tip_config: dict = dict(
             width=0.25,
@@ -65,6 +66,7 @@ class NumberLine(Line):
             self.big_tick_numbers = list(big_tick_numbers)
         self.line_to_number_direction = line_to_number_direction
         self.line_to_number_buff = line_to_number_buff
+        self.number_orientation = number_orientation
         self.include_tip = include_tip
         self.tip_config = dict(tip_config)
         self.decimal_number_config = dict(decimal_number_config)
@@ -158,6 +160,7 @@ class NumberLine(Line):
         self,
         x: float,
         direction: Vect3 | None = None,
+        orientation: float | None = None,
         buff: float | None = None,
         unit: float = 1.0,
         unit_tex: str = "",
@@ -168,6 +171,8 @@ class NumberLine(Line):
         )
         if direction is None:
             direction = self.line_to_number_direction
+        if orientation is None:
+            orientation = self.number_orientation
         if buff is None:
             buff = self.line_to_number_buff
         if unit_tex:
@@ -190,6 +195,8 @@ class NumberLine(Line):
                 num_mob.remove(num_mob[1])
                 num_mob[0].next_to(num_mob[1], LEFT, buff=num_mob[0].get_width() / 4)
             num_mob.move_to(center)
+            
+        num_mob.rotate(orientation)
         return num_mob
 
     def add_numbers(


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
The numbers on the y-axis of ``Axes`` are horizontal:
![image](https://github.com/user-attachments/assets/1a4dfaf3-20cb-417c-9ead-b34e90041b1d)

There is no feature to make them vertical.

## Proposed changes
<!-- What you changed in those files -->
To make them vertical, the ``NumberLine`` class (the mobject used to create the axes) was edited where a new argument ``number_orientation`` was introduced the the ``__init__``.

The variable ``number_orientation`` takes in the rotation in radians.

The y_axis_config argument within Axes can now include the number orientation value.

## Test
<!-- How do you test your changes -->
**Code**:
```python
class Test(Scene):
        ax = Axes(
            x_range=(0,x_max,1),
            y_range=(0,x_max+1,1),
            height=6,
            width=6,
            x_axis_config={'include_numbers': True},
            y_axis_config={
                'include_numbers': True,
                'line_to_number_direction': UP,
                'number_orientation' : -PI/2
            }
        )
        self.add(ax)
```

**Result**:
![image](https://github.com/user-attachments/assets/d7173e8f-44a5-41a8-b235-e2739149eb4d)
