### PR TITLE
Fix/staticmethod callable python 3 10 #2263

### DIFF
--- a/fix_staticmethod_python310.patch
+++ b/fix_staticmethod_python310.patch
@@ -1,0 +1,62 @@
+diff --git a/manimlib/mobject/mobject.py b/manimlib/mobject/mobject.py
+index 7a5253ac..450eae3f 100644
+--- a/manimlib/mobject/mobject.py
++++ b/manimlib/mobject/mobject.py
+@@ -212,7 +212,6 @@ class Mobject(object):
+                 mob.note_changed_data()
+         return self
+ 
+-    @staticmethod
+     def affects_data(func: Callable[..., T]) -> Callable[..., T]:
+         @wraps(func)
+         def wrapper(self, *args, **kwargs):
+@@ -221,7 +220,6 @@ class Mobject(object):
+             return result
+         return wrapper
+ 
+-    @staticmethod
+     def affects_family_data(func: Callable[..., T]) -> Callable[..., T]:
+         @wraps(func)
+         def wrapper(self, *args, **kwargs):
+@@ -632,7 +630,6 @@ class Mobject(object):
+ 
+     # Copying and serialization
+ 
+-    @staticmethod
+     def stash_mobject_pointers(func: Callable[..., T]) -> Callable[..., T]:
+         @wraps(func)
+         def wrapper(self, *args, **kwargs):
+@@ -1905,7 +1902,6 @@ class Mobject(object):
+ 
+     # Operations touching shader uniforms
+ 
+-    @staticmethod
+     def affects_shader_info_id(func: Callable[..., T]) -> Callable[..., T]:
+         @wraps(func)
+         def wrapper(self, *args, **kwargs):
+diff --git a/manimlib/scene/scene.py b/manimlib/scene/scene.py
+index defeaa68..4beb8585 100644
+--- a/manimlib/scene/scene.py
++++ b/manimlib/scene/scene.py
+@@ -315,7 +315,6 @@ class Scene(object):
+             for batch, key in batches
+         ]
+ 
+-    @staticmethod
+     def affects_mobject_list(func: Callable[..., T]) -> Callable[..., T]:
+         @wraps(func)
+         def wrapper(self, *args, **kwargs):
+diff --git a/manimlib/shader_wrapper.py b/manimlib/shader_wrapper.py
+index 154cb60f..51c11799 100644
+--- a/manimlib/shader_wrapper.py
++++ b/manimlib/shader_wrapper.py
+@@ -431,8 +431,8 @@ class VShaderWrapper(ShaderWrapper):
+         gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+ 
+     # Static method returning one shared value across all VShaderWrappers
+-    @lru_cache
+     @staticmethod
++    @lru_cache()
+     def get_fill_canvas(ctx: moderngl.Context) -> Tuple[Framebuffer, VertexArray, Framebuffer]:
+         """
+         Because VMobjects with fill are rendered in a funny way, using

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -212,7 +212,6 @@ class Mobject(object):
                 mob.note_changed_data()
         return self
 
-    @staticmethod
     def affects_data(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(self, *args, **kwargs):
@@ -221,7 +220,6 @@ class Mobject(object):
             return result
         return wrapper
 
-    @staticmethod
     def affects_family_data(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(self, *args, **kwargs):
@@ -632,7 +630,6 @@ class Mobject(object):
 
     # Copying and serialization
 
-    @staticmethod
     def stash_mobject_pointers(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(self, *args, **kwargs):
@@ -1905,7 +1902,6 @@ class Mobject(object):
 
     # Operations touching shader uniforms
 
-    @staticmethod
     def affects_shader_info_id(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(self, *args, **kwargs):

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -315,7 +315,6 @@ class Scene(object):
             for batch, key in batches
         ]
 
-    @staticmethod
     def affects_mobject_list(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(self, *args, **kwargs):

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -431,8 +431,8 @@ class VShaderWrapper(ShaderWrapper):
         gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
 
     # Static method returning one shared value across all VShaderWrappers
-    @lru_cache
     @staticmethod
+    @lru_cache()
     def get_fill_canvas(ctx: moderngl.Context) -> Tuple[Framebuffer, VertexArray, Framebuffer]:
         """
         Because VMobjects with fill are rendered in a funny way, using

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -143,7 +143,6 @@ class Window(PygletWindow):
         super().swap_buffers()
         self._has_undrawn_event = False
 
-    @staticmethod
     def note_undrawn_event(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(self, *args, **kwargs):


### PR DESCRIPTION
## Motivation
ManimGL fails to import on Python < 3.10 with TypeError: 'staticmethod' object is not callable.

Multiple functions across the codebase are declared with @staticmethod
and then used as decorators on other methods inside the same class body.
Prior to Python 3.10, staticmethod objects were not callable, making
this pattern invalid.

Fixes #2263

## Proposed changes
- Removed @staticmethod from note_undrawn_event in manimlib/window.py
- Removed @staticmethod from affects_data, affects_family_data, stash_mobject_pointers, affects_shader_info_id in manimlib/mobject/mobject.py
- Removed @staticmethod from affects_mobject_list in manimlib/scene/scene.py
- Fixed @lru_cache to @lru_cache() in manimlib/shader_wrapper.py

## Test
**Code**:
`python -c "from manimlib import *"`

**Result**: Import completes successfully on Python 3.9.25 with no TypeError.
The ffmpeg RuntimeWarning is expected and unrelated to this fix.

**Before:**
<img width="1260" height="282" alt="image" src="https://github.com/user-attachments/assets/a7a62a76-13d9-4ff6-83b4-70db779d4777" />

**After:**
<img width="1453" height="117" alt="image" src="https://github.com/user-attachments/assets/9f1e6667-a1a6-493e-961a-3a446cc76a7c" />
