### PR TITLE
docs: clarify Manim project choice

### DIFF
--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -3,6 +3,20 @@ Contributing
 
 Accept any contribution you make :)
 
+Choose the right Manim project first
+------------------------------------
+
+This repository is the ManimGL version used by 3Blue1Brown. It focuses on
+OpenGL rendering, interactive workflows, and the needs of the videos in
+`3b1b/videos <https://github.com/3b1b/videos>`_. Pull requests are welcome here,
+but reviews can take some time.
+
+For broad community features, packaging changes, or beginner-oriented
+documentation, also consider
+`ManimCommunity/manim <https://github.com/ManimCommunity/manim>`_, which has a
+larger contributor workflow and more active community review. If your change is
+specific to ManimGL, keep it in this repository.
+
 - **Contribute to the manim source code**: 
 
 Please fork to your own repository and make changes, submit a pull request, and fill in 

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -1,6 +1,13 @@
 Quick Start
 ===========
 
+This quick start is for ManimGL, the OpenGL-based version maintained in
+`3b1b/manim <https://github.com/3b1b/manim>`_. If you are looking for the
+Community Edition, install and follow the docs from
+`ManimCommunity/manim <https://github.com/ManimCommunity/manim>`_ instead.
+The two projects use different package names and setup instructions, so choose
+the version you want before installing dependencies or copying examples.
+
 After installing the manim environment according to the instructions on the
 :doc:`installation` page, you can try to make a scene yourself from scratch.
 
@@ -253,4 +260,3 @@ You succeeded!
 After reading the above content, you already know how to use manim.
 Below you can see some examples, in the :doc:`example_scenes` page.
 But before that, you'd better have a look at the :doc:`configuration` of manim.
-


### PR DESCRIPTION
## Motivation
New contributors can easily land on this repository while looking for either ManimGL or Manim Community Edition. This clarifies the project split before users install dependencies, copy examples, or decide where to open a contribution.

Refs #1243

## Proposed changes
- Add an early quickstart note that this documentation is for ManimGL in `3b1b/manim`.
- Add a contribution-page section describing when to contribute here versus `ManimCommunity/manim`.
- Preserve the existing contribution instructions after the new clarification.

## Test
**Code**:

`git diff --check`

`python3 -m sphinx.cmd.build -W -b html docs/source docs/build/html`

**Result**:

`git diff --check` passes.

The Sphinx build could not be run locally because `sphinx` is not installed in the available Python environment.
