### PR TITLE
Add Z-axis object grabbing using Z_GRAB_KEY in interactive mode

### DIFF
--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -116,6 +116,7 @@ key_bindings:
   grab: "g"
   x_grab: "h"
   y_grab: "v"
+  z_grab: "z"
   resize: "t"
   color: "c"
   information: "i"

--- a/manimlib/scene/interactive_scene.py
+++ b/manimlib/scene/interactive_scene.py
@@ -42,7 +42,8 @@ UNSELECT_KEY = manim_config.key_bindings.unselect
 GRAB_KEY = manim_config.key_bindings.grab
 X_GRAB_KEY = manim_config.key_bindings.x_grab
 Y_GRAB_KEY = manim_config.key_bindings.y_grab
-GRAB_KEYS = [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY]
+Z_GRAB_KEY = manim_config.key_bindings.z_grab
+GRAB_KEYS = [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY, Z_GRAB_KEY]
 RESIZE_KEY = manim_config.key_bindings.resize  # TODO
 COLOR_KEY = manim_config.key_bindings.color
 INFORMATION_KEY = manim_config.key_bindings.information
@@ -528,7 +529,7 @@ class InteractiveScene(Scene):
             self.add(self.crosshair)
 
         # Conditions for saving state
-        if char in [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY, RESIZE_KEY]:
+        if char in [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY, Z_GRAB_KEY, RESIZE_KEY]:
             self.save_state()
 
     def on_key_release(self, symbol: int, modifiers: int) -> None:
@@ -551,6 +552,8 @@ class InteractiveScene(Scene):
             self.selection.set_x(diff[0])
         elif self.window.is_key_pressed(ord(Y_GRAB_KEY)):
             self.selection.set_y(diff[1])
+        elif self.window.is_key_pressed(ord(Z_GRAB_KEY)):
+            self.selection.set_z(diff[2])
 
     def handle_resizing(self, point: Vect3):
         if not hasattr(self, "scale_about_point"):


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
Currently, in interactive mode, objects can only be grabbed along the X and Y axes using keys like `h`, `v`, etc. However, there was no built-in support for grabbing objects along the Z-axis. To improve 3D interactivity, I added support for grabbing objects along the Z-axis.

## Proposed changes
- Modified `interactive_scene.py` to add Z-axis grabbing functionality.
- Updated `default_config.yml` to include the `z_grab` key binding (`Z_GRAB_KEY`) under `key_bindings`.

## Test
**Code**:
```python
from manimlib import *

class TestZGrabKey(InteractiveScene):
    def construct(self):
        # Testing Z_GRAB_KEY
        cube = Cube()
        self.add(cube)

    def on_key_press(self, symbol, modifiers):
        super().on_key_press(symbol, modifiers)
        char = chr(symbol)
        if char in GRAB_KEYS:
            text = Text(f"Key Pressed: {char}")
            text.to_edge(UR)
            text.fix_in_frame()
            self.add(text)
            self.text = text

    def on_key_release(self, symbol, modifiers):
        super().on_key_release(symbol, modifiers)
        char = chr(symbol)
        if char in GRAB_KEYS:
            self.remove(self.text)
```
## Result:

https://github.com/user-attachments/assets/21e1bb43-be7f-4b59-8a5d-4787bfbcc518
