### PR TITLE
Add workaround for Pyglet 2.1 DPI scaling issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ When running in the CLI, some useful flags include:
 
 Take a look at custom_config.yml for further configuration.  To add your customization, you can either edit this file, or add another file by the same name "custom_config.yml" to whatever directory you are running manim from.  For example [this is the one](https://github.com/3b1b/videos/blob/master/custom_config.yml) for 3blue1brown videos.  There you can specify where videos should be output to, where manim should look for image files and sounds you want to read in, and other defaults regarding style and video quality.
 
+### Troubleshooting
+If you experience unexpected behavior with window positioning and/or sizing, consider setting the environment
+variable `PYGLET_DPI_SCALING` to either `scaled` or `stretch`. For instance:
+```sh
+PYGLET_DPI_SCALING=scaled manimgl example_scenes.py OpeningManimExample
+```
+
 ### Documentation
 Documentation is in progress at [3b1b.github.io/manim](https://3b1b.github.io/manim/). And there is also a Chinese version maintained by [**@manim-kindergarten**](https://manim.org.cn): [docs.manim.org.cn](https://docs.manim.org.cn/) (in Chinese).
 

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
 
     T = TypeVar("T")
 
+import os, sys, pyglet
+
+# It should be natively supported by Pyglet, but it doesn't work at the moment.
+# See https://github.com/pyglet/pyglet/issues/1342
+dpi_scaling = os.environ.get('PYGLET_DPI_SCALING')
+if dpi_scaling:
+    # dpi_scaling introduced in Pyglet 2.1
+    if hasattr(pyglet.options, 'dpi_scaling'):
+        pyglet.options.dpi_scaling = dpi_scaling
+    else:
+        print("Installed Pyglet doesn't support DPI scaling.",
+              file=sys.stderr)
+
 
 class Window(PygletWindow):
     fullscreen: bool = False


### PR DESCRIPTION
### Motivation

This update resolves a backward compatibility issue introduced in Pyglet 2.1, where the new default DPI settings may lead to incorrect window sizing and positioning on HiDPI displays. Pyglet 2.1 is automatically installed as a transitive dependency in modern deployments.

### Proposed Changes 

- A “Troubleshooting” section in README.md that documents the new `PYGLET_DPI_SCALING` environment variable. Users can set it to `scaled` or `stretch` to restore expected behavior.
- Support code in `manimlib/window.py` to read `PYGLET_DPI_SCALING` at startup and apply it to `pyglet.options.dpi_scaling` (if available). A stderr warning is emitted when running against older Pyglet versions that lack this option. 

This should restore prior DPI behavior without requiring a full downgrade or manual patching of Pyglet internals.