### PR TITLE
Fix graph point lookup outside unit x ranges

### DIFF
--- a/manimlib/mobject/coordinate_systems.py
+++ b/manimlib/mobject/coordinate_systems.py
@@ -238,8 +238,8 @@ class CoordinateSystem(ABC):
                     graph.quick_point_from_proportion(a)
                 )[0],
                 target=x,
-                lower_bound=self.x_range[0],
-                upper_bound=self.x_range[1],
+                lower_bound=0.0,
+                upper_bound=1.0,
             )
             if alpha is not None:
                 return graph.quick_point_from_proportion(alpha)

--- a/manimlib/utils/simple_functions.py
+++ b/manimlib/utils/simple_functions.py
@@ -79,9 +79,9 @@ def binary_search(
     while abs(rh - lh) > tolerance:
         lx, mx, rx = [function(h) for h in (lh, mh, rh)]
         if lx == target:
-            return lx
+            return lh
         if rx == target:
-            return rx
+            return rh
 
         if lx <= target and rx >= target:
             if mx > target:

--- a/tests/test_coordinate_systems.py
+++ b/tests/test_coordinate_systems.py
@@ -1,0 +1,52 @@
+import unittest
+
+import numpy as np
+
+from manimlib.mobject.coordinate_systems import CoordinateSystem
+from manimlib.utils.simple_functions import binary_search
+
+
+class StubCoordinateSystem(CoordinateSystem):
+    def coords_to_point(self, *coords):
+        return np.array([coords[0], coords[1], 0.0])
+
+    def point_to_coords(self, point):
+        return tuple(point[:2])
+
+    def get_axes(self):
+        return []
+
+    def get_all_ranges(self):
+        return []
+
+
+class LineGraph:
+    def quick_point_from_proportion(self, alpha):
+        return np.array([2.0 + 4.0 * alpha, 3.0, 0.0])
+
+
+class CoordinateSystemTests(unittest.TestCase):
+    def test_binary_search_returns_input_at_endpoints(self):
+        def function(value):
+            return 2.0 + 4.0 * value
+
+        self.assertEqual(binary_search(function, 2.0, 0.0, 1.0), 0.0)
+        self.assertEqual(binary_search(function, 6.0, 0.0, 1.0), 1.0)
+
+    def test_input_to_graph_point_searches_curve_proportion(self):
+        axes = StubCoordinateSystem(x_range=(2.0, 6.0, 1.0), y_range=(0.0, 5.0, 1.0))
+        graph = LineGraph()
+
+        np.testing.assert_allclose(
+            axes.input_to_graph_point(2.0, graph), [2.0, 3.0, 0.0]
+        )
+        np.testing.assert_allclose(
+            axes.input_to_graph_point(4.0, graph), [4.0, 3.0, 0.0]
+        )
+        np.testing.assert_allclose(
+            axes.input_to_graph_point(6.0, graph), [6.0, 3.0, 0.0]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`CoordinateSystem.input_to_graph_point` falls back to a binary search when a curve has no `underlying_function`. That search is over the curve proportion, but it currently uses the axes' x range as its bounds. For example, on axes with `x_range=(2, 6, 1)`, looking up x=2 or x=4 on a manually constructed curve returns the wrong result or no result instead of the corresponding point.

The endpoint path in `binary_search` also returns the function's output rather than the input bound, which can turn an endpoint x value into an invalid curve proportion.

## Proposed changes

- Search manual curves over proportions from 0 to 1
- Return the input bound when `binary_search` finds its target at an endpoint
- Add regression coverage for a non-unit x range and both search endpoints

## Test

**Code**:

```sh
python tests/test_coordinate_systems.py
python -m pytest -q
python -m compileall -q manimlib tests/test_coordinate_systems.py
```

**Result**: 2 tests pass, and all modules compile successfully.