### PR TITLE
Add Animation.get_interpolation_ends

### DIFF
--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -82,14 +82,23 @@ class Animation(object):
         Whatever holds of the two ends for the whole of the animation, settled here rather
         than found again in every blend, see Mobject.prepare_interpolation.
 
-        The ends are whichever mobjects interpolate_submobject is handed alongside each one,
-        so an animation blending between two states has nothing to say here. One which changes
-        its ends after they have been made says so by calling this again, see FadeTransform.
+        One which changes its ends after they have been made says so by calling this again,
+        see FadeTransform.
         """
-        first = self.families[0] if self.families else ()
-        if len(first) == 3:
-            mobject, *ends = first
-            mobject.prepare_interpolation(*ends)
+        ends = self.get_interpolation_ends()
+        if ends is not None:
+            self.mobject.prepare_interpolation(*ends)
+
+    def get_interpolation_ends(self) -> tuple[Mobject, Mobject] | None:
+        """
+        The two states every blend this animation makes runs between, in the order it blends
+        them, or none where it makes no such blend and so has nothing to settle in advance.
+
+        Saying so is the animation's to do rather than something read off the mobjects it
+        gathers: those same three may be two ends with the mobject between them, or a mobject
+        and two others put to some other use entirely.
+        """
+        return None
 
     def finish(self) -> None:
         self.interpolate(self.final_alpha_value)

--- a/manimlib/animation/creation.py
+++ b/manimlib/animation/creation.py
@@ -117,6 +117,17 @@ class DrawBorderThenFill(Animation):
     def get_all_mobjects(self) -> list[Mobject]:
         return [*super().get_all_mobjects(), self.outline]
 
+    def get_interpolation_ends(self) -> tuple[VMobject, VMobject]:
+        """
+        The second half blends between these two, and the first half never blends at all: it
+        traces the outline with pointwise_become_partial, which writes the points itself and
+        refreshes the box from them, so what is settled here is read only where it holds.
+
+        The outline being a copy of the mobject in another style, the two agree about every
+        point and about the box, and only the style has anywhere to go.
+        """
+        return self.outline, self.starting_mobject
+
     def interpolate_submobject(
         self,
         submob: VMobject,

--- a/manimlib/animation/fading.py
+++ b/manimlib/animation/fading.py
@@ -132,6 +132,10 @@ class FadeTransform(Transform):
     def get_all_families_zipped(self) -> zip[tuple[Mobject]]:
         return Animation.get_all_families_zipped(self)
 
+    def get_interpolation_ends(self) -> tuple[Mobject, Mobject]:
+        # Its own pair rather than Transform's, this one never having made a target_copy
+        return self.starting_mobject, self.ending_mobject
+
     def clean_up_from_scene(self, scene: Scene) -> None:
         Animation.clean_up_from_scene(self, scene)
         scene.remove(self.mobject)

--- a/manimlib/animation/transform.py
+++ b/manimlib/animation/transform.py
@@ -110,6 +110,9 @@ class Transform(Animation):
             ]
         ])
 
+    def get_interpolation_ends(self) -> tuple[Mobject, Mobject]:
+        return self.starting_mobject, self.target_copy
+
     def interpolate_submobject(
         self,
         submob: Mobject,


### PR DESCRIPTION
Be explicit about which mobjects held by an animation are meant to be the start/end of an interpolation.