### PR TITLE
Minor Fixes for Example Scenes

### DIFF
--- a/docs/source/getting_started/example_scenes.rst
+++ b/docs/source/getting_started/example_scenes.rst
@@ -426,7 +426,7 @@ CoordinateSystemExample
             # you can call call axes.coords_to_point, abbreviated to
             # axes.c2p, to associate a set of coordinates with a point,
             # like so:
-            dot = Dot(color=RED)
+            dot = Dot(fill_color=RED)
             dot.move_to(axes.c2p(0, 0))
             self.play(FadeIn(dot, scale=0.5))
             self.play(dot.animate.move_to(axes.c2p(3, 2)))
@@ -537,7 +537,7 @@ GraphExample
 
             # You can use axes.input_to_graph_point, abbreviated
             # to axes.i2gp, to find a particular point on a graph
-            dot = Dot(color=RED)
+            dot = Dot(fill_color=RED)
             dot.move_to(axes.i2gp(2, parabola))
             self.play(FadeIn(dot, scale=0.5))
 

--- a/example_scenes.py
+++ b/example_scenes.py
@@ -375,7 +375,7 @@ class CoordinateSystemExample(Scene):
         # you can call call axes.coords_to_point, abbreviated to
         # axes.c2p, to associate a set of coordinates with a point,
         # like so:
-        dot = Dot(color=RED)
+        dot = Dot(fill_color=RED)
         dot.move_to(axes.c2p(0, 0))
         self.play(FadeIn(dot, scale=0.5))
         self.play(dot.animate.move_to(axes.c2p(3, 2)))
@@ -480,7 +480,7 @@ class GraphExample(Scene):
 
         # You can use axes.input_to_graph_point, abbreviated
         # to axes.i2gp, to find a particular point on a graph
-        dot = Dot(color=RED)
+        dot = Dot(fill_color=RED)
         dot.move_to(axes.i2gp(2, parabola))
         self.play(FadeIn(dot, scale=0.5))
 

--- a/manimlib/utils/file_ops.py
+++ b/manimlib/utils/file_ops.py
@@ -29,13 +29,15 @@ def find_file(
     extensions: Iterable[str] | None = None
 ) -> Path:
     # Check if this is a file online first, and if so, download
-    # it to a temporary directory
+    # it to the configured downloads directory
     if validators.url(file_name):
         suffix = Path(file_name).suffix
         file_hash = hash_string(file_name)
         folder = manimlib.utils.directories.get_downloads_dir()
-
         path = Path(folder, file_hash).with_suffix(suffix)
+
+        # ensure that the target folder exists before downloading
+        guarantee_existence(folder)
         urllib.request.urlretrieve(file_name, path)
         return path
 


### PR DESCRIPTION
## Motivation
During the evaluation of example scenes, I encountered the following issues:

1. **SurfaceExample**
   Failed with the message: `FileNotFoundError: [Errno 2] No such file or directory: 'downloads/b4905915eb51c77d.jpg'`

2. **GraphExample and CoordinateSystemExample**
   `Dot`s appeared in the wrong color (light instead of red).

## Proposed Changes
- **file_ops.py**
  Added a call to `guarantee_existence(folder)` before `urllib.request.urlretrieve`.

- **Documentation and Example Code**
  Replaced all occurrences of `Dot(color=RED)` with `Dot(fill_color=RED)` in the relevant example scenes.

## Test
- Ran the SurfaceExample to verify that it now creates the `downloads` directory if it doesn’t exist and successfully renders afterward.
- Ran the updated example scenes to confirm that dots render in red.