### PR TITLE
Fix StrokeArrow: preserve tip geometry for large angles

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -964,15 +964,13 @@ class StrokeArrow(Line):
         prev_end = self.get_end()
         arc_len = self.get_arc_length()
         tip_len = self.get_stroke_width() * self.tip_width_ratio * self.tip_len_to_width
-        if tip_len >= self.max_tip_length_to_length_ratio * arc_len or arc_len == 0:
+        if tip_len >= self.max_tip_length_to_length_ratio * arc_len:
             alpha = self.max_tip_length_to_length_ratio
         else:
             alpha = tip_len / arc_len
-
-        if self.path_arc > 0 and self.buff > 0:
-            self.insert_n_curves(10)  # Is this needed?
         self.pointwise_become_partial(self, 0.0, 1.0 - alpha)
-        self.add_line_to(self.get_end())
+        # Dumb that this is needed
+        self.start_new_path(self.point_from_proportion(1 - 1e-5))
         self.add_line_to(prev_end)
         self.n_tip_points = 3
         return self
@@ -981,11 +979,10 @@ class StrokeArrow(Line):
     def create_tip_with_stroke_width(self) -> Self:
         if self.get_num_points() < 3:
             return self
-        stroke_width = min(
-            self.original_stroke_width,
+        tip_width = self.tip_width_ratio * min(
+            float(self.original_stroke_width),
             self.max_width_to_length_ratio * self.get_length(),
         )
-        tip_width = self.tip_width_ratio * stroke_width
         ntp = self.n_tip_points
         self.data['stroke_width'][:-ntp] = self.data['stroke_width'][0]
         self.data['stroke_width'][-ntp:, 0] = tip_width * np.linspace(1, 0, ntp)


### PR DESCRIPTION
## Motivation
`StrokeArrow` did not preserve the tip geometry correctly for certain arc angles.  
The arrow tips could disappear, distort, or scale incorrectly depending on the arc length.

## Proposed changes
- Fixed condition in `insert_tip_anchor` to properly handle arc length and tip length.  
- Replaced `pointwise_become_partial` with `start_new_path` to avoid distorted geometry.  
- Updated `create_tip_with_stroke_width` to compute `tip_width` using `original_stroke_width` for consistent tip geometry.  
- Removed redundant and buggy code paths.  

## Test
**Code used:**
```python
from manimlib import *

class FixStrokeArrow(InteractiveScene):
    def construct(self):
        arrows = VGroup()
        for angle in [0, 45, 90, 135, 180]:
            arrow = StrokeArrow(LEFT, RIGHT, path_arc=-angle*DEGREES)
            arrows.add(arrow)
        arrows.arrange(DOWN)
        self.add(arrows)
```
### Result
## Before
<img width="1366" height="768" alt="Screenshot 2025-09-16 15-28-16" src="https://github.com/user-attachments/assets/3cb494fd-c078-4886-b52c-af334bc30f6a" />

## After
<img width="1366" height="768" alt="Screenshot 2025-09-16 15-29-36" src="https://github.com/user-attachments/assets/7fbad7be-da0f-48ab-a937-bd0548217601" />
