### PR TITLE
Smooth out two sources of hard edges in VMobject rendering

### DIFF
--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -479,6 +479,7 @@ class VShaderWrapper(ShaderWrapper):
         if self.stroke_vao is None:
             return
         set_program_uniform(self.stroke_program, "is_fill_border", False)
+        set_program_uniform(self.stroke_program, "fill_border_inside", False)
         self.stroke_vao.render(vertices=self.stroke_verts_per_curve * self.get_num_curves())
 
     def render_fill(self):
@@ -524,14 +525,31 @@ class VShaderWrapper(ShaderWrapper):
 
         # Trace the boundary of the shape with a stroke in the fill color, which
         # is what anti-aliases the fill, since a stencil test is all or nothing.
-        # It's drawn only where the winding number is zero, meaning outside the
-        # shape, both because the inside is about to be filled in anyway, and so
-        # that its faded edge never blends on top of the fill, which would leave
-        # a seam along the boundary for partially transparent colors.
+        # A pixel the boundary crosses should come out partly covered either way
+        # it falls, so the band is drawn over both sides of the path, in two
+        # passes told apart by the winding number: outside the shape it fades
+        # away, and inside it fades up to full. Each pass covers only what the
+        # other does not, so no pixel is blended into twice, which would leave a
+        # seam along the boundary for partially transparent colors.
         set_program_uniform(self.stroke_program, "is_fill_border", True)
+        n_stroke_verts = self.stroke_verts_per_curve * self.get_num_curves()
+
+        # Outside the shape. This leaves the stencil alone, so that the pass
+        # below still finds the winding numbers it needs to test against.
+        set_program_uniform(self.stroke_program, "fill_border_inside", False)
         gl.glStencilFunc(gl.GL_EQUAL, 0, 0xFF)
         gl.glStencilOp(gl.GL_KEEP, gl.GL_KEEP, gl.GL_KEEP)
-        self.stroke_vao.render(vertices=self.stroke_verts_per_curve * self.get_num_curves())
+        self.stroke_vao.render(vertices=n_stroke_verts)
+
+        # Inside the shape, zeroing the winding number as it goes so that the
+        # cover pass below skips these pixels and lets this partial coverage
+        # stand, rather than painting over them at full opacity. Zeroing also
+        # keeps overlapping bands, such as those meeting at a joint, from
+        # blending on top of one another.
+        set_program_uniform(self.stroke_program, "fill_border_inside", True)
+        gl.glStencilFunc(gl.GL_NOTEQUAL, 0, 0xFF)
+        gl.glStencilOp(gl.GL_KEEP, gl.GL_ZERO, gl.GL_ZERO)
+        self.stroke_vao.render(vertices=n_stroke_verts)
 
         # Pass 2: Color in everywhere the winding number is nonzero. Zeroing the
         # stencil on the way through means the first triangle to cover a pixel

--- a/manimlib/shaders/quadratic_bezier/stroke/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier/stroke/frag.glsl
@@ -1,6 +1,17 @@
 #version 330
 
 
+/*
+When the stroke is tracing the border of a fill, it gets drawn twice: once
+outside the shape and once inside it. Which of the two a fragment belongs to is
+settled by the stencil, not by anything geometric, since the path's orientation
+decides which side of a curve the interior lies on and the shader has no way to
+know it. Outside, the band carries the falling half of the coverage ramp, and
+inside the rising half, so that the two together make a single smooth
+transition centered on the path.
+*/
+uniform bool fill_border_inside;
+
 // Distance to the curve, and half the curve width, both as
 // a ratio of the antialias width
 in float dist_to_aaw;
@@ -11,9 +22,14 @@ out vec4 frag_color;
 
 void main() {
     frag_color = color;
-    // sdf for the region around the curve we wish to color.
-    float signed_dist_to_region = abs(dist_to_aaw) - half_width_to_aaw;
-    frag_color.a *= smoothstep(0.5, -0.5, signed_dist_to_region);
+    float dist = abs(dist_to_aaw);
+    // sdf for the region around the curve we wish to color. Inside a fill, the
+    // band is measured from the far edge of the stroke rather than the near one,
+    // so that a border wide enough to cover the fragment leaves it fully opaque.
+    float coverage = fill_border_inside ?
+        1.0 - smoothstep(0.5, -0.5, dist + half_width_to_aaw) :
+        smoothstep(0.5, -0.5, dist - half_width_to_aaw);
+    frag_color.a *= coverage;
     // This line is replaced in VShaderWrapper
     // MODIFY FRAG COLOR
 }

--- a/manimlib/shaders/quadratic_bezier/stroke/vert.glsl
+++ b/manimlib/shaders/quadratic_bezier/stroke/vert.glsl
@@ -19,6 +19,15 @@ const float POLYLINE_FACTOR = 100;
 const int MAX_STEPS = 32;
 // Stands in for a record index where there is no neighboring curve to read
 const int NONE = -1;
+/*
+Shorter than this and a vector holds no direction worth reading. Squaring
+components that small to take a length underflows to zero, so normalizing one
+gives NaN, and a single NaN position quietly drops every triangle it touches.
+Points that are meant to coincide, such as the anchor and handle marking the end
+of a curve, come to rest a hair apart this often enough that testing them for
+equality will miss them, so everything degenerate is measured against this instead.
+*/
+const float DEGENERATE_LENGTH = 1e-12;
 // Over this range of turn cosines, a joint eases from a sharp miter to a round end
 const float ROUND_COS_START = -0.5;
 const float ROUND_COS_END = -0.95;
@@ -81,7 +90,7 @@ vec3 neighbor_tangent(int record, bool at_start, vec3 anchor){
     vec2 subpath_range = read_vec2(record, DATA_OFFSET_subpath_range);
     int first = int(subpath_range.x);
     int last = int(subpath_range.y);
-    bool closed = read_vec3(first, DATA_OFFSET_point) == read_vec3(last, DATA_OFFSET_point);
+    bool closed = length(read_vec3(first, DATA_OFFSET_point) - read_vec3(last, DATA_OFFSET_point)) < DEGENERATE_LENGTH;
     if (at_start){
         int prev = record > first ? record - 1 : (closed ? last - 1 : NONE);
         return prev == NONE ? vec3(0.0) : anchor - read_vec3(prev, DATA_OFFSET_point);
@@ -97,7 +106,7 @@ bool flatten_tangent(vec3 tangent, vec3 facing_normal, out vec3 result){
     no direction to work with and so no joint to make.
     */
     vec3 flat_tan = project(tangent, facing_normal);
-    if (flat_tan == vec3(0.0)) return false;
+    if (length(flat_tan) < DEGENERATE_LENGTH) return false;
     result = normalize(flat_tan);
     return true;
 }
@@ -188,7 +197,7 @@ void main(){
     joint that has no neighbor to turn towards. Collapsing all six corners onto one
     point leaves no area to rasterize.
     */
-    bool blank = (controls[0] == controls[1]);
+    bool blank = (length(controls[1] - controls[0]) < DEGENERATE_LENGTH);
     blank = blank || (!joint_fan && segment >= n_steps - 1);
     if (!is_fill_border){
         blank = blank || (vec3(widths[0], widths[1], widths[2]) == vec3(0.0));
@@ -207,6 +216,10 @@ void main(){
     float t = joint_fan ? 1.0 : float(index) / float(n_steps - 1);
     vec3 point = joint_fan ? controls[2] : point_on_quadratic(t, c0, c1, c2);
     vec3 tangent = tangent_on_quadratic(t, c1, c2);
+    // Where the handle has come to rest on the anchor at this end, the tangent
+    // vanishes and leaves no direction to step away from. Such a curve is a straight
+    // run between its anchors, so the chord across it is the direction wanted.
+    if (length(tangent) < DEGENERATE_LENGTH) tangent = controls[2] - controls[0];
 
     // By default stroke width is measured relative to the frame, so putting it in
     // the units of the space being drawn means scaling by that space's frame
@@ -234,7 +247,7 @@ void main(){
     bool at_start = !joint_fan && index == 0;
     bool at_joint = joint_fan || at_start || index == n_steps - 1;
     vec3 neighbor = at_joint ? neighbor_tangent(record, at_start, point) : vec3(0.0);
-    bool has_joint = at_joint && neighbor != vec3(0.0);
+    bool has_joint = at_joint && length(neighbor) > DEGENERATE_LENGTH;
 
     /*
     Measured from the incoming tangent to the outgoing one either way, so at a curve's


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
VMobject's rendering has significantly improved its rendering, but there was still something to improve: anti-aliasing.

I wrote the following Python script:

```py
import manimlib as m


class MyInteractiveScene(m.InteractiveScene):
    drag_to_pan: bool = False

    def setup(self) -> None:
        super().setup()
        self.camera.background_rgba = [0, 0, 0, 1]

    def construct(self) -> None:
        linear_algebra = m.TexText("Álgebra Lineal", additional_preamble=r"\usepackage{mlmodern}").scale(3).to_edge(m.UP).shift(m.LEFT * 2).rotate(7*m.DEGREES)
        matrix_times_vector = m.Tex(r"\mathbf{A}\mathbf{x} = \mathbf{b}", additional_preamble=r"\usepackage{mlmodern}").scale(3).to_edge(m.DOWN, buff=1).shift(3*m.RIGHT)
        matrix_times_vector.rotate(14*m.DEGREES)
        num_plane = m.NumberPlane(x_range=[-5, 5, 1], y_range=[-2, 2, 1])
        p1_1 = [-5, -1, 0]
        p1_2 = [5, 1.5, 0]
        p2_1 = [-5, 1.5, 0]
        p2_2 = [5, -0.5, 0]
        coefficients_1 = [
            (p1_2[1] - p1_1[1]) / (p1_2[0] - p1_1[0]),
            p1_1[1] - ((p1_2[1] - p1_1[1]) / (p1_2[0] - p1_1[0])) * p1_1[0],
        ]
        coefficients_2 = [
            (p2_2[1] - p2_1[1]) / (p2_2[0] - p2_1[0]),
            p2_1[1] - ((p2_2[1] - p2_1[1]) / (p2_2[0] - p2_1[0])) * p2_1[0]
        ]
        intersection_x = (coefficients_2[1] - coefficients_1[1]) / (coefficients_1[0] - coefficients_2[0])
        intersection_y = coefficients_1[0] * intersection_x + coefficients_1[1]
        line1 = m.Line(start=p1_1, end=p1_2, stroke_color=m.YELLOW, stroke_width=4)
        line2 = m.Line(start=p2_1, end=p2_2, stroke_color=m.YELLOW, stroke_width=4)
        dot = m.GlowDot(center=[intersection_x, intersection_y, 0], radius=0.5, glow_factor=2.0, color=m.YELLOW)
        number_1 = m.TexText("1", additional_preamble=r"\usepackage{mlmodern}").scale(4).to_corner(m.DL)
        self.add(num_plane, line1, line2, dot, linear_algebra, matrix_times_vector, number_1)
``` 

The result before my changes was this:

<img width="1920" height="1080" alt="old" src="https://github.com/user-attachments/assets/8a6d847a-10ef-4ddc-9ea3-65f3d5bc30e0" />

As you can see, there's a hard edge on both lowercase a's in "Álgebra Lineal".

After my changes, it renders a lot better:

<img width="1920" height="1080" alt="MyInteractiveScene" src="https://github.com/user-attachments/assets/1178bb73-45b1-4075-a79d-75de52acd5b4" />

## Proposed changes
| File | Change |
|---|---|
| `manimlib/shaders/quadratic_bezier/stroke/frag.glsl` | Added the `fill_border_inside` uniform; coverage now measures from the far edge of the stroke on the inside pass, so the two passes form one ramp centered on the path. |
| `manimlib/shader_wrapper.py` | `VShaderWrapper.render_fill()` draws the border band as two stencil-distinguished passes instead of one; `render_stroke()` sets `fill_border_inside = False`. |
| `manimlib/shaders/quadratic_bezier/stroke/vert.glsl` | Added `DEGENERATE_LENGTH = 1e-12`, replacing exact float equality in four degeneracy tests (`blank`, `flatten_tangent`, `closed`, `has_joint`), plus a chord fallback for a vanishing tangent. |