### PR TITLE
fix: handle dvisvgm conversion failures

### DIFF
--- a/manimlib/utils/tex_file_writing.py
+++ b/manimlib/utils/tex_file_writing.py
@@ -147,6 +147,10 @@ def full_tex_to_svg(full_tex: str, compiler: str = "latex", message: str = ""):
         capture_output=True,
     )
 
+    if process.returncode != 0:
+        error_str = process.stderr.decode("utf-8", errors="replace").strip()
+        raise LatexError(error_str or "dvisvgm failed to convert DVI to SVG")
+
     # Return SVG string
     result = process.stdout.decode("utf-8")
 


### PR DESCRIPTION
## Motivation

`full_tex_to_svg()` checks whether the LaTeX compiler fails, but it does not currently check whether the subsequent `dvisvgm` conversion fails.

When `dvisvgm` exits with a non-zero status, Manim may continue with empty SVG output and fail later with an unrelated exception. This makes the actual conversion problem harder to diagnose.

I encountered this while investigating #2457 and #2206. This change only addresses explicit `dvisvgm` process failures; it does not attempt to resolve cases where `dvisvgm` exits successfully but produces SVG without usable glyph geometry.

## Proposed changes

* Check the return code of the `dvisvgm` subprocess in `full_tex_to_svg()`.
* Raise `LatexError` when `dvisvgm` exits with a non-zero status.
* Include `dvisvgm` stderr in the raised error when available.

## Test

**Code**:

```python
from manimlib import *

label = TexText("Healthy probe 246801")
number = label.make_number_changeable("246801")

print("SUCCESS")
```

A failing `dvisvgm` process was also simulated to verify the error path.

**Result**:

Normal TeX rendering and `make_number_changeable()` continue to work:

```text
SUCCESS
```

When `dvisvgm` fails, Manim now raises:

```text
LatexError: dvisvgm failed to convert DVI to SVG
```

instead of allowing empty conversion output to propagate into an unrelated downstream exception.
