### PR TITLE
Fix color leakage issue in shader rendering

### DIFF
--- a/manimlib/shaders/quadratic_bezier/fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier/fill/frag.glsl
@@ -29,7 +29,7 @@ void main() {
     cap is to make sure the original fragment color can be recovered even after
     blending with an (alpha = 1) color.
     */
-    float a = 0.95 * frag_color.a;
+    float a = 0.90 * frag_color.a;
     if(orientation < 0) a = -a / (1 - a);
     frag_color.a = a;
 


### PR DESCRIPTION
# Fix Color Leakage in Fragment Shader

## Motivation

While rendering overlapping triangles with opposite orientations,
minor color leakage artifacts were observed.

The issue was caused by aggressive alpha scaling in the fragment shader:

```glsl
float a = 0.95 * frag_color.a;
```
This resulted in excessive blending, especially when negatively oriented triangles were involved.

## Proposed Changes
- Alpha scaling factor was reduced from 0.95 to 0.90:
```glsl
float a = 0.90 * frag_color.a;
```
This lowers the blending strength and prevents unintended color bleed.
- Orientation-Based Alpha Correction
For negatively oriented triangles, the following transformation is used:
```latex
if (orientation < 0)
    a = -a / (1 - a);
```
Mathematically, the modified alpha value is:
`a' = -a / (1 - a)`
This ensures correct cancellation behavior under the standard blending equation:
(1 - alpha) * dst + alpha * src
The transformation guarantees that blending a positively oriented triangle followed by a negatively oriented one restores the original fragment color.

## Testing
- Render overlapping triangles with opposite orientations
- Verify no residual tint remains
- Confirm stable blending behavior
```python
from manimlib import *

class GlyphTest1(InteractiveScene):
    def construct(self):
        char = "B"
        t = TexText(char)
        t.set_height(FRAME_HEIGHT - 2)
        self.add(t)
```

## Result
- Cleaner blending
- No color leakage
- Stable fragment output

## Before
![IMG_20260214_124531](https://github.com/user-attachments/assets/d0c6f2ea-f9e7-4a28-b7f7-76654aef17d4)

![IMG_20260214_124517](https://github.com/user-attachments/assets/7a825f27-fde9-47ef-ae02-2e55ea4f87a5)

![IMG_20260214_124540](https://github.com/user-attachments/assets/e9c4847f-f0a7-41fa-9d29-ff601e2b5e11)


## After
<img width="2160" height="2160" alt="GlyphTest2" src="https://github.com/user-attachments/assets/f03ff266-f146-4925-8bfa-8d225026f02a" />
<img width="2160" height="2160" alt="GlyphTest15" src="https://github.com/user-attachments/assets/ff1bf322-1803-4949-9de0-b525c8e483ac" />
<img width="2160" height="2160" alt="GlyphTest17" src="https://github.com/user-attachments/assets/c6913b2f-0c59-4571-9a47-be1cfc8cb31d" />
