### PR TITLE
Draw more fills together

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -781,5 +781,7 @@ class ComplexPlane(NumberPlane):
                 value = z.real
             number_mob = axis.get_number_mobject(value, font_size=font_size, **kwargs)
             self.coordinate_labels.add(number_mob)
+        # Confirm they can be safely drawn together
+        self.coordinate_labels.draw_fills_together_if_disjoint()
         self.add(self.coordinate_labels)
         return self

--- a/manimlib/mobject/matrix.py
+++ b/manimlib/mobject/matrix.py
@@ -70,6 +70,9 @@ class Matrix(VMobject):
             ellipses_col,
         )
 
+        # Draw fills together
+        self.draw_fills_together_if_disjoint()
+
     def copy(self, deep: bool = False):
         result = super().copy(deep)
         self_family = self.get_family()

--- a/manimlib/mobject/number_line.py
+++ b/manimlib/mobject/number_line.py
@@ -216,6 +216,8 @@ class NumberLine(Line):
             if excluding is not None and x in excluding:
                 continue
             numbers.add(self.get_number_mobject(x, **kwargs))
+        # Labels typically don't overlap, and hence can be drawn together
+        numbers.draw_fills_together_if_disjoint()
         self.add(numbers)
         self.numbers = numbers
         return numbers

--- a/manimlib/mobject/numbers.py
+++ b/manimlib/mobject/numbers.py
@@ -76,6 +76,7 @@ class DecimalNumber(VMobject):
 
         self.set_submobjects_from_number(number)
         self.init_colors()
+        self.draw_fills_together_if_disjoint()
 
     def set_submobjects_from_number(self, number: float | complex) -> None:
         # Create the submobject list
@@ -212,6 +213,8 @@ class DecimalNumber(VMobject):
         self.set_style(**style)
         for submob in self.get_family():
             submob.uniforms.update(self.uniforms)
+        # Digits are laid out in a row a buff apart, so they usually share a draw
+        self.draw_fills_together_if_disjoint()
         return self
 
     def _handle_scale_side_effects(self, scale_factor: float) -> Self:

--- a/manimlib/mobject/svg/string_mobject.py
+++ b/manimlib/mobject/svg/string_mobject.py
@@ -72,9 +72,9 @@ class StringMobject(SVGMobject, ABC):
         self.set_fill(fill_color, border_width=fill_border_width)
         self.labels = [submob.label for submob in self.submobjects]
         # Glyphs are placed by the typesetter, which does not lay one over another, so they
-        # may share a draw. Take it back with set_fills_disjoint(False) for the rare string
+        # may share a draw. Take it back with draw_fills_together(False) for the rare string
         # whose glyphs do overlap and whose fill is partly transparent.
-        self.set_fills_disjoint()
+        self.draw_fills_together()
 
     def get_svg_string(self, is_labelled: bool = False) -> str:
         content = self.get_content(is_labelled or self.use_labelled_svg)

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -35,6 +35,7 @@ from manimlib.utils.iterables import resize_array
 from manimlib.utils.iterables import resize_with_interpolation
 from manimlib.utils.iterables import resize_preserving_order
 from manimlib.utils.space_ops import angle_between_vectors
+from manimlib.utils.space_ops import boxes_are_disjoint
 from manimlib.utils.space_ops import get_norm
 from manimlib.utils.space_ops import get_unit_normal
 from manimlib.utils.space_ops import line_intersects_path
@@ -154,6 +155,37 @@ class VMobject(Mobject):
         group = self if draw_together else None
         for mob in self.get_family():
             mob.fill_group = group
+        return self
+
+    def draw_fills_together_if_disjoint(self) -> Self:
+        """
+        Looks at where the filled members of this family sit, and makes the promise of
+        draw_fills_together when none of them meet, so that a group laid out with room
+        between its members is drawn together without anyone having to say so.
+
+        What is compared is bounding boxes, so two shapes which do not overlap but whose
+        boxes do are taken to, which costs a few draws and never the picture. And what is
+        answered is how things stand now, so a group moved about or added to afterwards
+        is worth asking again.
+        """
+        filled = [
+            mob for mob in self.get_family()
+            if mob.has_points() and mob.has_fill()
+        ]
+        # Each member's own points rather than its bounding box, which for one holding
+        # submobjects covers them too and would have it overlap its own children
+        boxes = np.array([
+            [points.min(0), points.max(0)]
+            for points in (mob.get_points() for mob in filled)
+        ]).reshape((len(filled), 2, self.dim))
+        if boxes_are_disjoint(boxes[:, 0], boxes[:, 1]):
+            return self.draw_fills_together(True)
+        # Nothing to promise here, but one made about some smaller group, a string's
+        # glyphs say, is about a family this says nothing of and still holds. Only this
+        # mobject's own promise, which the layout no longer bears out, is dropped.
+        for mob in self.get_family():
+            if mob.fill_group is self:
+                mob.fill_group = None
         return self
 
     def copy(self, deep: bool = False) -> Self:

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -188,6 +188,13 @@ class VMobject(Mobject):
                 mob.fill_group = None
         return self
 
+    def get_grid(self, *args, **kwargs) -> Self:
+        """
+        Copies laid out apart from one another, so unless the layout crowds them their
+        fills may share a draw.
+        """
+        return super().get_grid(*args, **kwargs).draw_fills_together_if_disjoint()
+
     def copy(self, deep: bool = False) -> Self:
         """
         A copy is a group of its own. Left pointing at what it was copied from, its fills

--- a/manimlib/mobject/types/vectorized_mobject.py
+++ b/manimlib/mobject/types/vectorized_mobject.py
@@ -137,7 +137,7 @@ class VMobject(Mobject):
 
         super().__init__(**kwargs)
 
-    def set_fills_disjoint(self, disjoint: bool = True, recurse: bool = True) -> Self:
+    def draw_fills_together(self, draw_together: bool = True) -> Self:
         """
         Promises that these mobjects' filled regions do not overlap one another, which lets
         one draw cover the lot of them rather than three passes each, see VDrawing.can_follow.
@@ -151,8 +151,8 @@ class VMobject(Mobject):
         in turn. For opaque fills that is the same picture, and for partly transparent ones it
         is a lighter one.
         """
-        group = self if disjoint else None
-        for mob in self.get_family(recurse):
+        group = self if draw_together else None
+        for mob in self.get_family():
             mob.fill_group = group
         return self
 

--- a/manimlib/renderer/drawing.py
+++ b/manimlib/renderer/drawing.py
@@ -392,7 +392,7 @@ class VDrawing(Drawing):
         self.has_fill = False
         self.stroke_behind = False
         # Which mobjects this one's fill has been promised not to overlap, see
-        # VMobject.set_fills_disjoint
+        # VMobject.draw_fills_together
         self.fill_group: Any = None
 
     def write_uniforms(self) -> bool:
@@ -418,7 +418,7 @@ class VDrawing(Drawing):
         """
         A fill counts its winding across the whole of a draw, so two filled mobjects may share
         one only where they do not overlap. Telling whether they do costs more than sharing
-        saves, so it is left to the mobjects to say, see VMobject.set_fills_disjoint, and only
+        saves, so it is left to the mobjects to say, see VMobject.draw_fills_together, and only
         those which have said so about the same group are gathered.
 
         Unfilled strokes are gathered whatever they promise, a stroke being drawn along its own

--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -363,6 +363,42 @@ def get_closest_point_on_line(a: VectN, b: VectN, p: VectN) -> VectN:
     return ((t * a) + ((1 - t) * b))
 
 
+def boxes_are_disjoint(mins: Vect3Array, maxs: Vect3Array) -> bool:
+    """
+    Whether no two of the boxes with these lower and upper corners share any of their
+    insides, two which meet along a face counting as apart.
+
+    Rather than ask it of every pair, the boxes are swept along the axis they are most
+    spread out on: sorted by where each begins, it is compared only with those which
+    have begun and not yet ended. For a row of things laid out side by side, which is
+    mostly what this is asked about, that is a couple of neighbors each where all pairs
+    would be the whole row.
+    """
+    if len(mins) < 2:
+        return True
+    spread = maxs.max(0) - mins.min(0)
+    # A flat shape has no thickness at all in some direction, and two of them sharing
+    # nothing there are not thereby apart, so any such direction is given a little and
+    # what is compared is where the two lie in their own plane
+    thickness = 1e-6 * max(spread.max(), 1.0)
+    maxs = np.where(maxs - mins < thickness, mins + thickness, maxs)
+
+    axis = int(spread.argmax())
+    order = np.argsort(mins[:, axis])
+    mins, maxs = mins[order], maxs[order]
+    # Where the run of boxes still to compare against begins. Since one which ends before
+    # the sweep has reached this box ends before every box after it too, the run only ever
+    # moves forward, and its first box always reaches past the sweep, so it stops in time
+    first = 0
+    for index, (low, high) in enumerate(zip(mins, maxs)):
+        while maxs[first, axis] <= low[axis]:
+            first += 1
+        others = slice(first, index)
+        if ((mins[others] < high) & (maxs[others] > low)).all(1).any():
+            return False
+    return True
+
+
 def get_winding_number(points: Sequence[Vect2 | Vect3]) -> float:
     total_angle = 0
     for p1, p2 in adjacent_pairs(points):


### PR DESCRIPTION
Rendering is a bit more efficient if Filled VMobjects can be grouped together, but due to the winding-number algorithm used for their fill with the stencil buffer, they can only be joined in a shared draw if they are disjoint.

This has a few common Mobject types do a check for whether their fills are safe to draw jointly.