### PR TITLE
State a supported minimum Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note, there are two versions of manim.  This repository began as a personal proj
 > [!Note]
 > **Note**: To install manim directly through pip, please pay attention to the name of the installed package. This repository is ManimGL of 3b1b. The package name is `manimgl` instead of `manim` or `manimlib`. Please use `pip install manimgl` to install the version in this repository.
 
-Manim runs on Python 3.7 or higher.
+Manim runs on Python 3.10 or higher.
 
 System requirements are [FFmpeg](https://ffmpeg.org/), [OpenGL](https://www.opengl.org/) and [LaTeX](https://www.latex-project.org) (optional, if you want to use LaTeX).
 For Linux, [Pango](https://pango.org) along with its development headers are required. See instruction [here](https://github.com/ManimCommunity/ManimPango#building).
@@ -95,7 +95,7 @@ manim-render example_scenes.py OpeningManimExample
 ## Anaconda Install
 
 1. Install LaTeX as above.
-2. Create a conda environment using `conda create -n manim python=3.9`.
+2. Create a conda environment using `conda create -n manim python=3.10`.
 3. Activate the environment using `conda activate manim`.
 4. Install manimgl using `pip install -e .`.
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Manim runs on Python 3.7 or higher.
+Manim runs on Python 3.10 or higher.
 
 System requirements are：
 
@@ -90,6 +90,6 @@ For Anaconda
    
    git clone https://github.com/3b1b/manim.git
    cd manim 
-   conda create -n manim python=3.8
+   conda create -n manim python=3.10
    conda activate manim
    pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,16 +18,17 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Multimedia :: Video
     Topic :: Multimedia :: Graphics
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3 :: Only
     Natural Language :: English
 
 [options]
 packages = find:
 include_package_data = True
+python_requires = >=3.10
 install_requires =
     addict
     appdirs


### PR DESCRIPTION
## Motivation

The README and the installation docs say Python 3.7 or higher, and the conda instructions create a 3.8 environment. Neither can work. `ipython>=8.18.0` alone rules out anything below 3.9, and on 3.9 importing manimlib fails outright.

To be precise about why 3.10 rather than 3.9, since it comes down to very little: `compileall` under 3.9 passes on all of manimlib, so there is no 3.10 only syntax. The import failure is `Mobject.stash_mobject_pointers` and `Scene.affects_mobject_list`, `@staticmethod` functions used as decorators inside their own class body, legal to call directly only from 3.10. That is #2263, which #2466 targets. Drop those two `@staticmethod` lines locally and 3.9 imports and renders fine.

So the case for 3.10 is not that the library needs it deeply, it is that 3.9 went end of life in October 2025 and current releases of rendercanvas, skia-pathops, pillow and trimesh all require 3.10 or higher. On 3.9 pip resolves back to wgpu 0.24 and rendercanvas 2.2.1 to stay under that ceiling. Happy to cut this back to a docs only change and drop the `python_requires` if you would rather keep 3.9 installable.

Fixes #2405

## Proposed changes

- Say Python 3.10 in the README and in `installation.rst`, and create the conda env with 3.10
- Add `python_requires = >=3.10` to `setup.cfg`, so pip reports the problem before installing rather than after
- Update the classifiers to match

## Test

**Code**:

```sh
uv venv /tmp/v39 --python 3.9   # and 3.10, 3.11, 3.12
uv pip install --python /tmp/v39 -e .
/tmp/v39/bin/python -c "import manimlib"
```

**Result**:

3.9 fails with `TypeError: 'staticmethod' object is not callable`. 3.10, 3.11 and 3.12 all install and import fine.