### PR TITLE
Geometry improvements

### DIFF
--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -31,7 +31,7 @@ from manimlib.utils.space_ops import rotation_between_vectors
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, Optional
+    from typing import Iterable, Optional, Tuple
     from manimlib.typing import ManimColor, Vect3, Vect3Array, Self
 
 


### PR DESCRIPTION
## Motivation
Currently, some methods were implemented only in `Arrow` even though they are
more general and applicable to all `Line`-based objects (including `StrokeArrow`).
This caused:
- Code duplication (same logic repeated in `Arrow`).
- Inconsistency (methods unavailable in `StrokeArrow`).
- Bugs (e.g., `set_path_arc` in `Line` did not behave correctly).

This PR moves/refactors these methods into the `Line` class so that they can be
reused consistently across all inheriting classes.

---

## Proposed changes
- Moved `reset_points_around_ends` from `Arrow` → `Line`.
- Fixed and generalized `set_path_arc` in `Line` so that it works for both
  `Arrow` and `StrokeArrow`.
- Moved `set_perpendicular_to_camera` from `Arrow` → `Line`.
- Removed redundant implementations from `Arrow`.
- Added missing type hint import:
```python
  from typing import Tuple
```

## Code
```python
from manimlib import *

class TestInsertLine(InteractiveScene):
    def construct(self):
        # Line with arc
        line = Line(LEFT, RIGHT, path_arc=PI, color=BLUE)
        line.always.set_perpendicular_to_camera(self.frame)
        self.add(line)
        line.set_path_arc(PI/2)

        # Arrow inherits Line functionality
        arrow = Arrow(LEFT, RIGHT, path_arc=-PI/4, color=RED)
        arrow.always.set_perpendicular_to_camera(self.frame)
        self.add(arrow)
        arrow.set_path_arc(-PI/2)

        # StrokeArrow also inherits Line functionality
        stroke_arrow = StrokeArrow(LEFT, RIGHT, path_arc=PI/3, color=GREEN)
        stroke_arrow.always.set_perpendicular_to_camera(self.frame)
        self.add(stroke_arrow)
        stroke_arrow.set_path_arc(PI/2)
```

### Result:
- All three (`Line`, `Arrow`, and `StrokeArrow`) correctly reset around their ends.
- `set_path_arc` now applies consistently to both `Arrow` and `StrokeArrow`.
- `set_perpendicular_to_camera` works for all classes without duplication.