### PR TITLE
Modernize the docs build toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,20 +15,21 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@master
-    
-    - name: Install sphinx and manim env
-      run: |
-        pip3 install --upgrade pip
-        sudo apt install python3-setuptools libpango1.0-dev
-        pip3 install -r docs/requirements.txt
-        pip3 install -r requirements.txt
-    
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    # The docs are hand-written rst with no autodoc directives, so building
+    # them does not require manimlib or any of its runtime dependencies.
+    - name: Install sphinx
+      run: pip install -r docs/requirements.txt
+
     - name: Build document with Sphinx
       run: |
         cd docs
-        export PATH="$PATH:/home/runner/.local/bin"
-        export SPHINXBUILD="python3 -m sphinx"
         make html
         
     - name: Deploy to GitHub pages

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,7 @@
-Sphinx==3.0.3
-sphinx-copybutton
-furo==2020.10.5b9
-Jinja2
+# Upper bounds are deliberate. This build previously pinned Sphinx to 3.0.3
+# while leaving Jinja2 unbounded, so it broke the day Jinja2 3.1 dropped
+# environmentfilter. Bump these on purpose rather than drifting.
+Sphinx>=8,<10
+furo>=2024.8
+sphinx-copybutton>=0.5,<1
+Jinja2>=3.1,<4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ html_css_files = [
     "https://cdn.jsdelivr.net/gh/manim-kindergarten/CDN@master/manimgl_assets/custom.css", 
     "https://cdn.jsdelivr.net/gh/manim-kindergarten/CDN@master/manimgl_assets/colors.css"
 ]
-html_theme = 'furo'  # pip install furo==2020.10.5b9
+html_theme = 'furo'
 html_favicon = '_static/icon.png'
 html_logo = '../../logo/transparent_graph.png'
 html_theme_options = {


### PR DESCRIPTION
The docs job has failed on every run since at least February. It pinned Sphinx to 3.0.3 (2020) while leaving Jinja2 unbounded, so pip resolved Jinja2 3.1, which dropped environmentfilter and sphinx.util.rst failed to import before any page was read.

Move to current Sphinx and furo, and bound both so a future major cannot break the build unnoticed. The build otherwise needed no changes; the manim-example directive works as is.

Pin the interpreter with setup-python rather than inheriting whatever ubuntu-latest ships, and drop the manimlib install along with the setuptools and pango packages it needed. Nothing in docs/source uses autodoc, so the build never imported manimlib.