### PR TITLE
Replace TEXT_MOB_SCALE_FACTOR with a dynamically calculated value

### DIFF
--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -82,10 +82,14 @@ mobject:
 tex:
   # See tex_templates.yml
   template: "default"
+  # The font size at which Tex("0") has a height of 1 manim unit
+  font_size_for_unit_height: 144
 text:
   # font: "Cambria Math"
   font: "Consolas"
   alignment: "LEFT"
+  # The font size at which Text("0") has a height of 1 manim unit
+  font_size_for_unit_height: 144
 embed:
   exception_mode: "Verbose"
   autoreload: False

--- a/manimlib/mobject/svg/old_tex_mobject.py
+++ b/manimlib/mobject/svg/old_tex_mobject.py
@@ -6,6 +6,7 @@ import re
 
 from manimlib.constants import BLACK, DEFAULT_MOBJECT_COLOR
 from manimlib.mobject.svg.svg_mobject import SVGMobject
+from manimlib.mobject.svg.tex_mobject import get_tex_mob_scale_factor
 from manimlib.mobject.types.vectorized_mobject import VGroup
 from manimlib.utils.tex_file_writing import latex_to_svg
 
@@ -14,9 +15,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Iterable, List, Dict
     from manimlib.typing import ManimColor
-
-
-SCALE_FACTOR_PER_FONT_POINT = 0.001
 
 
 class SingleStringTex(SVGMobject):
@@ -59,7 +57,7 @@ class SingleStringTex(SVGMobject):
         )
 
         if self.height is None:
-            self.scale(SCALE_FACTOR_PER_FONT_POINT * self.font_size)
+            self.scale(get_tex_mob_scale_factor() * self.font_size)
         if self.organize_left_to_right:
             self.organize_submobjects_left_to_right()
 

--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -31,6 +31,21 @@ SVG_HASH_TO_MOB_MAP: dict[int, list[VMobject]] = {}
 PATH_TO_POINTS: dict[str, Vect3Array] = {}
 
 
+def get_svg_content_height(svg_string: str) -> float:
+    # Strip root attributes to match SVGMobject.modify_xml_tree,
+    # which avoids viewBox unit conversions (e.g. pt to px for dvisvgm)
+    root = ET.fromstring(svg_string)
+    root.attrib.clear()
+    data_stream = io.BytesIO()
+    ET.ElementTree(root).write(data_stream)
+    data_stream.seek(0)
+    svg = se.SVG.parse(data_stream)
+    bbox = svg.bbox()
+    if bbox is None:
+        raise ValueError("SVG has no content to measure")
+    return bbox[3] - bbox[1]
+
+
 def _convert_point_to_3d(x: float, y: float) -> np.ndarray:
     return np.array([x, y, 0.0])
 


### PR DESCRIPTION
Rather than having a hard-coded TEXT_MOB_SCALE_FACTOR to determine text size, which causes discrepancies between different systems, let this scaling factor be determined dynamically.

- In the config files, a value is set for the font at which a "0" would render at height 1 (default to 144)
- On initialization, render a sample "0" to determine the relevant scaling factor. Cache so this only needs to happen once.
