### PR TITLE
Fix degenerate bezier handles

### DIFF
--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -499,6 +499,9 @@ class VMobject(Mobject):
             quad_approx = get_quadratic_approximation_of_cubic(
                 last, handle1, handle2, anchor
             )
+            if self.consider_points_equal(quad_approx[3], quad_approx[4]):
+                # Avoid degenerate handles (duplicate points) to prevent visual bug
+                quad_approx[3] = midpoint(*quad_approx[2:4])
         if self.consider_points_equal(quad_approx[1], last):
             # This is to prevent subpaths from accidentally being marked closed
             quad_approx[1] = midpoint(*quad_approx[1:3])
@@ -685,6 +688,9 @@ class VMobject(Mobject):
             a1 = new_subpath[2::2]
             false_ends = np.equal(a0, h).all(1)
             h[false_ends] = 0.5 * (a0[false_ends] + a1[false_ends])
+            # Avoid degenerate handles (duplicate points) to prevent visual bug
+            degenerate_handles = np.equal(h, a1).all(1)
+            h[degenerate_handles] = 0.5 * (a0[degenerate_handles] + a1[degenerate_handles])
             self.add_subpath(new_subpath)
         return self
 


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

In some edge cases (colinear or nearly-colinear points), Bezier handles can become degenerate (duplicate anchors), which can lead to visual artifacts when rendering `VMobjects`. The examples shown are simple, but they could appear as part of a larger set of points used to create a `VMobject`.

## Proposed changes
<!-- What you changed in those files -->

- Avoid consecutive duplicate handle/anchor points in `VMobject` methods `add_cubic_bezier_curve_to` and `change_anchor_mode`.

## Test
<!-- How do you test your changes -->

- First example: colinear points on `CubicBezier`.
- Second example: nearly-colinear points on `VMobject`.

**Code**:

```py
from manimlib import *


class Example1(Scene):
    def construct(self):
        
        points = [
            2*LEFT,
            LEFT,
            RIGHT,
            2*RIGHT
        ]
        
        self.add(Dot(points[0]), Dot(points[-1]))
        curve = CubicBezier(*points)
        self.add(curve)

        print(curve.data['point'])


class Example2(Scene):
    def construct(self):
        
        points = [
            4*LEFT,
            3*LEFT + 0.01*UP,
            2*LEFT,
            LEFT,
            ORIGIN,
            RIGHT,
            2*RIGHT,
            3*RIGHT,
            4*RIGHT,
        ]
        
        self.add(VGroup(*[Dot(p) for p in points]))
        curve = VMobject().set_points_smoothly(points, approx=False)
        self.add(curve)

        print(curve.data['point'])
```

**Result**:

- Example 1 before the fix:

<img width="1920" height="1080" alt="Example1Bug" src="https://github.com/user-attachments/assets/497a616f-d874-4a04-a7f7-cd6d8413230d" />

- Example 1 after the fix:

<img width="1920" height="1080" alt="Example1Fix" src="https://github.com/user-attachments/assets/6ef3f687-376f-465c-a7d0-97f027cf3f76" />

- Example 2 before the fix:

<img width="1920" height="1080" alt="Example2Bug" src="https://github.com/user-attachments/assets/645174f9-7853-4db8-9605-81ca371c3a72" />

- Example 2 after the fix:

<img width="1920" height="1080" alt="Example2Fix" src="https://github.com/user-attachments/assets/c26703d1-5415-4902-8aa3-5e616bb346d8" />
