### PR TITLE
fix(latex): convert tex file Path to POSIX format for Windows compatibility

### DIFF
--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -38,13 +38,18 @@ def get_tex_config(template: str = "") -> tuple[str, str]:
 
 
 def get_full_tex(content: str, preamble: str = ""):
-    return "\n\n".join((
-        "\\documentclass[preview]{standalone}",
-        preamble,
-        "\\begin{document}",
-        content,
-        "\\end{document}"
-    )) + "\n"
+    return (
+        "\n\n".join(
+            (
+                "\\documentclass[preview]{standalone}",
+                preamble,
+                "\\begin{document}",
+                content,
+                "\\end{document}",
+            )
+        )
+        + "\n"
+    )
 
 
 @lru_cache(maxsize=128)
@@ -95,7 +100,7 @@ def full_tex_to_svg(full_tex: str, compiler: str = "latex", message: str = ""):
 
     # Use the custom LaTeX cache directory from the config
     temp_dir = Path(manim_config.directories.latex_cache)
-    temp_dir.mkdir(exist_ok=True) # Create the directory if it does not already exist
+    temp_dir.mkdir(exist_ok=True)  # Create the directory if it does not already exist
 
     # Define paths for the intermediate TeX and DVI files
     tex_path = temp_dir / "working.tex"
@@ -108,14 +113,14 @@ def full_tex_to_svg(full_tex: str, compiler: str = "latex", message: str = ""):
     process = subprocess.run(
         [
             compiler,
-            *(['-no-pdf'] if compiler == "xelatex" else []),
+            *(["-no-pdf"] if compiler == "xelatex" else []),
             "-interaction=batchmode",
             "-halt-on-error",
             f"-output-directory={temp_dir}",
-            tex_path
+            tex_path.as_posix(),
         ],
         capture_output=True,
-        text=True
+        text=True,
     )
 
     if process.returncode != 0:
@@ -135,14 +140,15 @@ def full_tex_to_svg(full_tex: str, compiler: str = "latex", message: str = ""):
             "dvisvgm",
             dvi_path,
             "-n",  # no fonts
-            "-v", "0",  # quiet
+            "-v",
+            "0",  # quiet
             "--stdout",  # output to stdout instead of file
         ],
-        capture_output=True
+        capture_output=True,
     )
 
     # Return SVG string
-    result = process.stdout.decode('utf-8')
+    result = process.stdout.decode("utf-8")
 
     if message:
         print(" " * len(message), end="\r")


### PR DESCRIPTION
Closes #2440 

<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
As discussed in #2440, when initializing the `TeX` class on Windows, TeX engines fail to locate the generated `.tex` file due to the native backslash (`\`) path separators. This triggers a `LatexError(error_str or "LaTeX compilation failed")`, whereas the execution succeeds normally on macOS and Linux.

Converting the path to POSIX format resolves this platform-specific rendering failure.

## Proposed changes
<!-- What you changed in those files -->
- Use `tex_path.as_posix()` to ensure forward slashes (`/`) are consistently used for TeX engine compatibility across all platforms.
- Automatically formatted the modified file using [Black](https://github.com/psf/black) on save.

*(Note: My editor automatically applied Black formatting to this file upon saving. I kept it as it helps maintain a clean and consistent code style, but if you prefer to keep the original formatting to avoid unrelated diffs, please let me know, and I am more than happy to revert the style-only changes!)*

## Test
<!-- How do you test your changes -->
**Code**:
```python
from manimlib import *


class Test(Scene):
    def construct(self):
        tex = Tex("Hello")
        self.add(tex)
```

**Result**:
TeX engines can now render LaTeX content successfully on Windows without throwing `LatexError`.

Thanks for your time and review!