### PR TITLE
Honor stroke widths declared in SVG files

### DIFF
--- a/manimlib/mobject/svg/svg_mobject.py
+++ b/manimlib/mobject/svg/svg_mobject.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
     from manimlib.typing import ManimColor, Vect3Array
 
 
+# A stroke_width of 100 spans one unit of a default scale frame, see
+# STROKE_WIDTH_CONVERSION in shaders/stroke.wgsl
+STROKE_WIDTHS_PER_UNIT: float = 100.0
+
 SVG_HASH_TO_MOB_MAP: dict[int, list[VMobject]] = {}
 PATH_TO_POINTS: dict[str, Vect3Array] = {}
 
@@ -66,7 +70,7 @@ class SVGMobject(VMobject):
         color: ManimColor = None,
         fill_color: ManimColor = None,
         fill_opacity: float | None = None,
-        stroke_width: float | None = 0.0,
+        stroke_width: float | None = None,
         stroke_color: ManimColor = None,
         stroke_opacity: float | None = None,
         # Style that fills only when not specified
@@ -99,8 +103,30 @@ class SVGMobject(VMobject):
         self.init_svg_mobject()
         self.ensure_positive_orientation()
 
+        # Initialize position
+        height = height or self.height
+        width = width or self.width
+
+        initial_height = self.get_height()
+
+        if should_center:
+            self.center()
+        if height is not None:
+            self.set_height(height)
+        if width is not None:
+            self.set_width(width)
+
+        # Widths read from the file are in the svg's own user units, while the geometry
+        # above has just been resized to the requested height or width. Converting them
+        # keeps a stroke the thickness it looks in the file, whatever units that file
+        # happens to be drawn in.
+        if initial_height > 0:
+            units_per_user_unit = self.get_height() / initial_height
+            self.scale_stroke_widths(STROKE_WIDTHS_PER_UNIT * units_per_user_unit)
+
         # Rather than passing style into super().__init__
-        # do it after svg has been taken in
+        # do it after svg has been taken in. Left until last so that a width asked for
+        # here is the width drawn, rather than something the resizing above has scaled.
         self.set_style(
             fill_color=color or fill_color,
             fill_opacity=fill_opacity,
@@ -109,16 +135,14 @@ class SVGMobject(VMobject):
             stroke_opacity=stroke_opacity,
         )
 
-        # Initialize position
-        height = height or self.height
-        width = width or self.width
-
-        if should_center:
-            self.center()
-        if height is not None:
-            self.set_height(height)
-        if width is not None:
-            self.set_width(width)
+    def scale_stroke_widths(self, factor: float) -> None:
+        if factor == 1:
+            return
+        for mob in self.get_family():
+            # The group holding the shapes carries no points of its own, so no widths either
+            if len(mob.data) == 0:
+                continue
+            mob.set_stroke(width=factor * mob.get_stroke_widths(), recurse=False)
 
     def init_svg_mobject(self) -> None:
         hash_val = hash_obj(self.hash_seed)
@@ -249,10 +273,14 @@ class SVGMobject(VMobject):
         mob: VMobject,
         shape: se.GraphicObject
     ) -> VMobject:
+        # svgelements hands back a stroke width of 1.0 even for a shape painted with
+        # `stroke: none`, so the width is only taken when a stroke color came with it.
+        # Otherwise it is zeroed, which is what an unstroked shape should draw as.
+        has_stroke = shape.stroke is not None and shape.stroke.hexrgb is not None
         mob.set_style(
-            stroke_width=shape.stroke_width,
-            stroke_color=shape.stroke.hexrgb,
-            stroke_opacity=shape.stroke.opacity,
+            stroke_width=shape.stroke_width if has_stroke else 0.0,
+            stroke_color=shape.stroke.hexrgb if has_stroke else None,
+            stroke_opacity=shape.stroke.opacity if has_stroke else None,
             fill_color=shape.fill.hexrgb,
             fill_opacity=shape.fill.opacity
         )


### PR DESCRIPTION
## Motivation

Any SVG with a stroked path draws with no stroke at all. `SVGMobject` defaults `stroke_width` to `0.0` and applies it to the whole family after parsing, so the per path widths read from the file get wiped out.

The default was doing real work, which is why it cannot simply go: svgelements reports a stroke width of `1.0` even for shapes painted with `stroke: none`, so unstroked shapes would pick up a spurious outline. Widths also need converting, since a file states them in its own user units while the geometry gets resized to the requested height or width, and a `stroke_width` of 100 spans one unit of a default scale frame (`STROKE_WIDTH_CONVERSION` in `shaders/stroke.wgsl`).

Fixes #2343

## Proposed changes

- Take a shape's stroke width only when a stroke color came with it, and zero it otherwise, so the default can become `None` and parsed strokes survive
- Convert those widths for the units the file is drawn in and the size the geometry is given
- Apply the caller's style after the resizing, so an explicit `stroke_width` is the width drawn. `Tex`, `Text` and the bundled SVG drawings are unaffected

## Test

**Code**:

The SVG from #2343, on a light background so the dark stroke reads:

```py
from manimlib import *

class IssueRepro(Scene):
    def construct(self):
        bg = Rectangle(width=FRAME_WIDTH, height=FRAME_HEIGHT)
        bg.set_fill("#88BBCC", 1).set_stroke(width=0)
        self.add(bg, SVGMobject("issue.svg", height=5))
```

**Result**:

Before, `get_stroke_width()` on the path is `0.0` and nothing draws:

![before](https://raw.githubusercontent.com/00PrabalK00/manim/pr-assets/pr-assets/svg-stroke-before.png)

After, the width is `9.05` and the stroke draws at the thickness the file asks for:

![after](https://raw.githubusercontent.com/00PrabalK00/manim/pr-assets/pr-assets/svg-stroke-after.png)

For the units, two files drawing the same picture, one in a 100 unit viewBox with `stroke-width: 4`, the other in a 1000 unit viewBox with `stroke-width: 40`, both at `height=3`. They now report the same width of `13.04` and draw alike, where without the conversion they came out `4.0` and `40.0`:

![scale](https://raw.githubusercontent.com/00PrabalK00/manim/pr-assets/pr-assets/svg-stroke-scale_after.png)

The other side of the change: `Text("Regression check")` still reports stroke width `0.0` on every glyph and renders identically, and a few multi path SVGs from matplotlib come out with widths only on the paths that declare a stroke.