### PR TITLE
Fix shared reference issue in traced_points initialization

### DIFF
--- a/manimlib/mobject/changing.py
+++ b/manimlib/mobject/changing.py
@@ -173,4 +173,4 @@ class TracingTail(TracedPath):
         )
         curr_point = self.traced_point_func()
         n_points = int(self.time_traced / self.time_per_anchor)
-        self.traced_points: list[np.ndarray] = n_points * [curr_point]
+        self.traced_points: list[np.ndarray] = [curr_point.copy() for _ in range(n_points)]


### PR DESCRIPTION
## Motivation

While using `TracingTail`, I observed incorrect trail behavior.
The issue was caused by list multiplication during initialization:

```python
self.traced_points = n_points * [curr_point]
```
This creates multiple references to the same NumPy array instead of independent copies. As a result, updating one point updated all stored points, producing visual artifacts and incorrect tracing behavior.

This PR fixes the issue by ensuring each traced point is an independent copy.

## Proposed changes
- Replaced list multiplication with list comprehension.
- Ensured each stored traced point is created using .copy().
- Prevented shared mutable reference bug in TracingTail.

## Before
```python
self.traced_points: list[np.ndarray] = n_points * [curr_point]
```

## After
```python
self.traced_points: list[np.ndarray] = [
    curr_point.copy() for _ in range(n_points)
]
```
## Test
The issue can be reproduced using a simple pendulum example.

# Code
```python
from manimlib import *
import numpy as np

class SimplePendulum(Scene):
    def construct(self):
        # Parameters
        length = 3
        angle = -PI / 4
        origin = UP * 2

        # Pivot point
        pivot = Dot(origin)

        # Bob
        bob = Dot(radius=0.15, stroke_color=GREY)
        bob.move_to(origin + length * np.array([
            np.sin(angle),
            -np.cos(angle),
            0
        ]))

        # String
        string = always_redraw(
            lambda: Line(origin, bob.get_center(), stroke_color=WHITE)
        )

        # Trail
        trail = TracingTail(
            bob.get_center,
            time_traced=2.0,
            stroke_color=WHITE,
        )

        self.add(pivot, string, bob, trail)

        # Animation (oscillation)
        def update_bob(mob, dt):
            nonlocal angle
            angle += -0.8 * np.sin(angle) * dt
            mob.move_to(origin + length * np.array([
                np.sin(angle),
                -np.cos(angle),
                0
            ]))

        bob.add_updater(update_bob)

        self.wait(6)
```
## Result
# Before the fix:
- Trail points overlapped incorrectly.
- Multiple segments collapsed due to shared references.

![IMG_20260214_133548](https://github.com/user-attachments/assets/c1edd4ef-f106-44c2-8f0a-3577298e497d)


https://github.com/user-attachments/assets/4b6a922f-0ade-4fae-9635-6ad0dbf8dc11


# After the fix:
- Trail updates correctly.
- Each traced point is independent.
- No visual artifacts appear.

https://github.com/user-attachments/assets/a90800de-213e-48c3-8217-b6fab389b272

