### PR TITLE
Keep the scene as it is when animating a group of what it already shows

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -530,9 +530,16 @@ class Scene(object):
             # animated mobjects that are in the family of
             # those on screen, this can result in a restructuring
             # of the scene.mobjects list, which is usually desired.
-            if animation.mobject not in all_mobjects:
+            # A group holding nothing but mobjects already on screen is
+            # itself already on screen, though, and restructuring for its
+            # sake would cost its ancestors whatever points they draw
+            # themselves, so leave the scene as it is.
+            family = animation.mobject.get_family()
+            drawn = [mob for mob in family if mob.has_points()]
+            shown_already = len(drawn) > 0 and all(mob in all_mobjects for mob in drawn)
+            if animation.mobject not in all_mobjects and not shown_already:
                 self.add(animation.mobject)
-                all_mobjects = all_mobjects.union(animation.mobject.get_family())
+                all_mobjects = all_mobjects.union(family)
 
     def progress_through_animations(self, animations: Iterable[Animation]) -> None:
         last_t = 0


### PR DESCRIPTION
Fixes #2352.

## Motivation

Indicating a number on a pair of `Axes` through a group wrapper, as in `Indicate(VGroup(x_axis_nums[0]))`, takes the axis line off the screen for the rest of the scene. Indicating the number directly is fine, which is what makes it look so arbitrary.

The wrapper is new to the scene, so `begin_animations` adds it (`scene.py:533`). `Scene.add` begins with `self.remove(*new_mobjects)` (`scene.py:315`), and `recursive_mobject_remove` replaces every ancestor of a removed mobject with that ancestor's submobjects (`family_ops.py:35-47`). A `NumberLine` draws its line from points of its own rather than from a submobject, so flattening it into `[ticks, numbers]` throws that line away.

Nothing was being removed here, and nothing needed adding either: everything the wrapper holds was already on screen.

## Proposed changes

- `Scene.begin_animations` now leaves the scene list alone when every mobject in the animated family that has points of its own is already on screen, since such a group is already being drawn.
- A group that is new, or that mixes something new with something on screen, is added exactly as before, and an explicit `Scene.remove` still restructures as documented.

## Test

**Code**:

```python
from manimlib import *

class AxErr(Scene):
    def construct(self):
        ax = Axes(
            x_range=(0, 5, 1), y_range=(0, 5, 1), height=6, width=6,
            x_axis_config={'include_numbers': True},
            y_axis_config={'include_numbers': True, 'line_to_number_direction': UP},
        )
        self.add(ax)
        x_axis, y_axis = ax
        x_axis_nums = x_axis[1]
        self.play(Indicate(VGroup(x_axis_nums[0])))
        self.wait()
```

**Result**:

Before, the x axis line is gone once the animation is over, while its ticks and numbers stay:

![before](https://raw.githubusercontent.com/00PrabalK00/manim/shots-2352/.shots/before.png)

After, the axis survives being indicated:

![after](https://raw.githubusercontent.com/00PrabalK00/manim/shots-2352/.shots/after.png)

Alongside that, checked in a scene that:

- the scene's mobject list is untouched by the wrapped `Indicate`, and the axis keeps its own points
- the wrapped number still scales and colours over the animation, and is restored at the end
- `FadeIn` of a group of two brand new mobjects still adds it
- `FadeIn` of a group mixing an on-screen number with a new triangle still adds it
- `self.remove(x_axis_nums[4])` still restructures the scene list

For rendering, `tests/render_compare.py` was captured on master and compared with the change over `Fills`, `Strokes`, `Surfaces`, `DotsAndVectors`, `ByCode`, `DrawnTogether`, `AnimShapes`, `AnimUpdaters`, `AnimCamera` and `AnimSorted`: all ten match to the byte. The remaining cases need LaTeX, which isn't installed here, so they were left out rather than reported as passing.
