### PR TITLE
Fix: Update installation guide to use Python 3.9 (Python 3.8 incompatible with ipython>=8.18.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ manim-render example_scenes.py OpeningManimExample
 ## Anaconda Install
 
 1. Install LaTeX as above.
-2. Create a conda environment using `conda create -n manim python=3.8`.
+2. Create a conda environment using `conda create -n manim python=3.9`.
 3. Activate the environment using `conda activate manim`.
 4. Install manimgl using `pip install -e .`.
 


### PR DESCRIPTION


The installation instructions suggested python=3.8, but manimgl depends on ipython>=8.18.0, which requires Python ≥3.9. This PR updates the environment creation command to use Python 3.9 to avoid installation errors.


## Motivation
imporve the readme.

## Proposed changes
The python version in README.md

