### PR TITLE
Remove redundant `kwargs` handling in `LaggedStartMap`

### DIFF
--- a/manimlib/animation/composition.py
+++ b/manimlib/animation/composition.py
@@ -172,10 +172,8 @@ class LaggedStartMap(LaggedStart):
         lag_ratio: float = DEFAULT_LAGGED_START_LAG_RATIO,
         **kwargs
     ):
-        anim_kwargs = dict(kwargs)
-        anim_kwargs.pop("lag_ratio", None)
         super().__init__(
-            *(anim_func(submob, **anim_kwargs) for submob in group),
+            *(anim_func(submob, **kwargs) for submob in group),
             run_time=run_time,
             lag_ratio=lag_ratio,
             group=group


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->

`lag_ratio` is already an explicit parameter in the constructor of `LaggedStartMap` and directly forwarded to the super class, so it is never included in `**kwargs`. As a result, popping `lag_ratio` from `kwargs` is redundant.