### PR TITLE
docs: sync CLI flag reference with current parser

### DIFF
--- a/docs/source/getting_started/configuration.rst
+++ b/docs/source/getting_started/configuration.rst
@@ -38,7 +38,7 @@ flag                                                       abbr   function
 ``--help``                                                 ``-h`` Show the help message and exit
 ``--version``                                              ``-v`` Display the version of manimgl
 ``--write_file``                                           ``-w`` Render the scene as a movie file
-``--skip_animations``                                      ``-s`` Save the last frame
+``--skip_animations``                                      ``-s`` Skip to the last frame
 ``--low_quality``                                          ``-l`` Render at a low quality (for faster rendering)
 ``--medium_quality``                                       ``-m`` Render at a medium quality
 ``--hd``                                                          Render at a 1080p quality

--- a/docs/source/getting_started/configuration.rst
+++ b/docs/source/getting_started/configuration.rst
@@ -38,31 +38,35 @@ flag                                                       abbr   function
 ``--help``                                                 ``-h`` Show the help message and exit
 ``--version``                                              ``-v`` Display the version of manimgl
 ``--write_file``                                           ``-w`` Render the scene as a movie file
-``--skip_animations``                                      ``-s`` Skip to the last frame
+``--skip_animations``                                      ``-s`` Save the last frame
 ``--low_quality``                                          ``-l`` Render at a low quality (for faster rendering)
 ``--medium_quality``                                       ``-m`` Render at a medium quality
 ``--hd``                                                          Render at a 1080p quality
 ``--uhd``                                                         Render at a 4k quality
 ``--full_screen``                                          ``-f`` Show window in full screen
 ``--presenter_mode``                                       ``-p`` Scene will stay paused during wait calls until space bar or right arrow is hit, like a slide show
-``--save_pngs``                                            ``-g`` Save each frame as a png
 ``--gif``                                                  ``-i`` Save the video as gif
 ``--transparent``                                          ``-t`` Render to a movie file with an alpha channel
-``--quiet``                                                ``-q``
+``--vcodec VCODEC``                                               Set the FFmpeg video codec
+``--pix_fmt PIX_FMT``                                             Set the FFmpeg pixel format; defaults to ``yuv420p``
+``--quiet``                                                ``-q`` Suppress rendering progress and file-ready messages
 ``--write_all``                                            ``-a`` Write all the scenes from a file
 ``--open``                                                 ``-o`` Automatically open the saved file once its done
 ``--finder``                                                      Show the output file in finder
-``--config``                                                      Guide for automatic configuration
+``--subdivide``                                                   Write an individual movie file for each animation
 ``--file_name FILE_NAME``                                         Name for the movie or image file
-``--start_at_animation_number START_AT_ANIMATION_NUMBER``  ``-n`` Start rendering not from the first animation, but from another, specified by its index. If you passing two comma separated values, e.g. "3,6", it will end the rendering at the second value.
-``--embed [EMBED]``                                        ``-e`` Creates a new file where the line ``self.embed`` is inserted into the Scenes construct method. If a string is passed in, the line will be inserted below the last line of code including that string.
+``--start_at_animation_number START[,END]``                ``-n`` Start at one animation index, or stop before a second index such as ``3,6``
+``--embed LINE_NUMBER``                                    ``-e`` Enter an interactive IPython session at the given source line
 ``--resolution RESOLUTION``                                ``-r`` Resolution, passed as "WxH", e.g. "1920x1080"
 ``--fps FPS``                                                     Frame rate, as an integer
 ``--color COLOR``                                          ``-c`` Background color
 ``--leave_progress_bars``                                         Leave progress bars displayed in terminal
+``--show_animation_progress``                                     Show a progress bar for each animation
+``--prerun``                                                      Calculate the frame count with an initial animation-free run
 ``--video_dir VIDEO_DIR``                                         Directory to write video
 ``--config_file CONFIG_FILE``                                     Path to the custom configuration file
 ``--log-level LOG_LEVEL``                                         Level of messages to Display, can be DEBUG / INFO / WARNING / ERROR / CRITICAL
+``--clear-cache``                                                 Erase the cache used for Tex and Text mobjects
 ``--autoreload``                                                  Automatically reload Python modules to pick up code changes across during an interactive embedding
 ========================================================== ====== =====================================================================================================================================================================================================
 


### PR DESCRIPTION
The CLI reference had drifted from the current parser behavior, so this updates the existing table to reflect the supported options.

This change:

- removes the stale `--save_pngs` and `--config` entries;
- adds `--vcodec`, `--pix_fmt`, `--subdivide`, `--show_animation_progress`, `--prerun`, and `--clear-cache`;
- updates the argument forms and descriptions for `--start_at_animation_number` and `--embed`;
- aligns the `--skip_animations` wording with the parser; and
- documents what `--quiet` suppresses.

`START[,END]` is intentionally used as a user-facing description of the accepted value shape rather than argparse's generated `START_AT_ANIMATION_NUMBER` variable name.

Validation:

- every documented long option matches an `add_argument` definition in `manimlib/config.py`;
- docutils parses the complete grid table with no warnings;
- all three table borders have identical widths and no row exceeds the table width; and
- `git diff --check` passes.

A full Sphinx build was not run because the documentation dependencies in this checkout are incomplete.