### PR TITLE
Clarify how stroke width and anti-alias width convert to drawn coordi…

### DIFF
--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -90,7 +90,10 @@ class VMobject(Mobject):
         # Could also be "no_joint", "bevel", "miter"
         joint_type: str = "auto",
         flat_stroke: bool = False,
-        scale_stroke_with_zoom: bool = False,
+        # If false, stroke width is measured relative to the frame, so that a given
+        # width looks the same at any zoom level. If true, it's measured relative to
+        # the scene, so that zooming in makes the stroke look thicker.
+        stroke_width_in_scene_units: bool = False,
         use_simple_quadratic_approx: bool = False,
         # Measured in pixel widths
         anti_alias_width: float = 1.5,
@@ -107,7 +110,7 @@ class VMobject(Mobject):
         self.long_lines = long_lines
         self.joint_type = joint_type
         self.flat_stroke = flat_stroke
-        self.scale_stroke_with_zoom = scale_stroke_with_zoom
+        self.stroke_width_in_scene_units = stroke_width_in_scene_units
         self.use_simple_quadratic_approx = use_simple_quadratic_approx
         self.anti_alias_width = anti_alias_width
         self.fill_border_width = fill_border_width
@@ -130,7 +133,7 @@ class VMobject(Mobject):
             anti_alias_width=self.anti_alias_width,
             joint_type=self.joint_type_map[self.joint_type],
             flat_stroke=float(self.flat_stroke),
-            scale_stroke_with_zoom=float(self.scale_stroke_with_zoom)
+            stroke_width_in_scene_units=float(self.stroke_width_in_scene_units)
         )
 
     def add(self, *vmobjects: VMobject) -> Self:
@@ -430,12 +433,19 @@ class VMobject(Mobject):
     def get_flat_stroke(self) -> bool:
         return self.uniforms["flat_stroke"] == 1.0
 
+    def set_stroke_width_in_scene_units(self, value: bool = True, recurse: bool = True) -> Self:
+        self.set_uniform(recurse, stroke_width_in_scene_units=float(value))
+        return self
+
+    def get_stroke_width_in_scene_units(self) -> bool:
+        return self.uniforms["stroke_width_in_scene_units"] == 1.0
+
+    # Old names, kept so that existing scenes don't break
     def set_scale_stroke_with_zoom(self, scale_stroke_with_zoom: bool = True, recurse: bool = True) -> Self:
-        self.set_uniform(recurse, scale_stroke_with_zoom=float(scale_stroke_with_zoom))
-        pass
+        return self.set_stroke_width_in_scene_units(scale_stroke_with_zoom, recurse)
 
     def get_scale_stroke_with_zoom(self) -> bool:
-        return self.uniforms["flat_stroke"] == 1.0
+        return self.get_stroke_width_in_scene_units()
 
     def set_joint_type(self, joint_type: str, recurse: bool = True) -> Self:
         for mob in self.get_family(recurse):

--- a/manimlib/shaders/inserts/emit_gl_Position.glsl
+++ b/manimlib/shaders/inserts/emit_gl_Position.glsl
@@ -1,4 +1,3 @@
-uniform float is_fixed_in_frame;
 uniform mat4 view;
 uniform float focal_distance;
 uniform vec3 frame_rescale_factors;
@@ -6,6 +5,8 @@ uniform vec4 clip_plane0;
 uniform vec4 clip_plane1;
 uniform vec4 clip_plane2;
 uniform vec4 clip_plane3;
+
+#INSERT frame_units.glsl
 
 void emit_gl_Position(vec3 point){
     vec4 result = vec4(point, 1.0);

--- a/manimlib/shaders/inserts/frame_units.glsl
+++ b/manimlib/shaders/inserts/frame_units.glsl
@@ -1,0 +1,24 @@
+uniform float frame_scale;
+uniform float pixel_size;
+uniform float is_fixed_in_frame;
+
+/*
+Points fixed in frame skip the view matrix (see emit_gl_Position), so they are drawn
+in the coordinates of a default scale frame, whereas everything else is drawn in scene
+coordinates. The functions below give the size, in whichever of those two spaces is
+being drawn, of the units a screen relative length might be measured in, so that such
+lengths can be converted without any dependence on the camera's zoom level.
+*/
+
+
+float get_frame_unit_size(){
+    // Size of one unit of a default scale frame
+    return mix(frame_scale, 1.0, is_fixed_in_frame);
+}
+
+
+float get_pixel_unit_size(){
+    // Size of one pixel. Note that pixel_size is measured in scene coordinates,
+    // so it must be scaled back down for points fixed in frame.
+    return pixel_size * get_frame_unit_size() / frame_scale;
+}

--- a/manimlib/shaders/quadratic_bezier/stroke/geom.glsl
+++ b/manimlib/shaders/quadratic_bezier/stroke/geom.glsl
@@ -5,9 +5,7 @@ layout (triangle_strip, max_vertices = 64) out;  // Related to MAX_STEPS below
 
 uniform float anti_alias_width;
 uniform float flat_stroke;
-uniform float pixel_size;
 uniform float joint_type;
-uniform float frame_scale;
 
 in vec3 verts[3];
 
@@ -141,7 +139,8 @@ void emit_point_with_width(
     // Figure out the step from the point to the corners of the
     // triangle strip around the polyline
     vec3 step = step_to_corner(point, tangent, unit_normal, joint_angle, inside_curve, draw_flat);
-    float aaw = max(anti_alias_width * pixel_size, 1e-8);
+    // anti_alias_width is measured in pixels
+    float aaw = max(anti_alias_width * get_pixel_unit_size(), 1e-8);
 
     // Emit two corners
     // The frag shader will receive a value from -1 to 1,
@@ -175,7 +174,7 @@ void main() {
     // Estimate how many line segment the curve should be divided into
     // based on the area of the triangle defined by these control points
     float area = 0.5 * length(cross(verts[1] - verts[0], verts[2] - verts[0]));
-    int count = int(round(POLYLINE_FACTOR * sqrt(area) / frame_scale));
+    int count = int(round(POLYLINE_FACTOR * sqrt(area) / get_frame_unit_size()));
     int n_steps = min(2 + count, MAX_STEPS);
 
     // Emit vertex pairs aroudn subdivided points

--- a/manimlib/shaders/quadratic_bezier/stroke/vert.glsl
+++ b/manimlib/shaders/quadratic_bezier/stroke/vert.glsl
@@ -1,8 +1,6 @@
 #version 330
 
-uniform float frame_scale;
-uniform float is_fixed_in_frame;
-uniform float scale_stroke_with_zoom;
+uniform float stroke_width_in_scene_units;
 
 in vec3 point;
 in vec4 stroke_rgba;
@@ -18,12 +16,24 @@ out float v_stroke_width;
 out float v_joint_angle;
 out vec3 v_unit_normal;
 
+// Number of units spanned by a stroke_width of 1 in a default scale frame,
+// so for instance a stroke_width of 100 comes out one unit thick
 const float STROKE_WIDTH_CONVERSION = 0.01;
+
+#INSERT frame_units.glsl
 
 void main(){
     verts = point;
     v_color = stroke_rgba;
-    v_stroke_width = STROKE_WIDTH_CONVERSION * stroke_width * mix(frame_scale, 1, scale_stroke_with_zoom);
+    // By default stroke width is measured relative to the frame, so putting it in the
+    // units of the space being drawn means scaling by that space's frame size, which
+    // keeps a given stroke width looking the same at any zoom level. When it's measured
+    // relative to the scene instead, no such conversion is needed, and zooming in makes
+    // the stroke look thicker.
+    float stroke_width_factor = STROKE_WIDTH_CONVERSION * mix(
+        get_frame_unit_size(), 1.0, stroke_width_in_scene_units
+    );
+    v_stroke_width = stroke_width_factor * stroke_width;
     v_joint_angle = joint_angle;
     v_unit_normal = unit_normal;
 }

--- a/manimlib/shaders/true_dot/geom.glsl
+++ b/manimlib/shaders/true_dot/geom.glsl
@@ -3,9 +3,7 @@
 layout (points) in;
 layout (triangle_strip, max_vertices = 4) out;
 
-uniform float pixel_size;
 uniform float anti_alias_width;
-uniform float frame_scale;
 uniform vec3 camera_position;
 
 in vec3 v_point[1];
@@ -26,7 +24,7 @@ void main(){
     color = v_rgba[0];
     radius = v_radius[0];
     center = v_point[0];
-    scaled_aaw = (anti_alias_width * pixel_size) / v_radius[0];
+    scaled_aaw = (anti_alias_width * get_pixel_unit_size()) / v_radius[0];
 
     to_cam = normalize(camera_position - v_point[0]);
     vec3 right = v_radius[0] * normalize(cross(vec3(0, 1, 1), to_cam));


### PR DESCRIPTION
Clarify how stroke width and anti-alias width convert to drawn coordinates

Both are screen-relative lengths applied to points in world space, so each needs
scaling by the camera zoom, but in opposite directions: stroke width is measured
in units of a default scale frame, whereas anti_alias_width is measured in pixels
and pixel_size already accounts for the frame size. Points fixed in frame skip the view matrix, and so need the reverse of both corrections again.

Previously each call site rederived this, mostly wrongly. Now a single insert,
frame_units.glsl, owns frame_scale, pixel_size and is_fixed_in_frame, and exposes get_frame_unit_size and get_pixel_unit_size for the two conversions. Consequences:

- Anti-aliasing no longer widens as the camera zooms out from a mobject fixed in
  frame, for both stroke and true dots.
- Curves fixed in frame are no longer subdivided based on the camera zoom.
- scale_stroke_with_zoom becomes stroke_width_in_scene_units, naming the unit that stroke width is measured in rather than one consequence of that choice, and it now takes effect for mobjects not fixed in frame. The old setter and getter remain as aliases.

Also fixes set_scale_stroke_with_zoom failing to return self, and
get_scale_stroke_with_zoom reading the flat_stroke uniform.