### PR TITLE
fix(SceneState): clear updaters on restore_scene

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -917,10 +917,11 @@ class SceneState():
     def restore_scene(self, scene: Scene):
         scene.time = self.time
         scene.num_plays = self.num_plays
-        scene.mobjects = [
-            mob.become(mob_copy)
-            for mob, mob_copy in self.mobjects_to_copies.items()
-        ]
+        scene.mobjects = []
+        for mob, mob_copy in self.mobjects_to_copies.items():
+            if mob.has_updaters():
+                mob.clear_updaters()
+            scene.mobjects.append(mob.become(mob_copy))
 
 
 class EndScene(Exception):


### PR DESCRIPTION
## Motivation
Restoring scene checkpoints did not clear updaters from mobjects.
As a result, after reverting to a previous checkpoint, updaters that
were not present originally continued to run, causing inconsistent
scene states.

This PR fixes the issue by ensuring that updaters are cleared during
scene restoration.

## Proposed changes
- In `SceneState.restore_scene`:
  - Clear updaters on each mobject before restoring its state.
  - Ensure restored scene matches exactly the saved checkpoint.

### Code
```python
from manimlib import *

class FixRestoreSceneWithUpdater(InteractiveScene):
    def construct(self):
        # Setup
        cube = Cube()
        self.add(cube)
        frame = self.frame
        frame.reorient(32, 68, 0, (-0.02, 0.0, 0.0))

        # cache the scene
        frame.always.increment_theta(1 * DEG)
```

### Before

https://github.com/user-attachments/assets/dcd17107-156f-4998-9dc2-fbde915a9b4d



### After


https://github.com/user-attachments/assets/f9343cac-46d3-4352-a259-552cf9155b46


## Test
- Created a checkpoint with a mobject without updaters.
- Added an updater to the same mobject later in the scene.
- Reverted to the previous checkpoint:
  - ✅ Now updater is cleared as expected.
  - ✅ Scene state is restored correctly.
