### PR TITLE
Add a lightweight alternative to MacTeX in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ manim-render example_scenes.py OpeningManimExample
     ```sh
     brew install ffmpeg mactex
     ```
+    <details>
+      <summary>💡 An alternative to heavyweight MacTeX bundle.</summary>
+
+      > To avoid installing the full MacTeX bundle, which is ~6GB, you can alternatively install the
+      > lightweight [BasicTeX](https://formulae.brew.sh/cask/basictex) and then gradually add
+      > only the LaTeX packages you actually need. A list of packages sufficient to run examples can 
+      > be found [here](https://github.com/3b1b/manim/issues/2133#issuecomment-2414547866).
+      > For an overview of the MacTeX installer bundles, see https://www.tug.org/mactex/.
+    </details>
 
 2. If you are using an ARM-based processor, install Cairo. 
     ```sh


### PR DESCRIPTION
## Motivation
Installing the full MacTeX distribution (~6 GB) can be prohibitive for users who only need a minimal set of LaTeX packages to render Manim examples. BasicTeX (a smaller, ~100 MB distribution) lets users install on demand and keeps their setup lightweight.

## Proposed changes
Enhance the installation instructions in `README.md` by providing a collapsible note on using Homebrew’s BasicTeX cask as a lightweight alternative to the full MacTeX distribution. Include links to:
  - Homebrew’s BasicTeX cask.
  - A GitHub issue comment enumerating the minimal set of LaTeX packages.
  - The TeX Users Group’s MacTeX package index for further reference.

Have a look at the result [here](https://github.com/azhuchkov/manim/tree/mactex-alternative#mac-osx).