### PR TITLE
feat(InteractiveScene): add z-axis object grabbing support

### DIFF
--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -116,6 +116,7 @@ key_bindings:
   grab: "g"
   x_grab: "h"
   y_grab: "v"
+  z_grab: "z"
   resize: "t"
   color: "c"
   information: "i"

--- a/manimlib/scene/interactive_scene.py
+++ b/manimlib/scene/interactive_scene.py
@@ -42,7 +42,8 @@ UNSELECT_KEY = manim_config.key_bindings.unselect
 GRAB_KEY = manim_config.key_bindings.grab
 X_GRAB_KEY = manim_config.key_bindings.x_grab
 Y_GRAB_KEY = manim_config.key_bindings.y_grab
-GRAB_KEYS = [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY]
+Z_GRAB_KEY = manim_config.key_bindings.z_grab
+GRAB_KEYS = [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY, Z_GRAB_KEY]
 RESIZE_KEY = manim_config.key_bindings.resize  # TODO
 COLOR_KEY = manim_config.key_bindings.color
 INFORMATION_KEY = manim_config.key_bindings.information
@@ -528,7 +529,7 @@ class InteractiveScene(Scene):
             self.add(self.crosshair)
 
         # Conditions for saving state
-        if char in [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY, RESIZE_KEY]:
+        if char in [GRAB_KEY, X_GRAB_KEY, Y_GRAB_KEY, Z_GRAB_KEY, RESIZE_KEY]:
             self.save_state()
 
     def on_key_release(self, symbol: int, modifiers: int) -> None:
@@ -551,6 +552,8 @@ class InteractiveScene(Scene):
             self.selection.set_x(diff[0])
         elif self.window.is_key_pressed(ord(Y_GRAB_KEY)):
             self.selection.set_y(diff[1])
+        elif self.window.is_key_pressed(ord(Z_GRAB_KEY)):
+            self.selection.set_z(diff[2])
 
     def handle_resizing(self, point: Vect3):
         if not hasattr(self, "scale_about_point"):


### PR DESCRIPTION
## Motivation
In the current interactive scene implementation, object grabbing is limited to the X and Y axes.  
This makes it difficult to manipulate objects in full 3D space without writing extra transformation code.  

This update adds Z-axis grabbing support, enabling depth movement directly through interactive mode.  
It improves usability for 3D scene creation and makes interactive object positioning more intuitive.

## Proposed changes
- **interactive_scene.py** – Extended the grab-and-move logic to include Z-axis handling alongside X and Y.
- **default_config.yml** – Updated configuration to include parameters for enabling and controlling Z-axis grabbing.

## Test
**Code**:
```python
from manimlib import *

class TestingZGrab(InteractiveScene):
    def construct(self):
        # Testing ZGrab
        z = Cube()
        self.add(z)
        
    def on_key_press(self, symbol, modifiers):
        super().on_key_press(symbol, modifiers)
        
        char = chr(symbol)
        if char in GRAB_KEYS:
            self.text = Text(f"Key Pressed: {chr(symbol)}")
            self.text.fix_in_frame()
            self.text.to_edge(UR)
            self.add(self.text)
    
    def on_key_release(self, symbol, modifiers):
        super().on_key_release(symbol, modifiers)
        
        char = chr(symbol)
        if char in GRAB_KEYS:
            self.remove(self.text)
```
-------------------------------
## 
https://github.com/user-attachments/assets/5f60b437-7f07-43a7-8da4-e6f45f55aedb