### PR TITLE
fix: latex compilation error on windows

### DIFF
--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -118,7 +118,7 @@ def full_tex_to_svg(full_tex: str, compiler: str = "latex", message: str = ""):
         text=True
     )
 
-    if process.returncode != 0:
+    if process.returncode != 0 and not dvi_path.exists():
         # Handle error
         error_str = ""
         log_path = tex_path.with_suffix(".log")


### PR DESCRIPTION
## Fix: LaTeX compilation error on Windows (#2002)

### Summary
Fixes a Windows-specific bug where `full_tex_to_svg()` incorrectly raises `LatexError` even when LaTeX compilation succeeds and the DVI file is produced. This prevented any scene using `Tex`, `MathTex`, or `Matrix` objects from rendering on Windows.

### Root cause
TeX Live / TinyTeX on Windows returns a non-zero exit code from `subprocess.run()` with `capture_output=True`, even on successful compilation. The old logic treated any non-zero exit code as a failure.

### Fix
Added a second condition to the error check in `manimlib/utils/tex_file_writing.py`:

**Before:**
```python
if returncode != 0:
    raise LatexError(...)
```

**After:**
```python
if returncode != 0 and not dvi_path.exists():
    raise LatexError(...)
```

A missing DVI file unambiguously indicates genuine compilation failure. If the DVI exists, compilation succeeded regardless of exit code, and the pipeline continues to `dvisvgm`.

### Files changed
- `manimlib/utils/tex_file_writing.py` — core fix in `full_tex_to_svg()`

### Preconditions to reproduce the issue
- Windows OS
- Master ManimGL 1.6.1
- Python 3.10.4
- TeX Live / TinyTeX installed with `latex` and `dvisvgm` on `PATH`
- Scene using `Tex`, `MathTex`, or `Matrix` objects