### PR TITLE
Update versioning to use importlib

### DIFF
--- a/manimlib/__init__.py
+++ b/manimlib/__init__.py
@@ -1,6 +1,6 @@
-import pkg_resources
+from importlib.metadata import version
 
-__version__ = pkg_resources.get_distribution("manimgl").version
+__version__ = version("manimgl")
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
## Motivation

Using `pkg_resources` is [deprecated and slated for removal](https://setuptools.pypa.io/en/latest/pkg_resources.html):

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)).

Thus, running `manim` on e.g. Python 3.11.13 results in the following warning:
```console
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The > pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

## Proposed changes

I simply updated the versioning code in `__init__.py` to use `importlib.metadata` instead of `pkg_resources`.

## Test

**Code**:

```console
$ manim --version
```

**Result**:
```console
ManimGL v1.7.2
```