### PR TITLE
Remove pkg_resources due to depracation Python >= 3.8

### DIFF
--- a/manimlib/__init__.py
+++ b/manimlib/__init__.py
@@ -1,6 +1,6 @@
-import pkg_resources
+from importlib.metadata import version
 
-__version__ = pkg_resources.get_distribution("manimgl").version
+__version__ = version("manimgl")
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
The changes is quite simple: It removes the `pkg_resources` dependency so that in future Python versions it could still run. Any version of Python below 3.8 is mostly discontinued nowadays, and a warning with the following:
`UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.`
pops up when you run it currently. With the new changes, it won't have this issue.

## Proposed changes
<!-- What you changed in those files -->
- Changed `__init__.py` to no longer use `pkg_resources`, instead use `importlib.metadata`

## Test
<!-- How do you test your changes -->
**Code**:
N/A, still builds, and works fine.

**Result**:
N/A