### PR TITLE
feat: integrate ImGui window into interactive embed loop for real-time

### DIFF
--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -20,12 +20,14 @@ if TYPE_CHECKING:
     from typing import Optional
     from manimlib.typing import ManimColor, Vect3
     from manimlib.window import Window
+    from manimlib.scene.scene import Scene
 
 
 class Camera(object):
     def __init__(
         self,
         window: Optional[Window] = None,
+        scene: Optional[Scene] = None,
         background_image: Optional[str] = None,
         frame_config: dict = dict(),
         # Note: frame height and width will be resized to match this resolution aspect ratio
@@ -44,8 +46,10 @@ class Camera(object):
         # without multisampling, for 3d scenes one might want
         # to set samples to be greater than 0.
         samples: int = 0,
+        imgui: bool = True,
     ):
         self.window = window
+        self.scene = scene
         self.background_image = background_image
         self.default_pixel_shape = resolution  # Rename?
         self.fps = fps
@@ -55,6 +59,7 @@ class Camera(object):
         self.pixel_array_dtype = pixel_array_dtype
         self.light_source_position = light_source_position
         self.samples = samples
+        self.imgui = imgui
 
         self.rgb_max_val: float = np.iinfo(self.pixel_array_dtype).max
         self.background_rgba: list[float] = list(color_to_rgba(
@@ -230,6 +235,9 @@ class Camera(object):
             mobject.render(self.ctx, self.uniforms)
 
         if self.window:
+            if self.imgui and self.scene is not None:
+                self.scene.construct_imgui_window()
+                self.scene.render_imgui()
             self.window.swap_buffers()
             if self.fbo is not self.window_fbo:
                 self.blit(self.fbo, self.window_fbo)


### PR DESCRIPTION
# 🎮 ImGui Integration in ManimGL

This repo adds **ImGui (Immediate Mode GUI)** support to **ManimGL**, enabling real-time control over scene objects like color, opacity, and selection. Built on top of `InteractiveScene`, this integration gives full GUI control during animation playback inside the Manim window.

---

## ✨ Features

- Live ImGui control panel embedded inside Manim window
- Control any Mobject’s:
  - ✅ Fill color
  - ✅ Opacity
  - ✅ Selection from scene
- Slider, Color Picker, Dropdown Combo via ImGui
- Works using `InteractiveScene` class
- Mouse scroll fix for ImGui usability

---

## 🔧 Requirements

| Component        | Version / Info                                      |
|------------------|-----------------------------------------------------|
| **Python**       | `3.12.7` ✅ Required<br>🚫 Not compatible with Python 3.13 |
| **Windows 10 SDK**  | ✅ Required for ImGui C++ build (`imgui.core`)       |
| **ManimGL**      | Latest from 3Blue1Brown fork                        |
| **PyImGui**      | Use `imgui` or latest pip version            |

---

## Fix moderngl_window mouse scroll event

---
# Before
```python
def mouse_scroll_event(self, x_offset, y_offset):
    self.io.mouse_wheel_h = x_offset # remove _h
    self.io.mouse_wheel = y_offset
```
# After
```python
def mouse_scroll_event(self, x_offset, y_offset):
    self.io.mouse_wheel = x_offset
    self.io.mouse_wheel = y_offset
```

## ⚙️ Setup Instructions

### 🐍 Python Environment

Make sure you're using Python **3.12.7**.

```bash
python --version
# Should output: Python 3.12.7
```
---
## Example
```python
from manimlib import *

class TestMG(InteractiveScene):
    imgui = True
    def setup(self):
        super().setup()
        # initial state
        self.text_color = [1.0, 1.0, 1.0]
        self.opacity = 0.0
        self.selected_index = 0

    def construct(self):
        # Cube
        sq = Square()
        self.play(
            ShowCreation(sq),
            run_time=1,
        )
        self.play(
            sq.animate.to_edge(RIGHT)
        )

    def construct_imgui_window(self):
        imgui.new_frame()
        imgui.begin("Control Panel")
        imgui.text("Adjust the opacity")
        ochanged, self.opacity = imgui.slider_float("Opacity", self.opacity, 0.0, 1.0)
        wchanged, self.text_color = imgui.color_edit3("Text Color", *self.text_color)
        names = [str(mob) for mob in self.mobjects]
        changed, self.selected_index = imgui.combo(
            "Select Mobject",
            self.selected_index,
            names
        )
        selected_mob = self.mobjects[self.selected_index]
        if wchanged:
            selected_mob.set_fill(rgb_to_color(self.text_color[:3]))
        if ochanged:
            selected_mob.set_opacity(self.opacity)
        imgui.end()
```
---
## 📽️ Demo


https://github.com/user-attachments/assets/d1c0d08b-2237-4d12-b4a0-af43c48e85f9


https://github.com/user-attachments/assets/481a696e-d05e-41fe-a14f-149c24bae0a7



A screen recording is included, showing how ImGui can interact with the square's color and opacity during rendering.

---
