### PR TITLE
Fix: remove pkg_resources usage (deprecated), use importlib.metadata

### DIFF
--- a/manimlib/__init__.py
+++ b/manimlib/__init__.py
@@ -1,6 +1,13 @@
-import pkg_resources
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # For Python <3.8 fallback
+    from importlib_metadata import version, PackageNotFoundError  # type: ignore
 
-__version__ = pkg_resources.get_distribution("manimgl").version
+try:
+    __version__ = version("manimgl")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
Currently, running `manimgl` on Python 3.13+ produces a warning:

UserWarning: pkg_resources is deprecated as an API...

This happens because `manimlib/__init__.py` imports `pkg_resources` only to retrieve the package version.  
Since `pkg_resources` is deprecated and scheduled for removal after 2025-11-30, this will eventually break ManimGL.

## Proposed changes
- Removed the dependency on `pkg_resources` in `manimlib/__init__.py`.
- Replaced it with `importlib.metadata`, the recommended standard library API (Python ≥3.8).
- Added a fallback for when the package version cannot be determined.

## Test
**Code**:
```bash
manimgl
```
Result:
```bash
ManimGL v1.7.2
```

No deprecation warning is shown, and the version is still correctly displayed.