### PR TITLE
Keep a moved bounding box's corners the right way round

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -272,7 +272,10 @@ class Mobject(object):
             for key in mob.pointlike_uniform_keys:
                 mob.uniforms.apply(key, moved)
             if box is not None:
-                box[:] = moved(box)
+                # Re-derive the corners, since a negative factor swaps which is which
+                corners = moved(box[::2].copy())
+                box[0], box[2] = corners.min(0), corners.max(0)
+                box[1] = (box[0] + box[2]) / 2
 
         if not works_on_bounding_box:
             self.refresh_bounding_box(recurse_down=True)

--- a/tests/bounding_box.py
+++ b/tests/bounding_box.py
@@ -1,0 +1,68 @@
+"""
+That a cached bounding box still says which corner is which after a transform.
+
+Most transforms leave the box to be worked out again from the points, but shift, scale and
+stretch move the cached corners instead, there being no need to look at every point to know
+where a box went. That shortcut assumes the corner which was smallest stays smallest, which a
+negative factor does not: stretch(-1, dim) sends the low corner high and the high corner low,
+and the box comes out inside out, get_width() of it negative and get_left() to the right of
+get_right().
+
+Nothing in the harness reads a box that closely. Dodecahedron builds a face with
+stretch(-1, 2, about_point=ORIGIN) and looks right anyway, a group working its own box out
+from the corners of its children with min and max, which puts an inside out one back the
+right way round.
+
+    python tests/bounding_box.py
+"""
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+from manimlib import ORIGIN, PI, RIGHT, Square
+
+
+def box_disagrees_with_points(mobject) -> str:
+    """What a box says against what the points it is meant to cover come to, or empty"""
+    box = mobject.get_bounding_box()
+    points = mobject.get_all_points()
+    problems = []
+    if not np.allclose(box[0], points.min(0), atol=1e-5):
+        problems.append(f"mins {np.round(box[0], 3).tolist()} for {np.round(points.min(0), 3).tolist()}")
+    if not np.allclose(box[2], points.max(0), atol=1e-5):
+        problems.append(f"maxs {np.round(box[2], 3).tolist()} for {np.round(points.max(0), 3).tolist()}")
+    if not np.allclose(box[1], (box[0] + box[2]) / 2, atol=1e-5):
+        problems.append(f"mid {np.round(box[1], 3).tolist()} between them")
+    return ", ".join(problems)
+
+
+CASES = [
+    ("stretch(-1, 0)", lambda: Square().stretch(-1, 0)),
+    ("stretch(-2, 1) off center", lambda: Square().shift(RIGHT).stretch(-2, 1, about_point=ORIGIN)),
+    # The transforms which took the shortcut already, and have to go on working
+    ("shift", lambda: Square().shift(2 * RIGHT)),
+    ("scale", lambda: Square().scale(3)),
+    ("stretch(2, 1)", lambda: Square().stretch(2, 1)),
+    # And one which does not, the box behind a rotation being worked out afresh
+    ("rotate", lambda: Square().shift(2 * RIGHT).rotate(PI / 4, about_point=ORIGIN)),
+]
+
+
+def main() -> int:
+    failures = []
+    for name, build in CASES:
+        problem = box_disagrees_with_points(build())
+        print(f"  {name}: {problem or 'box covers its points'}")
+        if problem:
+            failures.append(f"{name} left the box saying {problem}")
+
+    for failure in failures:
+        print(f"  FAIL: {failure}")
+    if not failures:
+        print("  a moved box keeps its corners the right way round")
+    return 1 if failures else 0
+
+
+sys.exit(main())


### PR DESCRIPTION
## Motivation

`apply_points_function` has two ways of keeping a bounding box up to date. Most transforms leave it to be worked out again from the points; `shift`, `scale` and `stretch` pass `works_on_bounding_box=True` and move the two cached corners instead, there being no need to look at every point to know where a box went.

That shortcut assumes the corner which was smallest stays smallest. A negative factor breaks the assumption — it sends the low corner high and the high corner low — and the box is left inside out:

```python
Square().stretch(-1, 0).get_bounding_box()
# [[ 1. -1.  0.]   <- mins
#  [ 0.  0.  0.]
#  [-1.  1.  0.]]  <- maxs
```

So `get_width()` comes out negative, and `get_left()` is to the right of `get_right()`. Everything downstream of the box is then wrong for that mobject: `next_to`, `align_to`, `surround`, `are_points_touching`.

`scale` can't reach this, clipping its factor to `min_scale_factor`, and `flip` goes through `rotate`, which works the box out afresh. `stretch` is the way in, and mirroring with `stretch(-1, dim)` is the ordinary reason to call it that way. `Dodecahedron` already does, at `three_dimensions.py:374`, and looks right anyway only because a group derives its own box from its children's corners with `min` and `max`, which puts an inside out one back the right way round. Ask the stretched face itself and it answers wrongly.

## Proposed changes

Re-derive which corner is which after moving them, rather than assuming the order survived, and put the midpoint between the two:

```python
corners = moved(box[::2].copy())
box[0], box[2] = corners.min(0), corners.max(0)
box[1] = (box[0] + box[2]) / 2
```

Same work for a positive factor, since `min` and `max` of an order which held leave it alone.

## Test

`tests/bounding_box.py`, alongside the other scripts in `tests/`, checking a box against the points it is meant to cover. It runs the two ways in — `stretch` with a negative factor, about the mobject's own center and about another point — along with `shift`, `scale`, positive `stretch` and `rotate`, so the paths which were already right are held to the same thing.

```
python tests/bounding_box.py
```

Before:

```
  stretch(-1, 0): mins [1.0, -1.0, 0.0] for [-1.0, -1.0, 0.0], maxs [-1.0, 1.0, 0.0] for [1.0, 1.0, 0.0]
  stretch(-2, 1) off center: mins [0.0, 2.0, 0.0] for [0.0, -2.0, 0.0], maxs [2.0, -2.0, 0.0] for [2.0, 2.0, 0.0]
  shift: box covers its points
  scale: box covers its points
  stretch(2, 1): box covers its points
  rotate: box covers its points
  FAIL: stretch(-1, 0) left the box saying mins [1.0, -1.0, 0.0] for [-1.0, -1.0, 0.0], maxs [-1.0, 1.0, 0.0] for [1.0, 1.0, 0.0]
  FAIL: stretch(-2, 1) off center left the box saying mins [0.0, 2.0, 0.0] for [0.0, -2.0, 0.0], maxs [2.0, -2.0, 0.0] for [2.0, 2.0, 0.0]
```

After:

```
  stretch(-1, 0): box covers its points
  stretch(-2, 1) off center: box covers its points
  shift: box covers its points
  scale: box covers its points
  stretch(2, 1): box covers its points
  rotate: box covers its points
  a moved box keeps its corners the right way round
```
