### PR TITLE
Fix batched 2D vector rotation

### DIFF
--- a/manimlib/utils/space_ops.py
+++ b/manimlib/utils/space_ops.py
@@ -110,10 +110,19 @@ def quaternion_conjugate(quaternion: Vect4) -> Vect4:
 
 
 def rotate_vector(
-    vector: Vect3,
+    vector: Vect2 | Vect3 | Vect2Array | Vect3Array,
     angle: float,
     axis: Vect3 = OUT
-) -> Vect3:
+) -> Vect2 | Vect3 | Vect2Array | Vect3Array:
+    if np.shape(vector)[-1] == 2:
+        cos_angle = math.cos(angle)
+        sin_angle = math.sin(angle)
+        matrix = np.array([
+            [cos_angle, -sin_angle],
+            [sin_angle, cos_angle],
+        ])
+        return np.dot(vector, matrix.T)
+
     rot = Rotation.from_rotvec(angle * normalize(axis))
     return np.dot(vector, rot.as_matrix().T)
 

--- a/tests/test_space_ops.py
+++ b/tests/test_space_ops.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from manimlib.constants import OUT
+from manimlib.utils.space_ops import rotate_vector
+
+
+def test_rotate_single_2d_vector():
+    result = rotate_vector(np.array([1.0, 0.0]), np.pi / 2)
+
+    np.testing.assert_allclose(result, [0.0, 1.0], atol=1e-8)
+
+
+def test_rotate_batch_of_2d_vectors():
+    vectors = np.array([
+        [1.0, 0.0],
+        [0.0, 1.0],
+    ])
+
+    result = rotate_vector(vectors, np.pi / 2)
+
+    np.testing.assert_allclose(result, [[0.0, 1.0], [-1.0, 0.0]], atol=1e-8)
+
+
+def test_rotate_single_3d_vector():
+    result = rotate_vector(np.array([1.0, 0.0, 0.0]), np.pi / 2, OUT)
+
+    np.testing.assert_allclose(result, [0.0, 1.0, 0.0], atol=1e-8)
+
+
+def test_rotate_batch_of_3d_vectors():
+    vectors = np.array([
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+    ])
+
+    result = rotate_vector(vectors, np.pi / 2, OUT)
+
+    np.testing.assert_allclose(
+        result,
+        [[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]],
+        atol=1e-8,
+    )


### PR DESCRIPTION
## Motivation

`VectorField` calls vectorized functions with an `(N, 2)` array of sample coordinates. Passing that array to `rotate_vector`, as in the curl example from #2336, currently attempts to multiply it by a 3x3 rotation matrix and raises a shape-mismatch `ValueError`.

The helper already accepts a single 2D vector in its public usage. Supporting the vectorized form lets the same helper work naturally with `VectorField` and restores the pattern used by existing Manim examples.

Closes #2336.

## Proposed changes

- Detect vectors whose final dimension is 2 and rotate them with a 2x2 planar rotation matrix.
- Preserve the existing SciPy axis-angle path for individual and batched 3D vectors.
- Add regression coverage for individual and batched 2D and 3D inputs.

## Test

**Code**:

```bash
python -m pytest tests/test_space_ops.py -q
python -m compileall -q manimlib tests/test_space_ops.py
```

The issue reproduction was also exercised through the real `VectorField` path:

```python
axes = NumberPlane()
curl_func = lambda p: rotate_vector(p / 3, PI / 2)
field = VectorField(curl_func, axes)
result = curl_func(field.sample_coords)
```

**Result**:

- `4 passed`
- `field.sample_coords.shape == (561, 2)`
- `result.shape == (561, 2)` and all values are finite
- `compileall` completed successfully
