### PR TITLE
Make formatting for copied frame orientation more universal

### DIFF
--- a/manimlib/scene/interactive_scene.py
+++ b/manimlib/scene/interactive_scene.py
@@ -644,15 +644,14 @@ class InteractiveScene(Scene):
         height = frame.get_height()
         angles = frame.get_euler_angles()
 
-        call = f"reorient("
-        theta, phi, gamma = (angles / DEG).astype(int)
-        call += f"{theta}, {phi}, {gamma}"
+        call = "reorient("
+        call += "%d, %d, %d" % tuple(angles / DEG)
         if any(center != 0):
-            call += f", {tuple(np.round(center, 2))}"
+            call += ", (%.2f, %.2f, %.2f)" % tuple(center)
         if height != FRAME_HEIGHT:
-            call += ", {:.2f}".format(height)
+            call += ", %.2f" % height
         call += ")"
         pyperclip.copy(call)
 
     def copy_cursor_position(self):
-        pyperclip.copy(str(tuple(self.mouse_point.get_center().round(2))))
+        pyperclip.copy("(%.2f, %.2f, %.2f)" % tuple(self.mouse_point.get_center()))


### PR DESCRIPTION
For copying a camera position, previously, different systems could copy different strings, e.g. "3.14" on one and "np.float32(3.14)" on another.