### PR TITLE
Add Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,60 @@ manimgl example_scenes.py OpeningManimExample
 manim-render example_scenes.py OpeningManimExample
 ```
 
+### Linux (Ubuntu/Debian)
+
+1. Install system dependencies.
+
+```sh
+sudo apt update
+
+sudo apt install ffmpeg
+sudo apt install python3-pip
+sudo apt install libpango1.0-dev
+```
+
+2. Install a lightweight LaTeX distribution (optional, for LaTeX rendering).
+
+```sh
+sudo apt install texlive-science texlive-fonts-extra texlive-latex-extra
+```
+
+This lightweight setup is significantly smaller than installing `texlive-full`
+while still supporting most Manim projects.
+
+3. Clone and install ManimGL.
+
+```sh
+git clone https://github.com/3b1b/manim.git
+cd manim
+
+python3 -m pip install -e .
+
+manimgl example_scenes.py OpeningManimExample
+```
+
+<details>
+  <summary>💡 Optional: Using a virtual environment (venv)</summary>
+
+It is recommended to use a virtual environment to avoid conflicts with system packages.
+
+```sh
+sudo apt install python3-venv
+
+python3 -m venv venv
+source venv/bin/activate
+
+python3 -m pip install -e .
+```
+
+If `python3-venv` is unavailable on your system, try installing the version-specific package instead:
+
+```sh
+sudo apt install python3.12-venv
+```
+
+</details>
+
 ### Directly (Windows)
 
 1. [Install FFmpeg](https://www.wikihow.com/Install-FFmpeg-on-Windows).


### PR DESCRIPTION
Added installation instructions for Linux (Ubuntu/Debian), including required system dependencies, optional lightweight LaTeX setup, and optional virtual environment (venv) instructions.

## Motivation

The README currently contains installation instructions for Windows and MacOS, but lacks a dedicated Linux installation section. This change adds clearer setup instructions for Ubuntu/Debian-based distributions, making it easier for Linux users to get started with ManimGL.

It also documents a lightweight LaTeX installation alternative instead of requiring the much larger texlive-full package.

## Proposed changes

- Added a dedicated Linux (Ubuntu/Debian) installation section
- Added installation steps for required system dependencies (ffmpeg, python3-pip, libpango1.0-dev)
- Added optional lightweight LaTeX installation instructions
- Added optional virtual environment (venv) setup instructions

### Lightweight LaTeX alternative

Instead of installing the much larger texlive-full package, the following lightweight setup was documented:

```sh
sudo apt install texlive-science texlive-fonts-extra texlive-latex-extra 
```

This setup was sufficient for rendering LaTeX in ManimGL during testing while requiring significantly less disk space compared to texlive-full.

> Screenshot attached below showing the approximate package size/install size during setup.
<img width="576" height="1280" alt="IMG_2423" src="https://github.com/user-attachments/assets/c0acc747-e16c-4af0-94bc-33fef5590225" />


## Test

Code:

```sh
sudo apt update

sudo apt install ffmpeg
sudo apt install python3-pip
sudo apt install libpango1.0-dev

sudo apt install texlive-science texlive-fonts-extra texlive-latex-extra

git clone https://github.com/3b1b/manim.git
cd manim

python3 -m pip install -e .
manimgl example_scenes.py OpeningManimExample 
```
Result:

ManimGL installed successfully and example scenes rendered correctly on Ubuntu/Debian-based Linux systems.