### PR TITLE
fix(interactive_scene): handle OverflowError in on_key_press for large key symbols

### DIFF
--- a/manimlib/scene/interactive_scene.py
+++ b/manimlib/scene/interactive_scene.py
@@ -475,7 +475,10 @@ class InteractiveScene(Scene):
     # Key actions
     def on_key_press(self, symbol: int, modifiers: int) -> None:
         super().on_key_press(symbol, modifiers)
-        char = chr(symbol)
+        try:
+            char = chr(symbol)
+        except OverflowError:
+            return
         if char == SELECT_KEY and (modifiers & ALL_MODIFIERS) == 0:
             self.enable_selection()
         if char == UNSELECT_KEY:


### PR DESCRIPTION
## Motivation

Currently, pressing certain system keys (like `Win`, `PrtScr`, or special key combinations) inside the interactive window causes an `OverflowError: Python int too large to convert to C int`. This fix prevents crashes by safely handling such cases, improving stability when working with `InteractiveScene`.

## Proposed changes

-   Updated `InteractiveScene.on_key_press`:
    -   Wrapped `chr(symbol)` in a `try/except`.
    -   Catch `OverflowError` to avoid crashing when key symbols are too
        large.
-   Prevents the application from breaking during user interaction with
    special keys.

## Test

**Code**:

``` python
from manimlib import *

class HelloWorldExample(InteractiveScene):
    def construct(self):
        pass
```

**Result**:
- Run the above scene.
- Press system keys like `Win + PrtScr`.
- Before fix → application crashed with `OverflowError`.
- After fix → application runs normally without crashing (large key
symbols are ignored).

## Before:
<img width="1366" height="768" alt="Screenshot (60)" src="https://github.com/user-attachments/assets/3f66bb53-50f5-40f9-a199-6ef65dd072dc" />

## After:
<img width="1366" height="768" alt="Screenshot (62)" src="https://github.com/user-attachments/assets/d22af899-aa31-4b68-a5fb-df4d07a02e83" />
