### PR TITLE
Prepare the renderer for the wgpu port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ CLAUDE.md
 
 # LaTeX scratch files, regenerated whenever Tex is rendered
 latex_cache/
+
+# Textures the render comparison harness makes for itself
+tests/assets/

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -276,8 +276,19 @@ class Camera(object):
         # only here to guarantee a clean slate, e.g. if a previous frame's
         # rendering was interrupted partway through
         gl.glClear(gl.GL_STENCIL_BUFFER_BIT)
-        for mobject in mobjects:
-            mobject.render(self.renderer)
+
+        wrappers = [
+            wrapper
+            for mobject in mobjects
+            for wrapper in mobject.get_shader_wrappers(self.renderer)
+        ]
+        # Everything the frame sends to the gpu, before anything it draws, see
+        # ShaderWrapper.write_buffers
+        for wrapper in wrappers:
+            wrapper.write_buffers()
+        self.renderer.reset_state()
+        for wrapper in wrappers:
+            wrapper.render()
 
         if self.window:
             self.window.swap_buffers()

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -14,7 +14,6 @@ from manimlib.mobject.mobject import Mobject
 from manimlib.mobject.mobject import Point
 from manimlib.renderer import Renderer
 from manimlib.utils.color import color_to_rgba
-from manimlib.utils.shaders import set_shared_uniforms
 
 from typing import TYPE_CHECKING
 
@@ -62,7 +61,6 @@ class Camera(object):
         self.background_rgba: list[float] = list(color_to_rgba(
             background_color, background_opacity
         ))
-        self.uniforms = dict()
         self.depth_stencil_rbos: list[int] = []
         self.init_frame(**frame_config)
         self.init_context()
@@ -277,8 +275,7 @@ class Camera(object):
     def capture(self, *mobjects: Mobject) -> None:
         self.clear()
         self.refresh_uniforms()
-        # These hold for every program, so they only need setting once a frame
-        set_shared_uniforms(self.uniforms)
+        self.renderer.send_frame_uniforms()
         self.fbo.use()
         # Fill rendering leaves the stencil buffer zeroed as it goes, so this is
         # only here to guarantee a clean slate, e.g. if a previous frame's
@@ -298,13 +295,13 @@ class Camera(object):
                 self.window.swap_buffers()
 
     def refresh_uniforms(self) -> None:
+        """
+        What every program reads about where the frame, the camera and the light are,
+        written into the block they all share, see Renderer.
+        """
         frame = self.frame
-        view_matrix = frame.get_view_matrix()
-        light_pos = self.light_source.get_location()
-        cam_pos = self.frame.get_implied_camera_location()
-
-        self.uniforms.update(
-            view=tuple(view_matrix.T.flatten()),
+        self.renderer.frame_uniforms.update(
+            view=frame.get_view_matrix().T.flatten(),
             frame_scale=frame.get_scale(),
             frame_rescale_factors=(
                 2.0 / FRAME_WIDTH,
@@ -312,8 +309,8 @@ class Camera(object):
                 frame.get_scale() / frame.get_focal_distance(),
             ),
             pixel_size=self.get_pixel_size(),
-            camera_position=tuple(cam_pos),
-            light_position=tuple(light_pos),
+            camera_position=frame.get_implied_camera_location(),
+            light_position=self.light_source.get_location(),
         )
 
 

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -12,6 +12,7 @@ from manimlib.constants import FRAME_HEIGHT
 from manimlib.constants import FRAME_WIDTH
 from manimlib.mobject.mobject import Mobject
 from manimlib.mobject.mobject import Point
+from manimlib.renderer import Renderer
 from manimlib.utils.color import color_to_rgba
 from manimlib.utils.shaders import set_shared_uniforms
 
@@ -87,6 +88,8 @@ class Camera(object):
             moderngl.ONE, moderngl.ONE_MINUS_SRC_ALPHA,
         )
         gl.glClearStencil(0)
+        # What every mobject drawn by this camera is handed in order to draw itself
+        self.renderer = Renderer(self.ctx)
         # Every vertex shader writes a distance for all four clip planes, using a
         # plane of all zeros to mean nothing gets clipped, so these stay on
         for clip_distance in [gl.GL_CLIP_DISTANCE0, gl.GL_CLIP_DISTANCE1,
@@ -282,7 +285,7 @@ class Camera(object):
         # rendering was interrupted partway through
         gl.glClear(gl.GL_STENCIL_BUFFER_BIT)
         for mobject in mobjects:
-            mobject.render(self.ctx)
+            mobject.render(self.renderer)
 
         if self.window:
             self.window.swap_buffers()

--- a/manimlib/camera/camera.py
+++ b/manimlib/camera/camera.py
@@ -88,11 +88,6 @@ class Camera(object):
         gl.glClearStencil(0)
         # What every mobject drawn by this camera is handed in order to draw itself
         self.renderer = Renderer(self.ctx)
-        # Every vertex shader writes a distance for all four clip planes, using a
-        # plane of all zeros to mean nothing gets clipped, so these stay on
-        for clip_distance in [gl.GL_CLIP_DISTANCE0, gl.GL_CLIP_DISTANCE1,
-                              gl.GL_CLIP_DISTANCE2, gl.GL_CLIP_DISTANCE3]:
-            gl.glEnable(clip_distance)
 
     def init_fbo(self) -> None:
         # This is the buffer used when writing to a video/image file

--- a/manimlib/event_keys.py
+++ b/manimlib/event_keys.py
@@ -1,0 +1,52 @@
+"""
+manim's own names for what a key event carries, so that nothing above the window has to
+know what the window is built on.
+
+A key which types something is named by what it types, so that ord("s") and Keys of it come
+to the same number and a binding may be written either way. Every other key takes a
+codepoint from Unicode's private use area, which is what it is for, so that chr() of one is
+harmless and can never come out equal to a key which does type something.
+
+A window translates from whatever vocabulary it is given into this one before handing an
+event up, and takes these back from is_key_pressed, see window.py. Mouse buttons are left
+alone: nothing compares one against anything, so they need no names.
+"""
+from __future__ import annotations
+
+
+class Keys:
+    # Keys which type a control character, named by the character
+    BACKSPACE = 0x08
+    TAB = 0x09
+    ENTER = 0x0D
+    ESCAPE = 0x1B
+    SPACE = 0x20
+    DELETE = 0x7F
+
+    # Keys which type nothing. Left and right hand modifiers come to the same key, since
+    # nothing manim binds cares which of the pair was pressed.
+    LEFT = 0xE000
+    RIGHT = 0xE001
+    UP = 0xE002
+    DOWN = 0xE003
+    SHIFT = 0xE004
+    CTRL = 0xE005
+    ALT = 0xE006
+    CMD = 0xE007
+
+
+class Mods:
+    """Which modifiers were held while an event happened, as the bits of one number"""
+
+    SHIFT = 1 << 0
+    CTRL = 1 << 1
+    ALT = 1 << 2
+    CMD = 1 << 3
+    CAPS_LOCK = 1 << 4
+
+    # A mac says command where everything else says control, and every shortcut manim
+    # binds means either of them
+    CTRL_OR_CMD = CTRL | CMD
+    # The modifiers anything is bound to, for a shortcut which asks that none be held.
+    # Alt and caps lock are left out because nothing is bound to them.
+    ANY = SHIFT | CTRL | CMD

--- a/manimlib/mobject/geometry.py
+++ b/manimlib/mobject/geometry.py
@@ -1422,7 +1422,7 @@ class ArrowTip(Triangle):
         if tip_style == 1:
             self.set_height(length * 0.9, stretch=True)
             self.data["point"][4] += np.array([0.6 * length, 0, 0])
-            self.data.changed = True
+            self.data.note_change()
         elif tip_style == 2:
             h = length / 2
             self.set_points(Dot().set_width(h).get_points())

--- a/manimlib/mobject/interactive.py
+++ b/manimlib/mobject/interactive.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import numpy as np
-from pyglet.window import key as PygletWindowKeys
 
 from manimlib.constants import FRAME_HEIGHT, FRAME_WIDTH
 from manimlib.constants import DOWN, LEFT, ORIGIN, RIGHT, UP
 from manimlib.constants import MED_LARGE_BUFF, MED_SMALL_BUFF, SMALL_BUFF
 from manimlib.constants import BLACK, BLUE, GREEN, GREY_A, GREY_C, RED, WHITE, DEFAULT_MOBJECT_COLOR
+from manimlib.event_keys import Keys
+from manimlib.event_keys import Mods
 from manimlib.mobject.mobject import Group
 from manimlib.mobject.mobject import Mobject
 from manimlib.mobject.geometry import Circle
@@ -450,15 +451,15 @@ class Textbox(ControlMobject):
             old_value = mob.get_value()
             new_value = old_value
             if char.isalnum():
-                if (modifiers & PygletWindowKeys.MOD_SHIFT) or (modifiers & PygletWindowKeys.MOD_CAPSLOCK):
+                if modifiers & (Mods.SHIFT | Mods.CAPS_LOCK):
                     new_value = old_value + char.upper()
                 else:
                     new_value = old_value + char.lower()
-            elif symbol in [PygletWindowKeys.SPACE]:
+            elif symbol == Keys.SPACE:
                 new_value = old_value + char
-            elif symbol == PygletWindowKeys.TAB:
+            elif symbol == Keys.TAB:
                 new_value = old_value + '\t'
-            elif symbol == PygletWindowKeys.BACKSPACE:
+            elif symbol == Keys.BACKSPACE:
                 new_value = old_value[:-1] or ''
             mob.set_value(new_value)
             return False

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -2000,14 +2000,13 @@ class Mobject(object):
     def get_uniforms(self):
         return self.uniforms
 
-    def render(self, renderer: Renderer):
-        for mob in self.get_family():
-            if len(mob.data) == 0:
-                # Groups hold no points of their own, but their members might
-                continue
-            shader_wrapper = mob.get_shader_wrapper(renderer)
-            shader_wrapper.pre_render()
-            shader_wrapper.render()
+    def get_shader_wrappers(self, renderer: Renderer) -> list[ShaderWrapper]:
+        return [
+            mob.get_shader_wrapper(renderer)
+            for mob in self.get_family()
+            # Groups hold no points of their own, but their members might
+            if len(mob.data) > 0
+        ]
 
     # Event Handlers
     """

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from typing import Callable, Iterator, Union, Tuple, Optional, Any
     import numpy.typing as npt
     from manimlib.typing import ManimColor, Vect3, Vect4Array, Vect3Array, Self
-    from moderngl.context import Context
+    from manimlib.renderer import Renderer
 
     T = TypeVar('T')
     TimeBasedUpdater = Callable[["Mobject", float], "Mobject" | None]
@@ -1976,9 +1976,9 @@ class Mobject(object):
 
     # For shader data
 
-    def init_shader_wrapper(self, ctx: Context):
+    def init_shader_wrapper(self, renderer: Renderer):
         self.shader_wrapper = ShaderWrapper(
-            ctx=ctx,
+            renderer=renderer,
             mobject_data=self.data,
             shader_folder=self.shader_folder,
             mobject_uniforms=self.uniforms,
@@ -1988,9 +1988,9 @@ class Mobject(object):
             verts_per_record=self.verts_per_record,
         )
 
-    def get_shader_wrapper(self, ctx: Context) -> ShaderWrapper:
+    def get_shader_wrapper(self, renderer: Renderer) -> ShaderWrapper:
         if self.shader_wrapper is None:
-            self.init_shader_wrapper(ctx)
+            self.init_shader_wrapper(renderer)
         # Whatever the wrapper needs a copy of is told to it here, where it is asked for
         # once a frame, rather than by everything which might change one of them having
         # to remember to pass it along
@@ -2000,12 +2000,12 @@ class Mobject(object):
     def get_uniforms(self):
         return self.uniforms
 
-    def render(self, ctx: Context):
+    def render(self, renderer: Renderer):
         for mob in self.get_family():
             if len(mob.data) == 0:
                 # Groups hold no points of their own, but their members might
                 continue
-            shader_wrapper = mob.get_shader_wrapper(ctx)
+            shader_wrapper = mob.get_shader_wrapper(renderer)
             shader_wrapper.pre_render()
             shader_wrapper.render()
 

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -235,7 +235,7 @@ class Mobject(object):
         self.data[n:] = self.data[n - 1]
         # Then read in new points, written into rather than replaced, so say so
         self.data["point"][n:] = new_points
-        self.data.changed = True
+        self.data.note_change()
         self.refresh_bounding_box()
         return self
 
@@ -1308,7 +1308,7 @@ class Mobject(object):
     ) -> Self:
         for mob in self.get_family(recurse):
             mob.data.rows_or_defaults[name] = rgba_array
-            mob.data.changed = True
+            mob.data.note_change()
         return self
 
     def set_color_by_rgba_func(
@@ -1357,7 +1357,7 @@ class Mobject(object):
                     opacity = resize_with_interpolation(np.array(opacity), len(data))
                 data[name][:, 3] = opacity
             # Those columns are written into rather than replaced
-            mob.data.changed = True
+            mob.data.note_change()
         return self
 
     def set_color(

--- a/manimlib/mobject/types/dot_cloud.py
+++ b/manimlib/mobject/types/dot_cloud.py
@@ -116,7 +116,7 @@ class DotCloud(PMobject):
 
     def set_radius(self, radius: float) -> Self:
         self.data.rows_or_defaults["radius"] = radius
-        self.data.changed = True
+        self.data.note_change()
         self.refresh_bounding_box()
         return self
 

--- a/manimlib/mobject/types/image_mobject.py
+++ b/manimlib/mobject/types/image_mobject.py
@@ -55,7 +55,7 @@ class ImageMobject(Mobject):
             np.array(listify(opacity)),
             self.get_num_points()
         )
-        self.data.changed = True
+        self.data.note_change()
         return self
 
     def set_color(self, color, opacity=None, recurse=None):

--- a/manimlib/mobject/types/point_cloud_mobject.py
+++ b/manimlib/mobject/types/point_cloud_mobject.py
@@ -44,7 +44,7 @@ class PMobject(Mobject):
             )
         if rgbas is not None:
             self.data["rgba"][-len(rgbas):] = rgbas
-            self.data.changed = True
+            self.data.note_change()
         return self
 
     def add_point(self, point: Vect3, rgba=None, color=None, opacity=None) -> Self:

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -427,7 +427,7 @@ class TexturedSurface(Surface):
     def set_opacity(self, opacity: float | Iterable[float], recurse=True) -> Self:
         op_arr = np.array(listify(opacity))
         self.data["opacity"][:, 0] = resize_with_interpolation(op_arr, len(self.data))
-        self.data.changed = True
+        self.data.note_change()
         return self
 
     def set_color(
@@ -453,7 +453,7 @@ class TexturedSurface(Surface):
         im_coords = self.data["im_coords"]
         im_coords[:] = tsmobject.data["im_coords"]
         # Written into rather than replaced, so say so
-        self.data.changed = True
+        self.data.note_change()
         if a <= 0 and b >= 1:
             return self
         nu, nv = tsmobject.get_resolution()

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Callable, Iterable, Sequence, Tuple
 
-    from moderngl.context import Context
+    from manimlib.renderer import Renderer
 
     from manimlib.camera.camera import Camera
     from manimlib.typing import ManimColor, Vect3, Vect3Array, Self
@@ -226,14 +226,14 @@ class Surface(Mobject):
         # updater to do the sorting, see set_sort_to_camera
         return self.set_sort_to_camera()
 
-    def get_shader_wrapper(self, ctx: Context) -> SurfaceShaderWrapper:
-        wrapper = super().get_shader_wrapper(ctx)
+    def get_shader_wrapper(self, renderer: Renderer) -> SurfaceShaderWrapper:
+        wrapper = super().get_shader_wrapper(renderer)
         wrapper.sort_to_camera = self.sort_to_camera
         return wrapper
 
-    def init_shader_wrapper(self, ctx: Context):
+    def init_shader_wrapper(self, renderer: Renderer):
         self.shader_wrapper = SurfaceShaderWrapper(
-            ctx=ctx,
+            renderer=renderer,
             sort_to_camera=self.sort_to_camera,
             mobject_data=self.data,
             mobject_uniforms=self.uniforms,

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -262,7 +262,7 @@ class VMobject(Mobject):
                         np.array(width), len(data)
                     ).flatten()
                 # That column is written into rather than replaced
-                mob.data.changed = True
+                mob.data.note_change()
 
         if behind is not None:
             for mob in self.get_family(recurse):
@@ -880,7 +880,7 @@ class VMobject(Mobject):
             # Reaching one past the end takes in the null curve's handle sitting
             # there, which belongs to no subpath, so that every point gets written
             self.data["subpath_range"][start:end + 2] = (start, end)
-        self.data.changed = True
+        self.data.note_change()
         return self
 
     def get_subpath_range(self, index: int = -1) -> Tuple[int, int]:
@@ -1039,7 +1039,10 @@ class VMobject(Mobject):
         else:
             p = self.get_points()
             normal = get_unit_normal(p[1] - p[0], p[2] - p[1])
-        self.uniforms["unit_normal"] = normal
+        # Rounded, adding zero to leave no negative one of it, so that mobjects facing
+        # the same way say so exactly rather than to within whatever noise their own
+        # points worked out to. Six digits is finer than any shading can show.
+        self.uniforms["unit_normal"] = np.round(normal, 6) + 0.0
         self.needs_new_unit_normal = False
         return normal
 
@@ -1222,7 +1225,7 @@ class VMobject(Mobject):
             # marks an end once the order of the points is flipped
             inner_ends = mob.get_subpath_end_indices()[:-1]
             mob.data["point"][inner_ends + 1] = mob.data["point"][inner_ends + 2]
-            mob.data.changed = True
+            mob.data.note_change()
             mob.uniforms["unit_normal"] = -mob.uniforms["unit_normal"]
         super().reverse_points()
         for mob in self.get_family(recurse):

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -54,7 +54,7 @@ SubVmobjectType = TypeVar('SubVmobjectType', bound='VMobject')
 if TYPE_CHECKING:
     from typing import Callable, Tuple, Any, Optional
     from manimlib.typing import ManimColor, Vect3, Vect4, Vect3Array, Self
-    from moderngl import Context
+    from manimlib.renderer import Renderer
 
 
 GRADIENT_POINT_KEYS = ['gradient_start', 'gradient_end']
@@ -1276,9 +1276,9 @@ class VMobject(Mobject):
 
     # For shaders
 
-    def init_shader_wrapper(self, ctx: Context):
+    def init_shader_wrapper(self, renderer: Renderer):
         self.shader_wrapper = VShaderWrapper(
-            ctx=ctx,
+            renderer=renderer,
             mobject_data=self.data,
             mobject_uniforms=self.uniforms,
             code_replacements=self.shader_code_replacements,
@@ -1287,8 +1287,8 @@ class VMobject(Mobject):
             depth_test=self.depth_test
         )
 
-    def get_shader_wrapper(self, ctx: Context) -> VShaderWrapper:
-        wrapper = super().get_shader_wrapper(ctx)
+    def get_shader_wrapper(self, renderer: Renderer) -> VShaderWrapper:
+        wrapper = super().get_shader_wrapper(renderer)
         wrapper.stroke_behind = self.stroke_behind
         return wrapper
 

--- a/manimlib/mobject/vector_field.py
+++ b/manimlib/mobject/vector_field.py
@@ -309,7 +309,7 @@ class VectorField(VMobject):
             )
 
         # The arrays above are written into rather than replaced
-        self.data.changed = True
+        self.data.note_change()
         return self
 
 

--- a/manimlib/renderer.py
+++ b/manimlib/renderer.py
@@ -1,10 +1,64 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import moderngl
+import OpenGL.GL as gl
 
 from manimlib.utils.shaders import FRAME_BLOCK_BINDING
 from manimlib.utils.shaders import FRAME_DTYPE
 from manimlib.utils.shaders import Uniforms
+
+
+@dataclass(frozen=True)
+class DrawState:
+    """
+    How a draw behaves, beyond which program runs and what it reads: whether depth decides
+    what is hidden and whether it is written, whether the stencil buffer is tested and what
+    it is left holding, whether color is written at all, and which facing is dropped.
+
+    Said as a value rather than poked into place around each draw, both because manim only
+    ever asks for the handful of combinations named below, and because wgpu takes exactly
+    this and bakes it into a pipeline object built once.
+
+    depth_test is None wherever the mobject being drawn decides, which is most of them. A
+    fill counting windings is the exception: it has to see every triangle of the path,
+    whatever stands in front of it.
+    """
+    depth_test: bool | None = None
+    depth_write: bool = True
+    color_write: bool = True
+    cull: int | None = None
+    # (function, reference, mask), or None to leave the stencil buffer out of it
+    stencil_func: tuple[int, int, int] | None = None
+    # What to leave in the stencil buffer when the test fails, when depth fails, and when
+    # the fragment is drawn: once for front facing triangles, once for back facing ones
+    stencil_ops: tuple[tuple[int, int, int], tuple[int, int, int]] | None = None
+
+
+KEEP = (gl.GL_KEEP, gl.GL_KEEP, gl.GL_KEEP)
+
+DEFAULT = DrawState()
+# A surface draws the side of itself facing away from the camera before the side facing
+# towards it, each pass dropping the other, see SurfaceShaderWrapper
+CULL_FRONT = DrawState(cull=gl.GL_FRONT)
+CULL_BACK = DrawState(cull=gl.GL_BACK)
+# The three passes a fill takes, see VShaderWrapper.render_fill for what each is for
+WINDING_COUNT = DrawState(
+    depth_test=False,
+    depth_write=False,
+    color_write=False,
+    stencil_func=(gl.GL_ALWAYS, 0, 0xFF),
+    stencil_ops=(
+        (gl.GL_KEEP, gl.GL_INCR_WRAP, gl.GL_INCR_WRAP),
+        (gl.GL_KEEP, gl.GL_DECR_WRAP, gl.GL_DECR_WRAP),
+    ),
+)
+FILL_BORDER = DrawState(stencil_func=(gl.GL_EQUAL, 0, 0xFF), stencil_ops=(KEEP, KEEP))
+WINDING_COVER = DrawState(
+    stencil_func=(gl.GL_NOTEQUAL, 0, 0xFF),
+    stencil_ops=2 * ((gl.GL_KEEP, gl.GL_ZERO, gl.GL_ZERO),),
+)
 
 
 class Renderer(object):
@@ -30,9 +84,70 @@ class Renderer(object):
         # Nothing else binds here, so the buffer stays bound for the life of the renderer
         # and only its contents are written afresh
         self.frame_uniform_buffer.bind_to_uniform_block(FRAME_BLOCK_BINDING)
+        # What state the context is in, so that a draw asking for the state it is already
+        # in says nothing to the driver, see use
+        self.state = DEFAULT
+        self.depth_test = False
 
     def send_frame_uniforms(self) -> None:
         """The frame's uniforms to the gpu, if they have been written to since last sent"""
         if self.frame_uniforms.version != self.sent_version:
             self.frame_uniform_buffer.write(self.frame_uniforms.array)
             self.sent_version = self.frame_uniforms.version
+
+    def use(self, state: DrawState, depth_test: bool = False) -> None:
+        """
+        Puts the context into the state a draw asks for, saying only what differs from the
+        state it is already in, which is usually nothing at all: consecutive draws mostly
+        want the same state, and the states differ from one another in a field or two.
+
+        Whether depth is tested is kept apart from the rest, since it is the one thing the
+        mobject being drawn has a say in, see DrawState.
+        """
+        if state.depth_test is not None:
+            depth_test = state.depth_test
+        if depth_test != self.depth_test:
+            if depth_test:
+                self.ctx.enable(moderngl.DEPTH_TEST)
+            else:
+                self.ctx.disable(moderngl.DEPTH_TEST)
+            self.depth_test = depth_test
+        current = self.state
+        if state is current:
+            return
+        if state.depth_write != current.depth_write:
+            gl.glDepthMask(state.depth_write)
+        if state.color_write != current.color_write:
+            gl.glColorMask(*4 * [state.color_write])
+        if state.cull != current.cull:
+            if state.cull is None:
+                gl.glDisable(gl.GL_CULL_FACE)
+            else:
+                gl.glEnable(gl.GL_CULL_FACE)
+                gl.glCullFace(state.cull)
+        if (state.stencil_func is None) != (current.stencil_func is None):
+            if state.stencil_func is None:
+                gl.glDisable(gl.GL_STENCIL_TEST)
+            else:
+                gl.glEnable(gl.GL_STENCIL_TEST)
+        if state.stencil_func is not None and state.stencil_func != current.stencil_func:
+            gl.glStencilFunc(*state.stencil_func)
+        if state.stencil_ops is not None and state.stencil_ops != current.stencil_ops:
+            front, back = state.stencil_ops
+            gl.glStencilOpSeparate(gl.GL_FRONT, *front)
+            gl.glStencilOpSeparate(gl.GL_BACK, *back)
+        self.state = state
+
+    def reset_state(self) -> None:
+        """
+        Says every part of the default state whether the context is in it or not, since
+        using a framebuffer or clearing one goes behind this class's back where the masks
+        are concerned. Called once a frame, before anything is drawn.
+        """
+        self.ctx.disable(moderngl.DEPTH_TEST)
+        gl.glDepthMask(True)
+        gl.glColorMask(True, True, True, True)
+        gl.glDisable(gl.GL_CULL_FACE)
+        gl.glDisable(gl.GL_STENCIL_TEST)
+        self.depth_test = False
+        self.state = DEFAULT

--- a/manimlib/renderer.py
+++ b/manimlib/renderer.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import moderngl
+
+
+class Renderer(object):
+    """
+    What a mobject needs of the gpu in order to draw itself, in one thing rather than
+    several.
+
+    For now that is the context it belongs to, which is where its buffers are made and
+    its programs compiled. It is also where whatever holds for a whole frame will sit,
+    the camera's own uniforms among it, rather than being pushed into every program
+    separately: a mobject asks the renderer for what it shares with all the others, and
+    the renderer is handed to it once a frame by the camera which owns it.
+    """
+
+    def __init__(self, ctx: moderngl.Context):
+        self.ctx = ctx

--- a/manimlib/renderer.py
+++ b/manimlib/renderer.py
@@ -2,18 +2,37 @@ from __future__ import annotations
 
 import moderngl
 
+from manimlib.utils.shaders import FRAME_BLOCK_BINDING
+from manimlib.utils.shaders import FRAME_DTYPE
+from manimlib.utils.shaders import Uniforms
+
 
 class Renderer(object):
     """
     What a mobject needs of the gpu in order to draw itself, in one thing rather than
     several.
 
-    For now that is the context it belongs to, which is where its buffers are made and
-    its programs compiled. It is also where whatever holds for a whole frame will sit,
-    the camera's own uniforms among it, rather than being pushed into every program
-    separately: a mobject asks the renderer for what it shares with all the others, and
-    the renderer is handed to it once a frame by the camera which owns it.
+    That is the context it belongs to, which is where its buffers are made and its
+    programs compiled, and the values which hold for every mobject of a frame: where the
+    camera is, what it is looking along, and where the light is.
+
+    Those travel in one block, written once a frame by the camera which owns this and read
+    by every program from the one buffer it is bound to, see inserts/frame_uniforms.glsl.
+    A mobject wanting one of them, as a surface sorting its triangles wants the camera
+    position, reads it from frame_uniforms rather than being told.
     """
 
     def __init__(self, ctx: moderngl.Context):
         self.ctx = ctx
+        self.frame_uniforms = Uniforms(FRAME_DTYPE)
+        self.frame_uniform_buffer = ctx.buffer(self.frame_uniforms.array)
+        self.sent_version = 0
+        # Nothing else binds here, so the buffer stays bound for the life of the renderer
+        # and only its contents are written afresh
+        self.frame_uniform_buffer.bind_to_uniform_block(FRAME_BLOCK_BINDING)
+
+    def send_frame_uniforms(self) -> None:
+        """The frame's uniforms to the gpu, if they have been written to since last sent"""
+        if self.frame_uniforms.version != self.sent_version:
+            self.frame_uniform_buffer.write(self.frame_uniforms.array)
+            self.sent_version = self.frame_uniforms.version

--- a/manimlib/scene/interactive_scene.py
+++ b/manimlib/scene/interactive_scene.py
@@ -4,7 +4,6 @@ import itertools as it
 import numpy as np
 import pyperclip
 from IPython.core.getipython import get_ipython
-from pyglet.window import key as PygletWindowKeys
 
 from manimlib.animation.fading import FadeIn
 from manimlib.config import manim_config
@@ -13,6 +12,8 @@ from manimlib.constants import FRAME_WIDTH, FRAME_HEIGHT, SMALL_BUFF
 from manimlib.constants import PI
 from manimlib.constants import DEG
 from manimlib.constants import MANIM_COLORS, WHITE, GREY_A, GREY_C
+from manimlib.event_keys import Keys
+from manimlib.event_keys import Mods
 from manimlib.mobject.geometry import Line
 from manimlib.mobject.geometry import Rectangle
 from manimlib.mobject.geometry import Square
@@ -51,14 +52,7 @@ CURSOR_KEY = manim_config.key_bindings.cursor
 
 # For keyboard interactions
 
-ARROW_SYMBOLS: list[int] = [
-    PygletWindowKeys.LEFT,
-    PygletWindowKeys.UP,
-    PygletWindowKeys.RIGHT,
-    PygletWindowKeys.DOWN,
-]
-
-ALL_MODIFIERS = PygletWindowKeys.MOD_CTRL | PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_SHIFT
+ARROW_SYMBOLS: list[int] = [Keys.LEFT, Keys.UP, Keys.RIGHT, Keys.DOWN]
 
 # Note, a lot of the functionality here is still buggy and very much a work in progress.
 
@@ -490,47 +484,47 @@ class InteractiveScene(Scene):
             char = chr(symbol)
         except OverflowError:
             return
-        if char == SELECT_KEY and (modifiers & ALL_MODIFIERS) == 0:
+        if char == SELECT_KEY and not (modifiers & Mods.ANY):
             self.enable_selection()
         if char == UNSELECT_KEY:
             self.clear_selection()
-        elif char in GRAB_KEYS and (modifiers & ALL_MODIFIERS) == 0:
+        elif char in GRAB_KEYS and not (modifiers & Mods.ANY):
             self.prepare_grab()
-        elif char == RESIZE_KEY and (modifiers & PygletWindowKeys.MOD_SHIFT):
-            self.prepare_resizing(about_corner=((modifiers & PygletWindowKeys.MOD_SHIFT) > 0))
-        elif symbol == PygletWindowKeys.LSHIFT:
+        elif char == RESIZE_KEY and (modifiers & Mods.SHIFT):
+            self.prepare_resizing(about_corner=((modifiers & Mods.SHIFT) > 0))
+        elif symbol == Keys.SHIFT:
             if self.window.is_key_pressed(ord("t")):
                 self.prepare_resizing(about_corner=True)
-        elif char == COLOR_KEY and (modifiers & ALL_MODIFIERS) == 0:
+        elif char == COLOR_KEY and not (modifiers & Mods.ANY):
             self.toggle_color_palette()
-        elif char == INFORMATION_KEY and (modifiers & ALL_MODIFIERS) == 0:
+        elif char == INFORMATION_KEY and not (modifiers & Mods.ANY):
             self.display_information()
-        elif char == "c" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == "c" and (modifiers & Mods.CTRL_OR_CMD):
             self.copy_selection()
-        elif char == "v" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == "v" and (modifiers & Mods.CTRL_OR_CMD):
             self.paste_selection()
-        elif char == "x" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == "x" and (modifiers & Mods.CTRL_OR_CMD):
             self.copy_selection()
             self.delete_selection()
-        elif symbol == PygletWindowKeys.BACKSPACE:
+        elif symbol == Keys.BACKSPACE:
             self.delete_selection()
-        elif char == "a" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == "a" and (modifiers & Mods.CTRL_OR_CMD):
             self.clear_selection()
             self.add_to_selection(*self.mobjects)
-        elif char == "g" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == "g" and (modifiers & Mods.CTRL_OR_CMD):
             self.group_selection()
-        elif char == "g" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL | PygletWindowKeys.MOD_SHIFT)):
+        elif char == "g" and (modifiers & (Mods.CTRL_OR_CMD | Mods.SHIFT)):
             self.ungroup_selection()
-        elif char == "t" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == "t" and (modifiers & Mods.CTRL_OR_CMD):
             self.toggle_selection_mode()
-        elif char == "d" and (modifiers & PygletWindowKeys.MOD_SHIFT):
+        elif char == "d" and (modifiers & Mods.SHIFT):
             self.copy_frame_positioning()
-        elif char == "c" and (modifiers & PygletWindowKeys.MOD_SHIFT):
+        elif char == "c" and (modifiers & Mods.SHIFT):
             self.copy_cursor_position()
         elif symbol in ARROW_SYMBOLS:
             self.nudge_selection(
                 vect=[LEFT, UP, RIGHT, DOWN][ARROW_SYMBOLS.index(symbol)],
-                large=(modifiers & PygletWindowKeys.MOD_SHIFT),
+                large=(modifiers & Mods.SHIFT),
             )
         # Adding crosshair
         if char == CURSOR_KEY:
@@ -553,7 +547,7 @@ class InteractiveScene(Scene):
             self.is_grabbing = False
         elif chr(symbol) == INFORMATION_KEY:
             self.display_information(False)
-        elif symbol == PygletWindowKeys.LSHIFT and self.window.is_key_pressed(ord(RESIZE_KEY)):
+        elif symbol == Keys.SHIFT and self.window.is_key_pressed(ord(RESIZE_KEY)):
             self.prepare_resizing(about_corner=False)
 
     # Mouse actions
@@ -572,7 +566,7 @@ class InteractiveScene(Scene):
         if not hasattr(self, "scale_about_point"):
             return
         vect = point - self.scale_about_point
-        if self.window.is_key_pressed(PygletWindowKeys.LCTRL):
+        if self.window.is_key_pressed(Keys.CTRL):
             for i in (0, 1):
                 scalar = vect[i] / self.scale_ref_vect[i]
                 self.selection.rescale_to_fit(
@@ -617,7 +611,7 @@ class InteractiveScene(Scene):
             self.handle_grabbing(point)
         elif self.window.is_key_pressed(ord(RESIZE_KEY)):
             self.handle_resizing(point)
-        elif self.window.is_key_pressed(ord(SELECT_KEY)) and self.window.is_key_pressed(PygletWindowKeys.LSHIFT):
+        elif self.window.is_key_pressed(ord(SELECT_KEY)) and self.window.is_key_pressed(Keys.SHIFT):
             self.handle_sweeping_selection(point)
 
     def on_mouse_drag(

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -10,7 +10,6 @@ from contextlib import ExitStack
 
 import numpy as np
 from tqdm.auto import tqdm as ProgressDisplay
-from pyglet.window import key as PygletWindowKeys
 
 from manimlib.animation.animation import prepare_animation
 from manimlib.camera.camera import Camera
@@ -18,6 +17,8 @@ from manimlib.camera.camera_frame import CameraFrame
 from manimlib.config import manim_config
 from manimlib.event_handler import EVENT_DISPATCHER
 from manimlib.event_handler.event_type import EventType
+from manimlib.event_keys import Keys
+from manimlib.event_keys import Mods
 from manimlib.logger import log
 from manimlib.mobject.mobject import _AnimationBuilder
 from manimlib.mobject.mobject import Group
@@ -823,15 +824,15 @@ class Scene(object):
 
         if char == manim_config.key_bindings.reset:
             self.play(self.camera.frame.animate.to_default_state())
-        elif char == "z" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == "z" and (modifiers & Mods.CTRL_OR_CMD):
             self.undo()
-        elif char == "z" and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL | PygletWindowKeys.MOD_SHIFT)):
+        elif char == "z" and (modifiers & (Mods.CTRL_OR_CMD | Mods.SHIFT)):
             self.redo()
         # command + q
-        elif char == manim_config.key_bindings.quit and (modifiers & (PygletWindowKeys.MOD_COMMAND | PygletWindowKeys.MOD_CTRL)):
+        elif char == manim_config.key_bindings.quit and (modifiers & Mods.CTRL_OR_CMD):
             self.quit_interaction = True
         # Space or right arrow
-        elif char == " " or symbol == PygletWindowKeys.RIGHT:
+        elif char == " " or symbol == Keys.RIGHT:
             self.hold_on_wait = False
 
     def on_resize(self, width: int, height: int) -> None:

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -7,10 +7,10 @@ import OpenGL.GL as gl
 import moderngl
 import numpy as np
 
+from manimlib.utils.shaders import MOBJECT_BLOCK_BINDING
 from manimlib.utils.shaders import MOBJECT_BLOCK_NAME
 from manimlib.utils.shaders import check_uniform_block
 from manimlib.utils.shaders import get_shader_code
-from manimlib.utils.shaders import get_shared_uniform
 from manimlib.utils.shaders import get_shader_program
 from manimlib.utils.shaders import image_path_to_texture
 from manimlib.utils.shaders import set_program_sampler
@@ -23,9 +23,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Optional
     from manimlib.renderer import Renderer
-
-UNIFORM_BLOCK_BINDING = 0
-
 
 class ShaderWrapper(object):
     """
@@ -132,7 +129,7 @@ class ShaderWrapper(object):
         for program in self.programs:
             if program is None or not check_uniform_block(program, dtype):
                 continue
-            program[MOBJECT_BLOCK_NAME].binding = UNIFORM_BLOCK_BINDING
+            program[MOBJECT_BLOCK_NAME].binding = MOBJECT_BLOCK_BINDING
             self.has_uniform_block = True
 
     def init_textures(self):
@@ -256,7 +253,7 @@ class ShaderWrapper(object):
             for name, unit in self.texture_names_to_ids.items():
                 set_program_sampler(program, name, unit)
         if self.uniform_buffer is not None:
-            self.uniform_buffer.bind_to_uniform_block(UNIFORM_BLOCK_BINDING)
+            self.uniform_buffer.bind_to_uniform_block(MOBJECT_BLOCK_BINDING)
 
     def render(self):
         n_verts = self.verts_per_record * len(self.mobject_data)
@@ -322,7 +319,7 @@ class SurfaceShaderWrapper(ShaderWrapper):
         to order that way: no camera yet, or records which are no grid, as an imported
         mesh's are.
         """
-        camera_position = get_shared_uniform("camera_position")
+        camera_position = self.renderer.frame_uniforms["camera_position"]
         nu, nv = self.mobject_uniforms["resolution"].astype(int)
         if camera_position is None or nu < 2 or nv < 2:
             return False

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -145,6 +145,10 @@ class ShaderWrapper(object):
         self.vaos = []
         self.data_texture = None
         self.uniform_buffer = None
+        # Which write to each of the mobject's arrays was the last to be sent, see
+        # write_vertex_buffer
+        self.data_version = 0
+        self.uniform_version = 0
 
     def add_texture(self, name: str, texture: moderngl.Texture):
         max_units = self.ctx.info['GL_MAX_TEXTURE_IMAGE_UNITS']
@@ -173,10 +177,11 @@ class ShaderWrapper(object):
 
     def write_vertex_buffer(self):
         """
-        The mobject's data, sent as it sits, when it has changed since it last was. A
-        buffer of the wrong size counts as much as changed values do, an array being
-        replaced rather than written into when it is resized, and no buffer at all means
-        either that nothing has been sent yet or that the shaders were built afresh.
+        The mobject's data, sent as it sits, when the array has been written to since it
+        last was sent. A buffer of the wrong size counts as much as written values do, an
+        array being replaced rather than written into when it is resized, and no buffer at
+        all means either that nothing has been sent yet or that the shaders were built
+        afresh.
         """
         array = self.mobject_data.array
         if len(array) == 0:
@@ -189,11 +194,11 @@ class ShaderWrapper(object):
         if self.vbo is None:
             self.vbo = self.ctx.buffer(array)
             self.generate_vaos()
-        elif self.mobject_data.changed:
+        elif self.mobject_data.version != self.data_version:
             self.vbo.write(array)
         else:
             return
-        self.mobject_data.changed = False
+        self.data_version = self.mobject_data.version
 
     def write_uniform_buffer(self):
         uniforms = self.mobject_uniforms
@@ -202,11 +207,11 @@ class ShaderWrapper(object):
             return
         if self.uniform_buffer is None:
             self.uniform_buffer = self.ctx.buffer(uniforms.array)
-        elif uniforms.changed:
+        elif uniforms.version != self.uniform_version:
             self.uniform_buffer.write(uniforms.array)
         else:
             return
-        uniforms.changed = False
+        self.uniform_version = uniforms.version
 
     def generate_vaos(self):
         if not self.programs:
@@ -421,13 +426,10 @@ class VShaderWrapper(ShaderWrapper):
         self.init_uniform_block()
 
     def init_vertex_objects(self):
+        super().init_vertex_objects()
         self.has_fill = False
-        self.vbo = None
         self.stroke_vao = None
         self.fill_vao = None
-        self.vaos = []
-        self.data_texture = None
-        self.uniform_buffer = None
 
     def generate_vaos(self):
         self.init_data_texture()
@@ -447,7 +449,7 @@ class VShaderWrapper(ShaderWrapper):
         # than looked at per frame. Many a mobject is stroke alone, and would otherwise
         # pay for all three of the fill passes, and the state they set, for nothing.
         uniforms = self.mobject_uniforms
-        if uniforms.changed:
+        if uniforms.version != self.uniform_version:
             self.has_fill = bool(uniforms["fill_rgba"][3] or uniforms["fill_rgba_end"][3])
         super().write_uniform_buffer()
 
@@ -551,5 +553,3 @@ class VShaderWrapper(ShaderWrapper):
         else:
             self.render_fill()
             self.render_stroke()
-
-

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -7,6 +7,12 @@ import OpenGL.GL as gl
 import moderngl
 import numpy as np
 
+from manimlib.renderer import CULL_BACK
+from manimlib.renderer import CULL_FRONT
+from manimlib.renderer import DEFAULT
+from manimlib.renderer import FILL_BORDER
+from manimlib.renderer import WINDING_COUNT
+from manimlib.renderer import WINDING_COVER
 from manimlib.utils.shaders import MOBJECT_BLOCK_BINDING
 from manimlib.utils.shaders import MOBJECT_BLOCK_NAME
 from manimlib.utils.shaders import check_uniform_block
@@ -41,12 +47,13 @@ class ShaderWrapper(object):
     itself, through a texture pointed at it, and expands every one into verts_per_record
     vertices, always triangles, see inserts/read_data.glsl.
 
-    Drawing means pre_render, which asks the context for what this mobject needs, its
-    textures among it, and then render. There is one wrapper to a mobject rather than to
-    a kind of mobject, which is what lets a fill count its own winding in the stencil
-    buffer without the mobject beside it joining in, and what any drawing taking more
-    than a single pass is built on: see VShaderWrapper, for a fill and the stroke around
-    it, and SurfaceShaderWrapper, for the two sides of a surface.
+    Drawing comes in two halves, so that every write a frame makes lands before any of its
+    draws: write_buffers sends what has changed, and render binds this mobject's buffers,
+    asks the renderer for the state each pass wants, and draws. There is one wrapper to a
+    mobject rather than to a kind of mobject, which is what lets a fill count its own
+    winding in the stencil buffer without the mobject beside it joining in, and what any
+    drawing taking more than a single pass is built on: see VShaderWrapper, for a fill and
+    the stroke around it, and SurfaceShaderWrapper, for the two sides of a surface.
     """
 
     def __init__(
@@ -166,13 +173,6 @@ class ShaderWrapper(object):
             code_map[name] = re.sub(old, new, code_map[name])
         self.init_program()
 
-    # Changing context
-    def set_ctx_depth_test(self, enable: bool = True) -> None:
-        if enable:
-            self.ctx.enable(moderngl.DEPTH_TEST)
-        else:
-            self.ctx.disable(moderngl.DEPTH_TEST)
-
     # Adding data
 
     def write_vertex_buffer(self):
@@ -235,15 +235,21 @@ class ShaderWrapper(object):
         gl.glTexBuffer(gl.GL_TEXTURE_BUFFER, gl.GL_R32F, self.vbo.glo)
 
     # Related to data and rendering
-    def pre_render(self):
+    def write_buffers(self):
         """
-        All that the draw needs in place: the mobject's two arrays written into their
-        buffers, its textures bound with the samplers pointed at them, and the context
-        asked for what this mobject wants of it.
+        The mobject's two arrays into their buffers. Every wrapper of a frame does this
+        before any of them draws, since a write reaching the gpu partway through a wgpu
+        render pass has no say over whether the draws before it see the old values or the
+        new, see Camera.capture.
         """
         self.write_vertex_buffer()
         self.write_uniform_buffer()
-        self.set_ctx_depth_test(self.depth_test)
+
+    def bind(self):
+        """
+        Points the programs at this mobject's own buffers and textures, which whatever was
+        drawn before it will have pointed at its own.
+        """
         for tid, texture in enumerate(self.textures):
             texture.use(tid)
         if self.data_texture is not None:
@@ -256,6 +262,11 @@ class ShaderWrapper(object):
             self.uniform_buffer.bind_to_uniform_block(MOBJECT_BLOCK_BINDING)
 
     def render(self):
+        self.bind()
+        self.renderer.use(DEFAULT, self.depth_test)
+        self.draw()
+
+    def draw(self):
         n_verts = self.verts_per_record * len(self.mobject_data)
         for vao in self.vaos:
             vao.render(vertices=n_verts)
@@ -299,18 +310,25 @@ class SurfaceShaderWrapper(ShaderWrapper):
 
     def init_vertex_objects(self):
         super().init_vertex_objects()
+        self.ordered = False
         self.order_ibo = None
         self.order_vao = None
 
+    def write_buffers(self):
+        super().write_buffers()
+        # Ordering the triangles writes a buffer of its own, so it belongs here rather
+        # than among the draws
+        self.ordered = self.sort_to_camera and self.order_triangles_by_depth()
+
     def render(self):
-        if self.sort_to_camera and self.order_triangles_by_depth():
+        self.bind()
+        if self.ordered:
+            self.renderer.use(DEFAULT, self.depth_test)
             self.order_vao.render(vertices=self.order_ibo.size // 4)
             return
-        gl.glEnable(gl.GL_CULL_FACE)
-        for culled in (gl.GL_FRONT, gl.GL_BACK):
-            gl.glCullFace(culled)
-            super().render()
-        gl.glDisable(gl.GL_CULL_FACE)
+        for state in (CULL_FRONT, CULL_BACK):
+            self.renderer.use(state, self.depth_test)
+            self.draw()
 
     def order_triangles_by_depth(self) -> bool:
         """
@@ -481,6 +499,7 @@ class VShaderWrapper(ShaderWrapper):
         if self.stroke_vao is None:
             return
         set_program_uniform(self.stroke_program, "is_fill_border", False)
+        self.renderer.use(DEFAULT, self.depth_test)
         self.stroke_vao.render(vertices=self.stroke_verts_per_curve * self.get_num_curves())
 
     def render_fill(self):
@@ -506,47 +525,33 @@ class VShaderWrapper(ShaderWrapper):
         if self.fill_vao is None or not self.has_fill:
             return
 
-        gl.glEnable(gl.GL_STENCIL_TEST)
-
-        # Pass 1: Count the winding number around each pixel. Depth testing must
-        # be off here, since an occluded triangle which failed to contribute
-        # would throw off the count, and depth writing must be off so that these
-        # invisible triangles don't clobber the depth buffer.
-        self.ctx.disable(moderngl.DEPTH_TEST)
-        gl.glDepthMask(gl.GL_FALSE)
-        gl.glColorMask(*4 * [gl.GL_FALSE])
-        gl.glStencilFunc(gl.GL_ALWAYS, 0, 0xFF)
-        gl.glStencilOpSeparate(gl.GL_FRONT, gl.GL_KEEP, gl.GL_INCR_WRAP, gl.GL_INCR_WRAP)
-        gl.glStencilOpSeparate(gl.GL_BACK, gl.GL_KEEP, gl.GL_DECR_WRAP, gl.GL_DECR_WRAP)
+        # Pass 1: Count the winding number around each pixel. Depth testing is off for
+        # this, since an occluded triangle which failed to contribute would throw off the
+        # count, and depth writing too, so that these invisible triangles don't clobber
+        # the depth buffer. Nor is any color written.
+        self.renderer.use(WINDING_COUNT)
         self.fill_vao.render(vertices=self.fill_verts_per_curve * self.get_num_curves())
 
-        gl.glColorMask(*4 * [gl.GL_TRUE])
-        gl.glDepthMask(gl.GL_TRUE)
-        self.set_ctx_depth_test(self.depth_test)
-
-        # Trace the boundary of the shape with a stroke in the fill color, which
-        # is what anti-aliases the fill, since a stencil test is all or nothing.
-        # It's drawn only where the winding number is zero, meaning outside the
-        # shape, both because the inside is about to be filled in anyway, and so
-        # that its faded edge never blends on top of the fill, which would leave
-        # a seam along the boundary for partially transparent colors.
+        # Trace the boundary of the shape with a stroke in the fill color, which is what
+        # anti-aliases the fill, since a stencil test is all or nothing. It's drawn only
+        # where the winding number is zero, meaning outside the shape, both because the
+        # inside is about to be filled in anyway, and so that its faded edge never blends
+        # on top of the fill, which would leave a seam along the boundary for partially
+        # transparent colors.
         set_program_uniform(self.stroke_program, "is_fill_border", True)
-        gl.glStencilFunc(gl.GL_EQUAL, 0, 0xFF)
-        gl.glStencilOp(gl.GL_KEEP, gl.GL_KEEP, gl.GL_KEEP)
+        self.renderer.use(FILL_BORDER, self.depth_test)
         self.stroke_vao.render(vertices=self.stroke_verts_per_curve * self.get_num_curves())
 
-        # Pass 2: Color in everywhere the winding number is nonzero. Zeroing the
-        # stencil on the way through means the first triangle to cover a pixel
-        # is the only one to color it, and that no clearing is needed afterwards.
-        # Note that zeroing on depth failure matters just as much as on depth
-        # success, else occluded fills would leave the buffer dirty.
-        gl.glStencilFunc(gl.GL_NOTEQUAL, 0, 0xFF)
-        gl.glStencilOp(gl.GL_KEEP, gl.GL_ZERO, gl.GL_ZERO)
+        # Pass 2: Color in everywhere the winding number is nonzero. Zeroing the stencil
+        # on the way through means the first triangle to cover a pixel is the only one to
+        # color it, and that no clearing is needed afterwards. Note that zeroing on depth
+        # failure matters just as much as on depth success, else occluded fills would
+        # leave the buffer dirty.
+        self.renderer.use(WINDING_COVER, self.depth_test)
         self.fill_vao.render(vertices=self.fill_verts_per_curve * self.get_num_curves())
 
-        gl.glDisable(gl.GL_STENCIL_TEST)
-
     def render(self):
+        self.bind()
         if self.stroke_behind:
             self.render_stroke()
             self.render_fill()

--- a/manimlib/shader_wrapper.py
+++ b/manimlib/shader_wrapper.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional
+    from manimlib.renderer import Renderer
 
 UNIFORM_BLOCK_BINDING = 0
 
@@ -53,7 +54,7 @@ class ShaderWrapper(object):
 
     def __init__(
         self,
-        ctx: moderngl.context.Context,
+        renderer: Renderer,
         mobject_data: StructuredArray,
         mobject_uniforms: Uniforms,
         shader_folder: Optional[str] = None,
@@ -62,7 +63,9 @@ class ShaderWrapper(object):
         code_replacements: dict[str, str] = dict(),
         verts_per_record: int = 0,
     ):
-        self.ctx = ctx
+        self.renderer = renderer
+        # The context is the renderer's, kept here as well for how often it is wanted
+        self.ctx = renderer.ctx
         self.mobject_data = mobject_data
         self.shader_folder = shader_folder
         self.depth_test = depth_test
@@ -378,7 +381,7 @@ class VShaderWrapper(ShaderWrapper):
 
     def __init__(
         self,
-        ctx: moderngl.context.Context,
+        renderer: Renderer,
         mobject_data: StructuredArray,
         mobject_uniforms: Uniforms,
         shader_folder: Optional[str] = None,
@@ -390,7 +393,7 @@ class VShaderWrapper(ShaderWrapper):
     ):
         self.stroke_behind = stroke_behind
         super().__init__(
-            ctx=ctx,
+            renderer=renderer,
             mobject_data=mobject_data,
             shader_folder=shader_folder,
             mobject_uniforms=mobject_uniforms,

--- a/manimlib/shaders/image/frag.glsl
+++ b/manimlib/shaders/image/frag.glsl
@@ -8,7 +8,10 @@ in float v_opacity;
 
 out vec4 frag_color;
 
+#INSERT clip_test.glsl
+
 void main() {
+    clip_test();
     frag_color = texture(Texture, v_im_coords);
     frag_color.a *= v_opacity;
 }

--- a/manimlib/shaders/inserts/clip_test.glsl
+++ b/manimlib/shaders/inserts/clip_test.glsl
@@ -1,0 +1,16 @@
+/*
+Cuts away whatever falls outside a mobject's clip planes.
+
+The vertex shader works out how far each point sits on the keeping side of each of the four
+planes, see emit_gl_Position.glsl, and every fragment shader drops a fragment which any of
+them puts outside. Dropping a fragment rather than cutting the geometry is what a hardware
+clip distance did until now; it comes to the same picture, the boundary being a hard edge
+either way since nothing anti-aliases a cut, and a dropped fragment writing neither color
+nor depth nor stencil. It is also the only way wgpu offers, which has no clip distance on
+every backend it targets.
+*/
+in vec4 clip_distances;
+
+void clip_test(){
+    if (any(lessThan(clip_distances, vec4(0.0)))) discard;
+}

--- a/manimlib/shaders/inserts/emit_gl_Position.glsl
+++ b/manimlib/shaders/inserts/emit_gl_Position.glsl
@@ -1,12 +1,15 @@
 #INSERT frame_uniforms.glsl
 #INSERT frame_units.glsl
 
+/*
+How far a point sits on the keeping side of each of the mobject's four clip planes, for the
+fragment shader to cut what falls outside, see clip_test.glsl. A distance is written for
+every plane whether or not it is in use, an unused one being all zeros, which stands for
+keeping everything.
+*/
+out vec4 clip_distances;
+
 float clip_distance(vec3 point, vec4 plane){
-    /*
-    Clipping stays switched on, so a distance has to be written for every plane,
-    whether or not it's in use. An unset plane is all zeros, which stands for
-    keeping everything.
-    */
     if (plane.xyz == vec3(0.0)) return 1.0;
     return dot(vec4(point, 1.0), plane);
 }
@@ -22,8 +25,10 @@ void emit_gl_Position(vec3 point){
     result.z *= -0.1;
     gl_Position = result;
     
-    gl_ClipDistance[0] = clip_distance(point, clip_plane0);
-    gl_ClipDistance[1] = clip_distance(point, clip_plane1);
-    gl_ClipDistance[2] = clip_distance(point, clip_plane2);
-    gl_ClipDistance[3] = clip_distance(point, clip_plane3);
+    clip_distances = vec4(
+        clip_distance(point, clip_plane0),
+        clip_distance(point, clip_plane1),
+        clip_distance(point, clip_plane2),
+        clip_distance(point, clip_plane3)
+    );
 }

--- a/manimlib/shaders/inserts/emit_gl_Position.glsl
+++ b/manimlib/shaders/inserts/emit_gl_Position.glsl
@@ -1,7 +1,4 @@
-uniform mat4 view;
-uniform float focal_distance;
-uniform vec3 frame_rescale_factors;
-
+#INSERT frame_uniforms.glsl
 #INSERT frame_units.glsl
 
 float clip_distance(vec3 point, vec4 plane){

--- a/manimlib/shaders/inserts/finalize_color.glsl
+++ b/manimlib/shaders/inserts/finalize_color.glsl
@@ -1,5 +1,4 @@
-uniform vec3 light_position;
-uniform vec3 camera_position;
+#INSERT frame_uniforms.glsl
 
 vec3 float_to_color(float value, float min_val, float max_val, vec3[9] colormap_data){
     float alpha = clamp((value - min_val) / (max_val - min_val), 0.0, 1.0);

--- a/manimlib/shaders/inserts/frame_uniforms.glsl
+++ b/manimlib/shaders/inserts/frame_uniforms.glsl
@@ -1,0 +1,21 @@
+/*
+What holds for every mobject of a frame: where the camera is looking from and along, how
+much of the scene the frame covers, and where the light is. One block, written once a frame
+by the camera rather than pushed into each program separately, see Camera.refresh_uniforms
+and shaders.FRAME_UNIFORMS, which this mirrors.
+
+Guarded, since several inserts want these and a block may only be declared once.
+*/
+#ifndef MANIM_FRAME_UNIFORMS
+#define MANIM_FRAME_UNIFORMS
+
+layout (std140) uniform FrameUniforms {
+    mat4 view;
+    vec3 frame_rescale_factors;
+    float frame_scale;
+    vec3 camera_position;
+    float pixel_size;
+    vec3 light_position;
+};
+
+#endif

--- a/manimlib/shaders/inserts/frame_units.glsl
+++ b/manimlib/shaders/inserts/frame_units.glsl
@@ -1,5 +1,4 @@
-uniform float frame_scale;
-uniform float pixel_size;
+#INSERT frame_uniforms.glsl
 
 /*
 Points fixed in frame skip the view matrix (see emit_gl_Position), so they are drawn

--- a/manimlib/shaders/mandelbrot_fractal/frag.glsl
+++ b/manimlib/shaders/mandelbrot_fractal/frag.glsl
@@ -22,10 +22,12 @@ out vec4 frag_color;
 #INSERT mobject_uniforms.glsl
 #INSERT finalize_color.glsl
 #INSERT complex_functions.glsl
+#INSERT clip_test.glsl
 
 const int MAX_DEGREE = 5;
 
 void main() {
+    clip_test();
     vec3 color_map[9] = vec3[9](
         color0, color1, color2, color3,
         color4, color5, color6, color7, color8

--- a/manimlib/shaders/newton_fractal/frag.glsl
+++ b/manimlib/shaders/newton_fractal/frag.glsl
@@ -33,6 +33,7 @@ out vec4 frag_color;
 #INSERT mobject_uniforms.glsl
 #INSERT finalize_color.glsl
 #INSERT complex_functions.glsl
+#INSERT clip_test.glsl
 
 const int MAX_DEGREE = 5;
 const float CLOSE_ENOUGH = 1e-3;
@@ -74,6 +75,7 @@ vec2 seek_root(vec2 z, vec2[MAX_DEGREE + 1] coefs, int max_steps, out float n_it
 }
 
 void main() {
+    clip_test();
     vec2[MAX_DEGREE + 1] coefs = vec2[MAX_DEGREE + 1](coef0, coef1, coef2, coef3, coef4, coef5);
     vec2[MAX_DEGREE] roots = vec2[MAX_DEGREE](root0, root1, root2, root3, root4);
     vec4[MAX_DEGREE] colors = vec4[MAX_DEGREE](color0, color1, color2, color3, color4);

--- a/manimlib/shaders/quadratic_bezier/fill/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier/fill/frag.glsl
@@ -7,7 +7,10 @@ in vec2 uv_coords;
 
 out vec4 frag_color;
 
+#INSERT clip_test.glsl
+
 void main() {
+    clip_test();
     if (color.a == 0) discard;
 
     // For the triangles hugging a bezier curve, cut away the part of the

--- a/manimlib/shaders/quadratic_bezier/stroke/frag.glsl
+++ b/manimlib/shaders/quadratic_bezier/stroke/frag.glsl
@@ -9,7 +9,10 @@ in vec4 color;
 
 out vec4 frag_color;
 
+#INSERT clip_test.glsl
+
 void main() {
+    clip_test();
     frag_color = color;
     // sdf for the region around the curve we wish to color.
     float signed_dist_to_region = abs(dist_to_aaw) - half_width_to_aaw;

--- a/manimlib/shaders/surface/frag.glsl
+++ b/manimlib/shaders/surface/frag.glsl
@@ -4,6 +4,9 @@
 in vec4 v_color;
 out vec4 frag_color;
 
+#INSERT clip_test.glsl
+
 void main() {
+    clip_test();
     frag_color = v_color;
 }

--- a/manimlib/shaders/textured_surface/frag.glsl
+++ b/manimlib/shaders/textured_surface/frag.glsl
@@ -12,10 +12,12 @@ out vec4 frag_color;
 
 #INSERT textured_surface_uniforms.glsl
 #INSERT finalize_color.glsl
+#INSERT clip_test.glsl
 
 const float dark_shift = 0.2;
 
 void main() {
+    clip_test();
     vec4 color = texture(LightTexture, v_im_coords);
     if(num_textures == 2.0){
         vec4 dark_color = texture(DarkTexture, v_im_coords);

--- a/manimlib/shaders/true_dot/frag.glsl
+++ b/manimlib/shaders/true_dot/frag.glsl
@@ -1,6 +1,5 @@
 #version 330
 
-uniform mat4 perspective;
 
 in vec4 color;
 in float scaled_aaw;

--- a/manimlib/shaders/true_dot/frag.glsl
+++ b/manimlib/shaders/true_dot/frag.glsl
@@ -14,8 +14,10 @@ out vec4 frag_color;
 // This includes a declaration of uniform vec3 shading
 #INSERT dot_cloud_uniforms.glsl
 #INSERT finalize_color.glsl
+#INSERT clip_test.glsl
 
 void main() {
+    clip_test();
     float r = length(uv_coords.xy);
     if(r > 1.0) discard;
 

--- a/manimlib/shaders/true_dot/vert.glsl
+++ b/manimlib/shaders/true_dot/vert.glsl
@@ -1,7 +1,5 @@
 #version 330
 
-uniform vec3 camera_position;
-
 out vec4 color;
 out float scaled_aaw;
 out vec3 point;

--- a/manimlib/utils/shaders.py
+++ b/manimlib/utils/shaders.py
@@ -260,7 +260,7 @@ class Uniforms(StructuredArray):
         if np.array_equal(floats1, floats2) and np.array_equal(self.floats, floats1):
             return
         self.floats[:] = (1 - alpha) * floats1 + alpha * floats2
-        self.changed = True
+        self.note_change()
 
 
 @lru_cache()

--- a/manimlib/utils/shaders.py
+++ b/manimlib/utils/shaders.py
@@ -24,12 +24,6 @@ if TYPE_CHECKING:
 PROGRAM_UNIFORM_MIRRORS: dict[int, dict[str, float | tuple]] = dict()
 # Names each program turned out not to have, so they aren't looked up again
 PROGRAM_ABSENT_UNIFORMS: dict[int, set[str]] = dict()
-# Every program which has been compiled, so that uniforms shared by all of them,
-# like those describing the camera, can be set once rather than once per mobject
-ALL_PROGRAMS: list[moderngl.Program] = []
-# The values last set for all of them, since programs are compiled on first use,
-# which may well be partway through a frame
-SHARED_UNIFORMS: dict[str, float | tuple] = dict()
 
 
 @lru_cache()
@@ -52,32 +46,12 @@ def get_shader_program(
         vertex_shader=vertex_shader,
         fragment_shader=fragment_shader,
     )
-    ALL_PROGRAMS.append(program)
-    for name, value in SHARED_UNIFORMS.items():
-        set_program_uniform(program, name, value)
+    # Which binding the frame's uniforms will be found at. Every program reads the same
+    # values from the same buffer, so this is settled once, when the program is compiled,
+    # rather than once a frame, see Renderer.
+    if check_uniform_block(program, FRAME_DTYPE, FRAME_BLOCK_NAME):
+        program[FRAME_BLOCK_NAME].binding = FRAME_BLOCK_BINDING
     return program
-
-
-def set_shared_uniforms(uniforms: UniformDict) -> None:
-    """
-    Sets uniforms which hold for every program, e.g. those describing where the
-    camera is. Doing this once a frame saves each mobject from pushing values it
-    shares with all the others.
-    """
-    SHARED_UNIFORMS.clear()
-    SHARED_UNIFORMS.update(uniforms)
-    for program in ALL_PROGRAMS:
-        for name, value in uniforms.items():
-            set_program_uniform(program, name, value)
-
-
-def get_shared_uniform(name: str) -> float | tuple | None:
-    """
-    One of the values which hold for every program, e.g. where the camera is, as it was
-    last set for the frame being drawn. None before anything has set them. See
-    set_shared_uniforms.
-    """
-    return SHARED_UNIFORMS.get(name, None)
 
 
 def set_program_uniform(
@@ -156,6 +130,7 @@ members every kind has, see inserts/vmobject_uniforms.glsl for an example, and l
 out a matching dtype with uniform_block_dtype, see Mobject.uniform_dtype.
 """
 MOBJECT_BLOCK_NAME = "MobjectUniforms"
+MOBJECT_BLOCK_BINDING = 0
 # What every mobject holds, whatever kind it is, as a name and a number of floats.
 # Mirrors inserts/common_uniform_members.glsl, and comes first in every block for the
 # same reason it does there: so the inserts reading them work wherever they are used.
@@ -167,16 +142,35 @@ COMMON_UNIFORMS = (
     ("clip_plane2", 4),
     ("clip_plane3", 4),
 )
-# What a block member of each size is called in a shader. Anything wider than a vec4,
-# a matrix say, is left out, since a block pads their columns in ways this would have
-# to know about.
-BLOCK_MEMBER_TYPES = {1: "float", 2: "vec2", 3: "vec3", 4: "vec4"}
+# What a block member of each size is called in a shader. A mat4 is in there because a
+# block lays one out as four vec4 columns, which is four vec4s and nothing else; a mat3
+# is not, because its columns get padded out to vec4 and this would have to know it.
+BLOCK_MEMBER_TYPES = {1: "float", 2: "vec2", 3: "vec3", 4: "vec4", 16: "mat4"}
 GL_MEMBER_SIZES = {
     gl.GL_FLOAT: 1,
     gl.GL_FLOAT_VEC2: 2,
     gl.GL_FLOAT_VEC3: 3,
     gl.GL_FLOAT_VEC4: 4,
+    gl.GL_FLOAT_MAT4: 16,
 }
+
+"""
+The camera's uniforms travel the same way a mobject's do, in one block, except that there
+is one of them for the whole frame rather than one per mobject. Every program reads it from
+the same buffer, bound once when the program is compiled, see get_shader_program.
+"""
+FRAME_BLOCK_NAME = "FrameUniforms"
+FRAME_BLOCK_BINDING = 1
+# Mirrors inserts/frame_uniforms.glsl. Ordered so that each vec3 is followed by the float
+# which fits beside it, leaving nothing padded but the last three floats.
+FRAME_UNIFORMS = (
+    ("view", 16),
+    ("frame_rescale_factors", 3),
+    ("frame_scale", 1),
+    ("camera_position", 3),
+    ("pixel_size", 1),
+    ("light_position", 3),
+)
 
 
 def uniform_block_dtype(*members: tuple[str, int]) -> np.dtype:
@@ -232,6 +226,9 @@ def uniform_block_code(dtype: np.dtype) -> str:
     return "\n".join(lines)
 
 
+FRAME_DTYPE = uniform_block_dtype(*FRAME_UNIFORMS)
+
+
 class Uniforms(StructuredArray):
     """
     A mobject's uniforms: one value each for the whole of it, laid out to match the
@@ -264,10 +261,14 @@ class Uniforms(StructuredArray):
 
 
 @lru_cache()
-def check_uniform_block(program: moderngl.Program, dtype: np.dtype) -> bool:
+def check_uniform_block(
+    program: moderngl.Program,
+    dtype: np.dtype,
+    block_name: str = MOBJECT_BLOCK_NAME,
+) -> bool:
     """
-    Whether a program declares the mobject block at all, and if it does, that its
-    members sit exactly where the dtype says they do.
+    Whether a program declares the block at all, and if it does, that its members sit
+    exactly where the dtype says they do.
 
     Nothing needs this to render, since std140's layout is what uniform_block_dtype
     reproduces, but a shader's block and a mobject's uniform_dtype drifting apart
@@ -275,7 +276,7 @@ def check_uniform_block(program: moderngl.Program, dtype: np.dtype) -> bool:
     costs a handful of calls into the driver, once per program.
     """
     glo = program.glo
-    index = gl.glGetUniformBlockIndex(glo, MOBJECT_BLOCK_NAME)
+    index = gl.glGetUniformBlockIndex(glo, block_name)
     if index == gl.GL_INVALID_INDEX:
         return False
 
@@ -303,10 +304,10 @@ def check_uniform_block(program: moderngl.Program, dtype: np.dtype) -> bool:
         if field is None or size is None or size != (shape[0] if shape else 1) \
                 or field[1] != offset:
             raise ValueError(
-                f"The {MOBJECT_BLOCK_NAME} block this shader declares does not match "
-                f"the uniforms of the mobject drawn with it, starting at {name}. "
-                f"What the mobject holds would be declared as:\n"
-                f"layout (std140) uniform {MOBJECT_BLOCK_NAME} {{\n"
+                f"The {block_name} block this shader declares does not match what "
+                f"is held for it, starting at {name}. What is held would be declared "
+                f"as:\n"
+                f"layout (std140) uniform {block_name} {{\n"
                 f"{uniform_block_code(dtype)}\n}};"
             )
     return True

--- a/manimlib/utils/structured_array.py
+++ b/manimlib/utils/structured_array.py
@@ -23,21 +23,21 @@ class StructuredArray(object):
     Either way, what gets sent is a copy of the whole array, which is why the layout has
     to mirror what the shader declares, see Mobject.data_dtype and uniform_dtype.
 
-    Three things come with holding it here rather than as a bare array. Whether anything
-    has changed since it was last sent is noted, so that nothing needs sending twice, and
-    nothing needs to say that it changed. Emptying the array remembers what was in it, so
-    that a mobject stripped of its points and given new ones keeps the style it had, see
-    resize. And fields are read and written by name, as with a dict, while rows are read
-    and written by index, as with the array itself.
+    Three things come with holding it here rather than as a bare array. Every write to
+    it is counted, so that whatever has sent it somewhere can tell whether what it sent
+    is still what the array holds, and nothing needs to say that it changed. Emptying the
+    array remembers what was in it, so that a mobject stripped of its points and given
+    new ones keeps the style it had, see resize. And fields are read and written by name,
+    as with a dict, while rows are read and written by index, as with the array itself.
 
-    Either kind of write is noted. Reading, though, hands back a view onto the array, so
-    writing through one of those, as in
+    Either kind of write is counted. Reading, though, hands back a view onto the array,
+    so writing through one of those, as in
 
         mob.data["point"][::2] = new_points
 
-    goes unnoticed, and whoever does it has to say so with
+    goes uncounted, and whoever does it has to say so with
 
-        mob.data.changed = True
+        mob.data.note_change()
 
     Assigning the whole field instead, mob.data["point"] = new_points, needs no such
     thing, and is the same operation as far as the array is concerned: a field cannot
@@ -48,15 +48,20 @@ class StructuredArray(object):
         self.array: np.ndarray = np.zeros(length, dtype=dtype)
         # What to fill in with when growing from nothing, see resize
         self.defaults: np.ndarray = np.ones(1, dtype=dtype)
-        # Nothing has been sent yet, so it all counts as having changed
-        self.changed: bool = True
+        # Counted up by every write, and started above zero so that anything watching
+        # the array, which starts from zero, has something to send in the first place.
+        # A count rather than a yes or no, since more than one thing may be watching,
+        # e.g. a mobject drawn both on its own and as part of a merged family, and each
+        # needs to know what it has missed rather than whether anyone has missed
+        # anything, see ShaderWrapper.write_vertex_buffer and MergedRun.gather.
+        self.version: int = 1
 
     def __getitem__(self, key: str | int | slice | np.ndarray) -> np.ndarray:
         return self.array[key]
 
     def __setitem__(self, key: str | int | slice | np.ndarray, value: Any) -> None:
         self.array[key] = value
-        self.changed = True
+        self.version += 1
 
     def __len__(self) -> int:
         return len(self.array)
@@ -70,6 +75,13 @@ class StructuredArray(object):
     def __repr__(self) -> str:
         values = ", ".join(f"{key}={self[key]}" for key in self)
         return f"{type(self).__name__}({values})"
+
+    def note_change(self) -> None:
+        """
+        Says that the array was written to in a way it had no chance to count, as any
+        write through a view onto it is.
+        """
+        self.version += 1
 
     @property
     def dtype(self) -> np.dtype:
@@ -108,8 +120,8 @@ class StructuredArray(object):
         """
         The rows held, or the row of defaults standing in for them while there are
         none, which is where a style read or written in the meantime belongs. Being the
-        array itself, writing into what this hands back goes unnoticed, so say so with
-        changed = True.
+        array itself, writing into what this hands back goes uncounted, so say so with
+        note_change.
         """
         return self.array if len(self.array) else self.defaults
 
@@ -129,7 +141,7 @@ class StructuredArray(object):
         elif len(self.array) == 0:
             self.array = self.defaults.copy()
         self.array = resize_func(self.array, length)
-        self.changed = True
+        self.version += 1
 
     def match(self, other: StructuredArray) -> None:
         """
@@ -138,7 +150,7 @@ class StructuredArray(object):
         """
         if self.dtype == other.dtype and len(self) == len(other):
             self.array[:] = other.array
-            self.changed = True
+            self.version += 1
         else:
             self.update(other)
 
@@ -146,5 +158,5 @@ class StructuredArray(object):
         result = copy.copy(self)
         result.array = self.array.copy()
         result.defaults = self.defaults.copy()
-        result.changed = True
+        result.version += 1
         return result

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -6,10 +6,13 @@ import moderngl_window as mglw
 from moderngl_window.context.pyglet.window import Window as PygletWindow
 from moderngl_window.timers.clock import Timer
 from functools import wraps
+from pyglet.window import key as PygletWindowKeys
 import screeninfo
 
 from manimlib.constants import ASPECT_RATIO
 from manimlib.constants import FRAME_SHAPE
+from manimlib.event_keys import Keys
+from manimlib.event_keys import Mods
 
 from typing import TYPE_CHECKING
 
@@ -18,6 +21,45 @@ if TYPE_CHECKING:
     from manimlib.scene.scene import Scene
 
     T = TypeVar("T")
+
+
+# What the window is built on calls a key one thing and manim calls it another, so this
+# is the one place either vocabulary meets the other, see event_keys.py. A key which types
+# something needs no entry, being named by what it types in both.
+KEY_NAMES: dict[int, int] = {
+    PygletWindowKeys.BACKSPACE: Keys.BACKSPACE,
+    PygletWindowKeys.TAB: Keys.TAB,
+    PygletWindowKeys.ENTER: Keys.ENTER,
+    PygletWindowKeys.ESCAPE: Keys.ESCAPE,
+    PygletWindowKeys.DELETE: Keys.DELETE,
+    PygletWindowKeys.LEFT: Keys.LEFT,
+    PygletWindowKeys.RIGHT: Keys.RIGHT,
+    PygletWindowKeys.UP: Keys.UP,
+    PygletWindowKeys.DOWN: Keys.DOWN,
+    PygletWindowKeys.LSHIFT: Keys.SHIFT,
+    PygletWindowKeys.RSHIFT: Keys.SHIFT,
+    PygletWindowKeys.LCTRL: Keys.CTRL,
+    PygletWindowKeys.RCTRL: Keys.CTRL,
+    PygletWindowKeys.LALT: Keys.ALT,
+    PygletWindowKeys.RALT: Keys.ALT,
+    PygletWindowKeys.LCOMMAND: Keys.CMD,
+    PygletWindowKeys.RCOMMAND: Keys.CMD,
+}
+MOD_NAMES: list[tuple[int, int]] = [
+    (PygletWindowKeys.MOD_SHIFT, Mods.SHIFT),
+    (PygletWindowKeys.MOD_CTRL, Mods.CTRL),
+    (PygletWindowKeys.MOD_ALT, Mods.ALT),
+    (PygletWindowKeys.MOD_COMMAND, Mods.CMD),
+    (PygletWindowKeys.MOD_CAPSLOCK, Mods.CAPS_LOCK),
+]
+
+
+def to_key(symbol: int) -> int:
+    return KEY_NAMES.get(symbol, symbol)
+
+
+def to_mods(modifiers: int) -> int:
+    return sum(mine for theirs, mine in MOD_NAMES if modifiers & theirs)
 
 
 class Window(PygletWindow):
@@ -167,7 +209,7 @@ class Window(PygletWindow):
             return
         point = self.pixel_coords_to_space_coords(x, y)
         d_point = self.pixel_coords_to_space_coords(dx, dy, relative=True)
-        self.scene.on_mouse_drag(point, d_point, buttons, modifiers)
+        self.scene.on_mouse_drag(point, d_point, buttons, to_mods(modifiers))
 
     @note_undrawn_event
     def on_mouse_press(self, x: int, y: int, button: int, mods: int) -> None:
@@ -175,7 +217,7 @@ class Window(PygletWindow):
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
-        self.scene.on_mouse_press(point, button, mods)
+        self.scene.on_mouse_press(point, button, to_mods(mods))
 
     @note_undrawn_event
     def on_mouse_release(self, x: int, y: int, button: int, mods: int) -> None:
@@ -183,7 +225,7 @@ class Window(PygletWindow):
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
-        self.scene.on_mouse_release(point, button, mods)
+        self.scene.on_mouse_release(point, button, to_mods(mods))
 
     @note_undrawn_event
     def on_mouse_scroll(self, x: int, y: int, x_offset: float, y_offset: float) -> None:
@@ -196,19 +238,19 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_key_press(self, symbol: int, modifiers: int) -> None:
-        self.pressed_keys.add(symbol)  # Modifiers?
+        self.pressed_keys.add(to_key(symbol))
         super().on_key_press(symbol, modifiers)
         if not self.scene:
             return
-        self.scene.on_key_press(symbol, modifiers)
+        self.scene.on_key_press(to_key(symbol), to_mods(modifiers))
 
     @note_undrawn_event
     def on_key_release(self, symbol: int, modifiers: int) -> None:
-        self.pressed_keys.difference_update({symbol})  # Modifiers?
+        self.pressed_keys.difference_update({to_key(symbol)})
         super().on_key_release(symbol, modifiers)
         if not self.scene:
             return
-        self.scene.on_key_release(symbol, modifiers)
+        self.scene.on_key_release(to_key(symbol), to_mods(modifiers))
 
     @note_undrawn_event
     def on_resize(self, width: int, height: int) -> None:

--- a/tests/render_compare.py
+++ b/tests/render_compare.py
@@ -1,0 +1,233 @@
+"""
+Renders a fixed list of scenes and compares them against references rendered earlier.
+
+There is no way to unit test a renderer. What there is, is the frame it drew last time.
+So: capture references from a tree known to be good, then compare against them after every
+change which has any business leaving the picture alone.
+
+    python tests/render_compare.py capture --refs <dir>
+    python tests/render_compare.py compare --refs <dir>
+
+Any case which differs is reported with how far off it is and, for the worst frame, an
+image written to the output directory showing the two side by side over their difference.
+A tolerance may be given, for comparing renders which have no business being identical to
+the byte, as across a change of graphics api; within one renderer, expect nothing to move
+at all, and leave it at zero.
+
+    --only NAME [NAME ...]   just these cases
+    --tolerance N            allow a per channel difference of up to N out of 255
+    --quality l|m|hd|uhd     what to render at, low by default
+    --twice                  (capture) render everything twice and report anything unstable
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+TESTS = Path(__file__).parent
+SCENES = TESTS / "scenes.py"
+EXAMPLES = TESTS.parent / "example_scenes.py"
+
+# Every case is a scene, the file holding it, and whether one frame of it is enough. The
+# stills are quick and cover how a frame is drawn; the videos cover everything which only
+# goes wrong once a mobject changes between frames.
+CASES = [
+    (SCENES, "Fills", "still"),
+    (SCENES, "Strokes", "still"),
+    (SCENES, "PartialDraws", "still"),
+    (SCENES, "TextAndTex", "still"),
+    (SCENES, "ClipPlanes", "still"),
+    (SCENES, "ClippedInThree", "still"),
+    (SCENES, "Surfaces", "still"),
+    (SCENES, "TransparentSurfaces", "still"),
+    (SCENES, "TexturedAndImages", "still"),
+    (SCENES, "DotsAndVectors", "still"),
+    (SCENES, "FixedInFrame", "still"),
+    (SCENES, "Zoomed", "still"),
+    (SCENES, "ByCode", "still"),
+    (SCENES, "AnimWrite", "video"),
+    (SCENES, "AnimTransform", "video"),
+    (SCENES, "AnimShapes", "video"),
+    (SCENES, "AnimUpdaters", "video"),
+    (SCENES, "AnimCamera", "video"),
+    # The example scenes are the closest thing to real content in the repository, and
+    # between them they exercise most of what a video would
+    (EXAMPLES, "OpeningManimExample", "still"),
+    (EXAMPLES, "AnimatingMethods", "still"),
+    (EXAMPLES, "TextExample", "still"),
+    (EXAMPLES, "TexTransformExample", "still"),
+    (EXAMPLES, "TexIndexing", "still"),
+    (EXAMPLES, "UpdatersExample", "still"),
+    (EXAMPLES, "CoordinateSystemExample", "still"),
+    (EXAMPLES, "GraphExample", "still"),
+    (EXAMPLES, "SurfaceExample", "still"),
+    (EXAMPLES, "TexAndNumbersExample", "still"),
+    (EXAMPLES, "ControlsExample", "still"),
+]
+
+QUALITY_FLAGS = {"l": "-l", "m": "-m", "hd": "--hd", "uhd": "--uhd"}
+
+
+def render(case, into: Path, quality: str) -> Path | None:
+    """One case into a directory of its own, coming back with what it wrote"""
+    path, scene, kind = case
+    into.mkdir(parents=True, exist_ok=True)
+    command = ["manimgl", str(path), scene, "-w", QUALITY_FLAGS[quality],
+               "--video_dir", str(into)]
+    if kind == "still":
+        command.append("-s")
+    result = subprocess.run(command, capture_output=True, text=True)
+    written = list(into.glob(f"{scene}.*"))
+    if not written:
+        tail = "\n".join(result.stderr.strip().splitlines()[-6:])
+        print(f"  {scene:28s} FAILED TO RENDER\n{tail}")
+        return None
+    return written[0]
+
+
+def frames_of(path: Path, into: Path) -> list[np.ndarray]:
+    """Every frame of what was rendered, whether that is a still or a video"""
+    if path.suffix == ".png":
+        return [np.asarray(Image.open(path).convert("RGB"), dtype=np.int16)]
+    into.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error", "-i", str(path), str(into / "%05d.png")],
+        check=True,
+    )
+    return [
+        np.asarray(Image.open(frame).convert("RGB"), dtype=np.int16)
+        for frame in sorted(into.glob("*.png"))
+    ]
+
+
+def compare_frames(new: list[np.ndarray], old: list[np.ndarray]) -> dict:
+    """How far apart two renders are, and which frame is the worst of it"""
+    if len(new) != len(old):
+        return {"error": f"{len(new)} frames against {len(old)}"}
+    worst = {"frame": 0, "max": 0, "pixels": 0}
+    differing = 0
+    for index, (a, b) in enumerate(zip(new, old)):
+        if a.shape != b.shape:
+            return {"error": f"{a.shape} against {b.shape}"}
+        diff = np.abs(a - b)
+        pixels = int((diff.max(axis=2) > 0).sum())
+        if pixels:
+            differing += 1
+        if int(diff.max()) > worst["max"]:
+            worst = {"frame": index, "max": int(diff.max()), "pixels": pixels}
+    return {"frames": len(new), "differing": differing, **worst}
+
+
+def write_diff_image(new: np.ndarray, old: np.ndarray, path: Path) -> None:
+    """The reference over the new render over their difference, brightened to be visible"""
+    diff = np.abs(new - old)
+    amplified = np.clip(diff * max(1, 255 // max(1, int(diff.max()))), 0, 255)
+    rule = np.full((4, new.shape[1], 3), 128)
+    stack = np.vstack([old, rule, new, rule, amplified]).astype(np.uint8)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(stack).save(path)
+
+
+def run(args) -> int:
+    cases = [case for case in CASES if not args.only or case[1] in args.only]
+    if args.only:
+        missing = set(args.only) - {case[1] for case in cases}
+        if missing:
+            print(f"No such case: {', '.join(sorted(missing))}")
+            return 2
+
+    refs = Path(args.refs).expanduser()
+    work = refs / "_work"
+    if work.exists():
+        shutil.rmtree(work)
+
+    failures = []
+    for case in cases:
+        _, scene, kind = case
+        if args.command == "capture":
+            rendered = render(case, refs / "render", args.quality)
+            if rendered is None:
+                failures.append(scene)
+                continue
+            kept = refs / rendered.name
+            shutil.move(str(rendered), kept)
+            note = ""
+            if args.twice:
+                again = render(case, work / "again", args.quality)
+                same = again is not None and compare_frames(
+                    frames_of(again, work / "frames_a"),
+                    frames_of(kept, work / "frames_b"),
+                ).get("max") == 0
+                note = "  stable" if same else "  NOT STABLE between runs"
+                if not same:
+                    failures.append(scene)
+            print(f"  {scene:28s} captured{note}")
+            continue
+
+        reference = next((refs / f"{scene}.{ext}" for ext in ["png", "mp4"]
+                          if (refs / f"{scene}.{ext}").exists()), None)
+        if reference is None:
+            print(f"  {scene:28s} NO REFERENCE")
+            failures.append(scene)
+            continue
+        rendered = render(case, work / "render", args.quality)
+        if rendered is None:
+            failures.append(scene)
+            continue
+        new = frames_of(rendered, work / "frames_new")
+        old = frames_of(reference, work / "frames_old")
+        report = compare_frames(new, old)
+        if "error" in report:
+            print(f"  {scene:28s} SHAPE MISMATCH: {report['error']}")
+            failures.append(scene)
+            continue
+        if report["max"] <= args.tolerance:
+            within = "" if report["max"] == 0 else f" (within tolerance, max {report['max']})"
+            print(f"  {scene:28s} matches{within}")
+            continue
+        where = "" if report["frames"] == 1 else \
+            f", {report['differing']}/{report['frames']} frames, worst {report['frame'] + 1}"
+        print(f"  {scene:28s} DIFFERS: max {report['max']} on {report['pixels']} px{where}")
+        out = Path(args.out) / f"{scene}.png"
+        write_diff_image(new[report["frame"]], old[report["frame"]], out)
+        failures.append(scene)
+
+    if work.exists():
+        shutil.rmtree(work)
+    print()
+    if failures:
+        print(f"{len(failures)} of {len(cases)}: {', '.join(failures)}")
+        if args.command == "compare":
+            print(f"Diff images in {args.out}")
+        return 1
+    print(f"All {len(cases)} cases {'captured' if args.command == 'capture' else 'match'}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("command", choices=["capture", "compare", "list"])
+    parser.add_argument("--refs", default="~/.cache/manimgl-render-refs")
+    parser.add_argument("--out", default="/tmp/manimgl-render-diffs")
+    parser.add_argument("--only", nargs="+", default=[])
+    parser.add_argument("--tolerance", type=int, default=0)
+    parser.add_argument("--quality", choices=list(QUALITY_FLAGS), default="l")
+    parser.add_argument("--twice", action="store_true")
+    args = parser.parse_args()
+    if args.command == "list":
+        for path, scene, kind in CASES:
+            print(f"  {scene:28s} {kind:6s} {path.name}")
+        return 0
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scenes.py
+++ b/tests/scenes.py
@@ -1,0 +1,371 @@
+"""
+Scenes for the frame comparison harness, see render_compare.py.
+
+Each one is meant to be quick to render, to come out the same every time it is rendered, and
+to put on screen something whose look depends on a part of the renderer which is easy to
+break without noticing. Between them they cover every kind of mobject, every pass the
+renderer makes, and every uniform a shader reads.
+"""
+from __future__ import annotations
+
+import numpy as np
+from pathlib import Path
+from PIL import Image
+
+from manimlib import *
+
+
+ASSETS = Path(__file__).parent / "assets"
+
+
+def checker_image(name: str = "checker.png", size: int = 64) -> str:
+    """
+    An image to hang on things which take a texture, made here rather than committed, so
+    that it is the same every time without a binary living in the repository.
+    """
+    ASSETS.mkdir(exist_ok=True)
+    path = ASSETS / name
+    if not path.exists():
+        rows, cols = np.indices((size, size))
+        squares = ((rows // 8 + cols // 8) % 2).astype(np.uint8)
+        Image.fromarray(np.stack([
+            255 * squares,
+            (255 * rows / size).astype(np.uint8),
+            (255 * cols / size).astype(np.uint8),
+        ], axis=2)).save(path)
+    return str(path)
+
+
+def star_points(n: int = 5, turns: int = 2, radius: float = 1.0) -> np.ndarray:
+    """A self crossing outline, so that a fill has to count windings above one"""
+    angles = TAU * turns * np.arange(n + 1) / n + PI / 2
+    return radius * np.array([[np.cos(a), np.sin(a), 0] for a in angles])
+
+
+def corners(*points) -> VMobject:
+    return VMobject().set_points_as_corners([np.array(p, dtype=float) for p in points])
+
+
+def fit(mob: Mobject) -> Mobject:
+    """As large as fits in the frame, so that a case cannot quietly grow off the edge"""
+    mob.set_height(FRAME_HEIGHT - 1)
+    if mob.get_width() > FRAME_WIDTH - 1:
+        mob.set_width(FRAME_WIDTH - 1)
+    return mob.center()
+
+
+def half_plane(mob: Mobject, direction: Vect3, offset: float = 0.0):
+    """
+    A plane through the mobject, keeping the side of it the direction points towards,
+    cutting that far along the direction from its center.
+
+    Clip planes are in the scene's coordinates rather than in a mobject's own, so where
+    one cuts depends on where the mobject has ended up, and these have to be worked out
+    after everything has been arranged rather than before.
+    """
+    unit = normalize(np.array(direction, dtype=float))
+    return (unit, -float(np.dot(mob.get_center(), unit)) - offset)
+
+
+# Stills
+
+
+class Fills(Scene):
+    """Winding counts: overlaps, holes, self crossing, gradients, transparency"""
+
+    def construct(self):
+        opaque = Circle(radius=1.1).set_fill(BLUE_D, 1).set_stroke(width=0)
+        over = Square(side_length=1.8).set_fill(RED_D, 1).set_stroke(width=0)
+        over.shift(0.6 * RIGHT + 0.4 * DOWN)
+        see_through = Circle(radius=0.9).set_fill(YELLOW, 0.5).set_stroke(width=0)
+        see_through.shift(0.5 * RIGHT + 0.5 * UP)
+        overlaps = Group(opaque, over, see_through)
+
+        holes = Annulus(inner_radius=0.4, outer_radius=1.0).set_fill(TEAL, 1)
+        star = corners(*star_points(radius=1.0)).set_fill(GREEN, 1).set_stroke(width=0)
+        gradient = Square(side_length=1.8).set_stroke(width=0)
+        gradient.set_fill([PINK, BLUE], 1, gradient_direction=UR)
+        fading = Circle(radius=0.9).set_stroke(width=0)
+        fading.set_fill([WHITE, WHITE], [0.9, 0.1], gradient_direction=RIGHT)
+
+        group = Group(overlaps, holes, star, gradient, fading)
+        group.arrange(RIGHT, buff=0.4)
+        self.add(fit(group))
+
+
+class Strokes(Scene):
+    """Joints of every angle, closed and open paths, widths along a path"""
+
+    def construct(self):
+        angles = VGroup(*(
+            corners(LEFT, ORIGIN, rotate_vector(RIGHT, angle))
+            for angle in np.linspace(0.05 * PI, 0.95 * PI, 6)
+        ))
+        angles.set_stroke(WHITE, 8)
+        angles.arrange_in_grid(2, 3, buff=0.4)
+
+        closed = Circle(radius=0.8).set_stroke(YELLOW, 10)
+        reversal = corners(LEFT, ORIGIN, LEFT + 0.08 * UP).set_stroke(RED, 10)
+        rounded = corners(*star_points(radius=0.8))
+        rounded.set_stroke(BLUE, 10).set_joint_roundness(1.0)
+        tapered = Line(LEFT, RIGHT).insert_n_curves(20).set_stroke(GREEN, [1, 12, 1])
+        behind = Circle(radius=0.7).set_fill(GREY_D, 1).set_stroke(ORANGE, 14, behind=True)
+
+        top = Group(angles, closed).arrange(RIGHT, buff=0.5)
+        bottom = Group(reversal, rounded, tapered, behind).arrange(RIGHT, buff=0.4)
+        both = Group(top, bottom).arrange(DOWN, buff=0.5)
+        self.add(fit(both))
+
+
+class PartialDraws(Scene):
+    """
+    Shapes part way through being drawn, which is where an open subpath's fill and the
+    joints at a subpath's ends are on show. Held still rather than animated, so that what
+    is compared is one frame and not a rate function.
+    """
+
+    def construct(self):
+        def partway(mob, alpha):
+            result = mob.copy()
+            result.pointwise_become_partial(mob, 0, alpha)
+            return result
+
+        sources = [
+            Circle(radius=0.7).set_fill(BLUE, 1).set_stroke(WHITE, 4),
+            Annulus(inner_radius=0.3, outer_radius=0.7).set_fill(TEAL, 1),
+            Tex(R"e^{i\pi}", font_size=72).set_fill(WHITE, 1).set_stroke(YELLOW, 2),
+            Square(side_length=1.2).set_fill(RED, 0.5).set_stroke(width=0),
+        ]
+        rows = Group(*(
+            Group(*(partway(source, alpha) for alpha in [0.2, 0.5, 0.8, 1.0]))
+            for source in sources
+        ))
+        for row in rows:
+            row.arrange(RIGHT, buff=0.4)
+        rows.arrange(DOWN, buff=0.4)
+        self.add(fit(rows))
+
+
+class TextAndTex(Scene):
+    """Glyph fills, kerning, colored substrings, and a stroke around text"""
+
+    def construct(self):
+        group = VGroup(
+            Text("The quick brown fox", font_size=42),
+            Text("jumps over the lazy dog", font_size=42,
+                 t2c={"jumps": BLUE, "lazy": YELLOW}),
+            Tex(R"\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}", font_size=60),
+            TexText(R"Text and $\int_0^1 x^2\,dx$ together", font_size=42),
+            Text("outlined", font_size=60).set_fill(BLACK, 1).set_stroke(WHITE, 2),
+        )
+        group.arrange(DOWN, buff=0.3)
+        self.add(fit(group))
+
+
+class ClipPlanes(Scene):
+    """
+    Every kind of mobject cut by clip planes, one to four at a time, and by clip_to_box.
+    Heavily used in the videos repository, and the one place where a change of technique
+    could look almost right, see phase 0c of the port plan.
+    """
+
+    def construct(self):
+        filled = Circle(radius=0.8).set_fill(BLUE, 1).set_stroke(WHITE, 3)
+        two = Square(side_length=1.4).set_fill(RED, 1).set_stroke(width=0)
+        four = Circle(radius=0.9).set_fill(TEAL, 1).set_stroke(width=0)
+        diagonal = Text("clipped", font_size=48)
+        see_through = Square(side_length=1.4).set_fill(YELLOW, 0.5).set_stroke(width=0)
+        stroked = corners(*star_points(radius=0.8)).set_stroke(GREEN, 8)
+        boxed = Group(
+            Tex(R"\pi r^2", font_size=48),
+            Circle(radius=0.5).set_fill(PURPLE, 1).set_stroke(width=0),
+        ).arrange(RIGHT, buff=0.1)
+        box = Square(side_length=1.1).move_to(boxed).set_stroke(GREY_B, 1)
+
+        group = Group(filled, two, four, diagonal, see_through, stroked, Group(boxed, box))
+        group.arrange_in_grid(2, 4, buff=0.4)
+        self.add(fit(group))
+
+        filled.set_clip_plane(*half_plane(filled, RIGHT, -0.2))
+        two.set_clip_planes(half_plane(two, RIGHT), half_plane(two, UP))
+        four.set_clip_planes(*(
+            half_plane(four, direction, -0.25)
+            for direction in [RIGHT, LEFT, UP, DOWN]
+        ))
+        diagonal.set_clip_plane(*half_plane(diagonal, UR))
+        see_through.set_clip_plane(*half_plane(see_through, UP, -0.2))
+        stroked.set_clip_plane(*half_plane(stroked, LEFT, -0.2))
+        boxed.clip_to_box(box)
+
+
+class ClippedInThree(ThreeDScene):
+    """A clip plane cutting things which are depth tested and shaded"""
+
+    def construct(self):
+        sphere = Sphere(radius=1.3).set_color(BLUE_E)
+        cube = VCube(side_length=1.3).set_fill(TEAL, 1)
+        group = Group(sphere, cube).arrange(RIGHT, buff=1.0)
+        self.add(group)
+        sphere.set_clip_plane(*half_plane(sphere, RIGHT, -0.3))
+        cube.set_clip_plane(*half_plane(cube, UP))
+        self.frame.reorient(20, 70)
+
+
+class Surfaces(ThreeDScene):
+    """Shading, depth testing, culling, and a mesh over a surface"""
+
+    def construct(self):
+        sphere = Sphere(radius=1.0, resolution=(51, 26)).set_color(BLUE_D)
+        torus = Torus(r1=0.8, r2=0.3).set_color(GREEN_D)
+        graph = ParametricSurface(
+            lambda u, v: [u, v, 0.4 * np.sin(2 * u) * np.cos(2 * v)],
+            u_range=(-1, 1), v_range=(-1, 1), resolution=(31, 31),
+        ).set_color(TEAL_D)
+        mesh = SurfaceMesh(Sphere(radius=0.9, resolution=(21, 11)))
+        group = Group(sphere, torus, graph, mesh)
+        group.arrange_in_grid(2, 2, buff=0.5)
+        self.add(fit(group))
+        self.frame.reorient(15, 65)
+
+
+class TransparentSurfaces(ThreeDScene):
+    """Two see through surfaces overlapping, one of them sorted to the camera"""
+
+    def construct(self):
+        plain = Sphere(radius=1.0).set_color(BLUE, 0.5)
+        folded = ParametricSurface(
+            lambda u, v: [u, v, 0.7 * np.sin(3 * u)],
+            u_range=(-1, 1), v_range=(-1, 1), resolution=(41, 41),
+        ).set_color(YELLOW, 0.5)
+        folded.set_sort_to_camera(True)
+        group = Group(plain, folded).arrange(RIGHT, buff=0.7)
+        group.set_height(FRAME_HEIGHT - 2)
+        self.add(group)
+        self.frame.reorient(25, 70)
+
+
+class TexturedAndImages(ThreeDScene):
+    """A texture on a surface and an image in the plane, both being sampled"""
+
+    def construct(self):
+        path = checker_image()
+        surface = TexturedSurface(Sphere(radius=1.1, resolution=(51, 26)), path)
+        image = ImageMobject(path, height=2.2)
+        group = Group(surface, image).arrange(RIGHT, buff=0.8)
+        self.add(group)
+        self.frame.reorient(10, 70)
+
+
+class DotsAndVectors(Scene):
+    """Many small mobjects: dot clouds, glow, and a field of arrows"""
+
+    def construct(self):
+        dots = DotCloud([
+            [x, y, 0] for x in np.linspace(-1, 1, 7) for y in np.linspace(-1, 1, 7)
+        ], radius=0.06)
+        dots.set_color_by_gradient(BLUE, RED)
+        glow = GlowDots([[x, 0, 0] for x in np.linspace(-1, 1, 5)], radius=0.4)
+
+        plane = NumberPlane(x_range=(-2, 2), y_range=(-2, 2))
+        field = VectorField(
+            lambda coords: 0.3 * np.stack([
+                -coords[:, 1], coords[:, 0], np.zeros(len(coords)),
+            ], axis=1),
+            plane,
+        )
+
+        group = Group(dots, glow, Group(plane, field))
+        group.arrange(RIGHT, buff=0.4)
+        self.add(fit(group))
+
+
+class FixedInFrame(ThreeDScene):
+    """Things pinned to the frame while the camera is turned, over things which are not"""
+
+    def construct(self):
+        label = Text("fixed in frame", font_size=36).to_corner(UL)
+        formula = Tex(R"\vec{v} \cdot \hat{n}", font_size=48).to_corner(DR)
+        for mob in [label, formula]:
+            mob.fix_in_frame()
+        self.add(ThreeDAxes(), Sphere(radius=1.3).set_color(BLUE_E), label, formula)
+        self.frame.reorient(35, 60)
+
+
+class Zoomed(Scene):
+    """
+    Shapes far smaller and far larger than the frame, which is what decides whether a
+    stroke width holds its look, see frame_rescale_factors
+    """
+
+    def construct(self):
+        shapes = Group(
+            Circle(radius=1).set_stroke(WHITE, 4),
+            Square(side_length=1.5).set_stroke(YELLOW, 4).set_fill(BLUE, 0.4),
+            Tex(R"\alpha", font_size=60),
+        ).arrange(RIGHT, buff=0.5)
+        self.add(
+            shapes.copy().scale(0.1).to_edge(LEFT),
+            shapes.copy().scale(2.5).to_edge(RIGHT),
+        )
+        self.frame.set_height(6)
+
+
+class ByCode(Scene):
+    """A mobject whose color comes from a snippet of shader code"""
+
+    def construct(self):
+        square = Square(side_length=3).set_fill(WHITE, 1).set_stroke(width=0)
+        square.set_color_by_code(
+            "color.rgb *= vec3(0.5 + 0.5 * sin(3.0 * point.x), 0.4, 1.0);"
+        )
+        self.add(square)
+
+
+# Videos, kept short. These are what catch anything to do with a mobject changing between
+# frames, rather than with how one frame is drawn.
+
+
+class AnimWrite(Scene):
+    def construct(self):
+        self.play(Write(Tex(R"x^2 + y^2 = r^2", font_size=60)), run_time=0.4)
+        self.wait(0.1)
+
+
+class AnimTransform(Scene):
+    def construct(self):
+        source = Tex("A^2 + B^2", font_size=60)
+        target = Tex("A^2 = B^2", font_size=60)
+        self.add(source)
+        self.play(TransformMatchingStrings(source, target), run_time=0.4)
+        self.wait(0.1)
+
+
+class AnimShapes(Scene):
+    def construct(self):
+        circle = Circle(radius=1.2).set_fill(BLUE, 0.5).set_stroke(WHITE, 4)
+        square = Square(side_length=2).set_fill(RED, 0.5).set_stroke(YELLOW, 4)
+        self.add(circle)
+        self.play(ReplacementTransform(circle, square), run_time=0.3)
+        self.play(FadeOut(square), run_time=0.2)
+
+
+class AnimUpdaters(Scene):
+    def construct(self):
+        tracker = ValueTracker(0.5)
+        line = always_redraw(lambda: Line(
+            2 * LEFT, 2 * LEFT + 4 * tracker.get_value() * RIGHT,
+        ).set_stroke(BLUE, 6))
+        dot = GlowDot(color=YELLOW)
+        dot.add_updater(lambda m: m.move_to(line.get_end()))
+        number = DecimalNumber(0).to_edge(UP)
+        number.add_updater(lambda m: m.set_value(tracker.get_value()))
+        self.add(line, dot, number)
+        self.play(tracker.animate.set_value(1.0), run_time=0.3)
+
+
+class AnimCamera(ThreeDScene):
+    def construct(self):
+        label = Text("turning", font_size=36).to_corner(UL)
+        label.fix_in_frame()
+        self.add(ThreeDAxes(), Sphere(radius=1.2).set_color(BLUE_E), label)
+        self.play(self.frame.animate.reorient(40, 60), run_time=0.3)


### PR DESCRIPTION

- **Count writes to a `StructuredArray`** rather than saying whether it changed. A count says what a watcher has missed instead of whether anyone has, so more than one thing can watch one array, and nothing has to put a flag back. 
- Rounds unit normals, so mobjects facing the same way say so exactly.
- **A frame comparison harness** (`tests/render_compare.py`). There is no way to unit test a renderer; what there is, is the frame it drew last time. 
- **manim's own names for keys and modifiers** (`event_keys.py`). Three files above the window imported pyglet's constants; now the window translates and nothing above it knows what it is built on. Collapses a ten-times-repeated `MOD_COMMAND | MOD_CTRL` into `Mods.CTRL_OR_CMD`.
- **A `Renderer` handed to a mobject** in place of the bare moderngl context, which is where what holds for a whole frame can live.
- **The camera's uniforms as one std140 block**, exactly as a mobject's have travelled since #2482. Deletes `ALL_PROGRAMS`, `SHARED_UNIFORMS`, `set_shared_uniforms`, `get_shared_uniform` and the loop pushing every shared value into each newly compiled program. All of these existed because GL has no way to say a value holds for everything. 
- **Clipping by dropping fragments** rather than by writing `gl_ClipDistance`. wgpu has no clip distance on the backends this is headed for.
- **Named draw states, and every write before any draw.** A fill's forty lines of `glStencilOpSeparate`/`glColorMask` poking become three states asked for by name; there are six states in all, which is the useful thing to have learned. And `pre_render` splits into `write_buffers` and `render`, because a single wgpu render pass per frame requires every buffer write to precede it.