### PR TITLE
Clean Animation.begin

### DIFF
--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -74,10 +74,26 @@ class Animation(object):
             self.mobject_was_updating = not self.mobject.updating_suspended
             self.mobject.suspend_updating()
         self.families = list(self.get_all_families_zipped())
+        self.prepare_interpolation()
         self.interpolate(0)
+
+    def prepare_interpolation(self) -> None:
+        """
+        Whatever holds of the two ends for the whole of the animation, settled here rather
+        than found again in every blend, see Mobject.prepare_interpolation.
+
+        The ends are whichever mobjects interpolate_submobject is handed alongside each one,
+        so an animation blending between two states has nothing to say here. One which changes
+        its ends after they have been made says so by calling this again, see FadeTransform.
+        """
+        first = self.families[0] if self.families else ()
+        if len(first) == 3:
+            mobject, *ends = first
+            mobject.prepare_interpolation(*ends)
 
     def finish(self) -> None:
         self.interpolate(self.final_alpha_value)
+        self.mobject.turn_off_interpolation_skip()
         self.mobject.set_animating_status(False)
         if self.suspend_mobject_updating and self.mobject_was_updating:
             self.mobject.resume_updating()

--- a/manimlib/animation/fading.py
+++ b/manimlib/animation/fading.py
@@ -113,6 +113,9 @@ class FadeTransform(Transform):
         start, end = self.starting_mobject, self.ending_mobject
         for m0, m1 in ((start[1], start[0]), (end[0], end[1])):
             self.ghost_to(m0, m1)
+        # The two ends only became what they are here, so what a blend between them comes to
+        # has to be settled again, having been settled over what they held a moment ago
+        self.prepare_interpolation()
 
     def ghost_to(self, source: Mobject, target: Mobject) -> None:
         source.replace(target, stretch=self.stretch, dim_to_match=self.dim_to_match)

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -56,6 +56,7 @@ class Transform(Animation):
         self.check_target_mobject_validity()
 
         if self.mobject.is_aligned_with(self.target_mobject):
+            # Nothing to align, so nothing is done to the target and it can stand as it is
             self.target_copy = self.target_mobject
         else:
             # Use a copy of target_mobject for the align_data_and_family
@@ -63,7 +64,7 @@ class Transform(Animation):
             # preserved, since calling align_data will potentially
             # change the structure of both arguments
             self.target_copy = self.target_mobject.copy()
-        self.mobject.align_data_and_family(self.target_copy)
+            self.mobject.align_data_and_family(self.target_copy)
         super().begin()
 
     def create_target(self) -> Mobject:

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -65,11 +65,6 @@ class Transform(Animation):
             self.target_copy = self.target_mobject.copy()
         self.mobject.align_data_and_family(self.target_copy)
         super().begin()
-        self.mobject.prepare_interpolation(self.starting_mobject, self.target_copy)
-
-    def finish(self) -> None:
-        super().finish()
-        self.mobject.turn_off_interpolation_skip()
 
     def create_target(self) -> Mobject:
         # Has no meaningful effect here, but may be useful

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -32,6 +32,7 @@ from manimlib.utils.color import color_gradient
 from manimlib.utils.color import color_to_rgb
 from manimlib.utils.color import get_colormap_list
 from manimlib.utils.color import rgb_to_hex
+from manimlib.utils.iterables import arrays_match
 from manimlib.utils.iterables import list_update
 from manimlib.utils.iterables import listify
 from manimlib.utils.iterables import resize_array
@@ -116,6 +117,9 @@ class Mobject(object):
         self.saved_state = None
         self.target = None
         self.bounding_box: Vect3Array = np.zeros((3, 3))
+        # Whether the box is the same at both ends of an animation, and so wants no blending,
+        # see prepare_interpolation
+        self.skip_box_interpolation: bool = False
         self._is_animating: bool = False
         self._needs_new_bounding_box: bool = True
         self.shader_code_replacements: dict[str, str] = dict()
@@ -1815,7 +1819,10 @@ class Mobject(object):
         self.uniforms.interpolate(
             mobject1.uniforms, mobject2.uniforms, alpha, uniform_keys_to_alt_func,
         )
-        self.bounding_box[:] = path_func(mobject1.bounding_box, mobject2.bounding_box, alpha)
+        if not self.skip_box_interpolation:
+            self.bounding_box[:] = path_func(
+                mobject1.bounding_box, mobject2.bounding_box, alpha,
+            )
         return self
 
     def pointwise_become_partial(self, mobject, a, b) -> Self:
@@ -1839,18 +1846,25 @@ class Mobject(object):
         animation: blending would only write back what is already there, at the cost of
         sending the array to the gpu again for nothing. One whose ends are laid out
         differently, as two kinds of mobject are, is blended a field at a time instead.
+
+        The bounding box goes the same way, kept apart from the arrays only because it is no
+        part of what a shader reads.
         """
         fam1 = mobject1.get_family()
         fam2 = mobject2.get_family()
         for sm, sm1, sm2 in zip(self.get_family(), fam1, fam2):
             sm.data.prepare_interpolation(sm1.data, sm2.data)
             sm.uniforms.prepare_interpolation(sm1.uniforms, sm2.uniforms)
+            sm.skip_box_interpolation = arrays_match(
+                sm1.get_bounding_box(), sm2.get_bounding_box(),
+            )
         return self
 
     def turn_off_interpolation_skip(self) -> Self:
         for mob in self.get_family():
             for arr in [mob.data, mob.uniforms]:
                 arr.turn_off_interpolation_skip()
+            mob.skip_box_interpolation = False
         return self
 
     # Operations touching shader uniforms

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -132,8 +132,7 @@ class VMobject(Mobject):
         self.needs_new_unit_normal = True
 
         self.shader_code_target = None
-        # Which set of mobjects this one's fill has been promised not to overlap, see
-        # set_fills_disjoint. None, meaning no such promise, for all but text.
+        # Which set of mobjects this one's fill has been promised not to overlap
         self.fill_group: VMobject | None = None
 
         super().__init__(**kwargs)


### PR DESCRIPTION
- Prepare the ends before the first blend, not after. 
- Skip a bounding box interpolation when start/end match
