### PR TITLE
Fix x_range slicing in get_area_under_graph to prevent TypeError

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -417,7 +417,7 @@ class CoordinateSystem(ABC):
             raise Exception("Argument `graph` must have attribute `x_range`")
 
         alpha_bounds = [
-            inverse_interpolate(*graph.x_range, x)
+            inverse_interpolate(*graph.x_range[:2], x)
             for x in x_range
         ]
         sub_graph = graph.copy()


### PR DESCRIPTION
## Motivation
Fix a bug in `get_area_under_graph` where passing the full `graph.x_range` 
to `inverse_interpolate` could cause a `TypeError`:

    TypeError: inverse_interpolate() takes 3 positional arguments but 4 were given

This happened when `graph.x_range` had more than 2 elements. Slicing the 
x_range ensures that alpha bounds are calculated correctly and subgraphs 
are created reliably.

## Proposed changes
- Slice `graph.x_range` to only the first two elements when passing to `inverse_interpolate`: `graph.x_range[:2]`.
- Preserve existing behavior for standard 2-element `x_range`.

## Test
**Code**:
```python
from manimlib import *

class HelloWorldExample(InteractiveScene):
    def construct(self):
        # Setup
        plane = NumberPlane(
            x_range=(-4, 4), y_range=(0, 1.5, 0.5),
            width=14, height=5,
            background_line_style=dict(
                stroke_color=GREY_B,
                stroke_width=2,
                stroke_opacity=0.75
            )
        )
        plane.to_edge(DOWN)
        plane.x_axis.add_numbers(num_decimal_places=1, excluding=[0])
        plane.y_axis.add_numbers(font_size=24)
        self.add(plane)

        # graph
        graph = plane.get_graph(lambda x: np.exp(-x**2))
        graph.set_stroke(BLUE, 2)
        self.add(graph)

        area = plane.get_area_under_graph(graph, x_range=[-1, 1])
        area.scale(0.7)
        area.next_to(graph.pfp(0.65), UR)
        self.add(area)
```
### Result:
- No `TypeError` occurs
- Area under the graph is filled correctly for both standard and extended x_ranges

## Before:
<img width="1366" height="768" alt="Screenshot (55)" src="https://github.com/user-attachments/assets/43c65caa-9c4b-4bb9-9450-e82993fd929d" />

## After:
<img width="1366" height="768" alt="Screenshot (56)" src="https://github.com/user-attachments/assets/8f18d1f9-25e1-46c1-b3ab-86c049985087" />
