### PR TITLE
Select the right glyph for a \frac argument

### DIFF
--- a/manimlib/mobject/svg/string_mobject.py
+++ b/manimlib/mobject/svg/string_mobject.py
@@ -561,6 +561,14 @@ class StringMobject(SVGMobject, ABC):
     def substr_to_path_count(self, substr: str) -> int:
         return len(re.sub(r"\s", "", substr))
 
+    def count_paths_before_index(self, index: int) -> int:
+        """
+        How many paths are drawn before the character at `index` in the string.
+
+        Subclasses whose glyphs are not drawn in source order override this.
+        """
+        return self.substr_to_path_count(self.string[:index])
+
     def get_symbol_substrings(self):
         return list(re.sub(r"\s", "", self.string))
 
@@ -570,7 +578,7 @@ class StringMobject(SVGMobject, ABC):
         result = []
         for match in re.finditer(pattern, self.string):
             index = match.start()
-            start = self.substr_to_path_count(self.string[:index])
+            start = self.count_paths_before_index(index)
             substr = match.group()
             end = start + self.substr_to_path_count(substr)
             result.append(self[start:end])

--- a/manimlib/mobject/svg/tex_mobject.py
+++ b/manimlib/mobject/svg/tex_mobject.py
@@ -14,6 +14,7 @@ from manimlib.utils.color import color_to_hex
 from manimlib.utils.color import hex_to_int
 from manimlib.utils.tex_file_writing import latex_to_svg
 from manimlib.utils.tex import num_tex_symbols
+from manimlib.utils.tex import num_pending_fraction_rules
 from manimlib.logger import log
 
 from typing import TYPE_CHECKING
@@ -221,6 +222,14 @@ class Tex(StringMobject):
         if len(self) != num_tex_symbols(tex):
             log.warning(f"Estimated size of {tex} does not match true size")
         return num_tex_symbols(substr)
+
+    def count_paths_before_index(self, index: int) -> int:
+        # A \frac draws its rule between its two arguments rather than where the
+        # command appears, so a \frac whose numerator is still open at `index` has
+        # not drawn its rule yet and must not be counted. Without this, selecting
+        # the numerator of \frac{1}{2} lands on the fraction rule instead.
+        return super().count_paths_before_index(index) - \
+            num_pending_fraction_rules(self.string, index)
 
     def get_symbol_substrings(self):
         pattern = "|".join((

--- a/manimlib/utils/tex.py
+++ b/manimlib/utils/tex.py
@@ -33,6 +33,76 @@ def num_tex_symbols(tex: str) -> int:
     return total
 
 
+# Fraction commands which draw a rule between their two arguments. LaTeX ships that
+# rule out after the numerator, not where the command itself sits in the source, so
+# these are the commands whose glyph order does not follow their source order. The
+# infix \over needs no entry: it already sits where its rule is drawn.
+FRACTION_COMMANDS = (R"\frac", R"\dfrac", R"\tfrac", R"\cfrac")
+
+
+def _iter_tex_tokens(tex: str) -> list[re.Match]:
+    # A command, an escaped character, or a single character. Matching "\\" as one
+    # token keeps the "frac" in "\\frac" (a line break followed by literal text)
+    # from reading as a fraction command.
+    return list(re.finditer(r"\\[a-zA-Z]+|\\.|.", tex, re.S))
+
+
+def get_fraction_rule_positions(tex: str) -> list[tuple[int, int]]:
+    """
+    For every fraction command in `tex`, where the command sits and where its
+    numerator ends.
+
+    The second index is the position the fraction's rule is drawn at, since TeX
+    ships a fraction out as numerator, then rule, then denominator.
+    """
+    tokens = _iter_tex_tokens(tex)
+    result = []
+    for i, token in enumerate(tokens):
+        if token.group() not in FRACTION_COMMANDS:
+            continue
+        j = i + 1
+        while j < len(tokens) and tokens[j].group().isspace():
+            j += 1
+        if j >= len(tokens):
+            continue
+        if tokens[j].group() == "{":
+            # Walk to the brace which closes the numerator
+            depth = 0
+            while j < len(tokens):
+                group = tokens[j].group()
+                if group == "{":
+                    depth += 1
+                elif group == "}":
+                    depth -= 1
+                    if depth == 0:
+                        j += 1
+                        break
+                j += 1
+            if depth != 0:
+                continue
+        else:
+            # An unbraced numerator, as in \frac12, is a single token
+            j += 1
+        result.append((token.start(), tokens[j - 1].end()))
+    return result
+
+
+def num_pending_fraction_rules(tex: str, index: int) -> int:
+    """
+    How many fraction rules `tex[:index]` names but has not yet drawn.
+
+    A \\frac before `index` whose numerator is still open at `index` has not drawn
+    its rule there, even though the command precedes that point in the source. The
+    rule is drawn at the numerator's end, so an `index` which has reached that point
+    is past the rule, as the denominator of an unbraced \\frac12 is.
+    """
+    return sum(
+        1
+        for command_start, rule_position in get_fraction_rule_positions(tex)
+        if command_start < index < rule_position
+    )
+
+
 def remove_tex_environments(tex: str) -> str:
     # Handle \phantom{...} with any content
     tex = re.sub(r"\\phantom\{[^}]*\}", "", tex)

--- a/tests/tex_frac_indices.py
+++ b/tests/tex_frac_indices.py
@@ -1,0 +1,90 @@
+"""
+That selecting a substring of a Tex picks the glyph which draws it.
+
+Tex.select_parts falls back to counting glyphs when a substring was not isolated: it
+counts how many glyphs the source before the substring draws, and slices there. That
+count assumes glyphs are drawn in source order, which a \\frac breaks. TeX ships a
+fraction out as numerator, then rule, then denominator, so the rule is drawn after the
+numerator even though \\frac is written before it. Counting \\frac where it is written
+puts every glyph of the numerator one place late, and Tex(R"\\frac{1}{2}") colours its
+rule when asked for its "1" (issue #2367).
+
+This checks the mapping rather than a picture, so it needs no latex and no gpu. It is
+the mapping that was wrong; the picture only showed it.
+
+    python tests/tex_frac_indices.py
+"""
+from __future__ import annotations
+
+import sys
+
+from manimlib.mobject.svg.tex_mobject import Tex
+from manimlib.utils.tex import num_tex_symbols
+
+
+# Each case is a tex string and, for substrings of it, the glyph the substring should
+# land on. Indices are into the glyphs as drawn, counting from zero.
+CASES = [
+    # The report's case. Drawn as "1", rule, "2", so the numerator is glyph 0 and
+    # counting \frac where it is written would say 1, which is the rule.
+    (R"\frac{1}{2}", {"1": 0, "2": 2}),
+    # Spaces inside the arguments draw nothing and must not shift anything
+    (R"\frac{ 1 }{ 2 }", {"1": 0, "2": 2}),
+    # Drawn as "1", inner rule, "2", outer rule, "3"
+    (R"\frac{\frac{1}{2}}{3}", {"1": 0, "2": 2, "3": 4}),
+    # A denominator holding the fraction instead: "1", outer rule, "2", inner rule, "3"
+    (R"\frac{1}{\frac{2}{3}}", {"1": 0, "2": 2, "3": 4}),
+    # Two fractions, so the count has to stay right across a finished one. Drawn as
+    # "1", rule, "2", "+", "3", rule, "4"
+    (R"\frac{1}{2} + \frac{3}{4}", {"2": 2, "+": 3, "3": 4, "4": 6}),
+    # An unbraced numerator is a single token
+    (R"\frac12", {"1": 0, "2": 2}),
+    # Either side of a fraction, and so unaffected by it. The letters avoid those of
+    # "frac", so that looking a substring up finds the glyph and not the command name.
+    (R"p + \frac{q}{w} + z", {"p": 0, "+": 1, "q": 2, "w": 4, "z": 6}),
+    # The infix form already sits where its rule is drawn, and should stay right
+    (R"{1 \over 2}", {"1": 0, "2": 2}),
+    # Nothing to reorder at all
+    (R"x + y", {"x": 0, "+": 1, "y": 2}),
+]
+
+
+def make_tex(tex: str) -> Tex:
+    """
+    A Tex which was never rendered, carrying only what the glyph counting reads.
+
+    Building one for real wants latex, and none of latex's output is under test here.
+    """
+    mob = object.__new__(Tex)
+    mob.string = tex
+    mob.tex_string = tex
+    # substr_to_path_count warns unless the glyph count agrees with the string
+    mob.submobjects = [None] * num_tex_symbols(tex)
+    return mob
+
+
+def main() -> int:
+    failures = []
+    for tex, expected in CASES:
+        mob = make_tex(tex)
+        for substr, glyph_index in expected.items():
+            index = tex.index(substr)
+            found = mob.count_paths_before_index(index)
+            if found != glyph_index:
+                failures.append(
+                    f"{tex}: {substr!r} should be drawn by glyph {glyph_index}, "
+                    f"counting found {found}"
+                )
+
+    for line in failures:
+        print(f"FAIL {line}")
+    cases = sum(len(expected) for _, expected in CASES)
+    if failures:
+        print(f"\n{len(failures)} of {cases} substrings land on the wrong glyph")
+        return 1
+    print(f"PASS all {cases} substrings across {len(CASES)} strings land on their glyph")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

Fixes #2367. `Tex(R"\frac{1}{2}").get_parts_by_tex("1")` colours the fraction rule instead of the numerator, and only passing `isolate=["1", "2"]` makes it work.

When a substring was not isolated, `select_parts` falls back to `select_unisolated_substring`, which finds the substring by counting glyphs:

```python
start = self.substr_to_path_count(self.string[:index])
```

That count walks the source and so assumes glyphs are drawn in source order. A `\frac` breaks the assumption. TeX ships a fraction out as **numerator, then rule, then denominator**, so `\frac{1}{2}` draws `1`, the rule, `2` — but `\frac` is *written* before its numerator. Counting the rule where the command sits puts every glyph of the numerator one place late:

| selector | glyph counted | glyph drawn there |
| --- | --- | --- |
| `"1"` | 1 | the fraction rule |
| `"2"` | 2 | `2`, right by coincidence |

That is exactly the reported symptom: the numerator picks the divider, while the denominator happens to come out right.

Two things corroborate the ordering. The infix `{1 \over 2}` has always worked, because `\over` is written where its rule is drawn; and `num_tex_symbols(R"\frac{1}{2})` is 3, so the rule is one of the three glyphs the selector indexes into.

## Proposed changes

- `manimlib/utils/tex.py`: add `get_fraction_rule_positions`, giving each fraction command and the end of its numerator, which is where its rule is drawn; and `num_pending_fraction_rules(tex, index)`, how many rules the source names before `index` but has not drawn there. Covers braced and unbraced (`\frac12`) numerators, nesting, and `\dfrac`/`\tfrac`/`\cfrac`. Tokenising `\\` as a single token keeps the `frac` in `\\frac` (a line break followed by literal text) from reading as a fraction command.
- `manimlib/mobject/svg/string_mobject.py`: put the prefix count behind an overridable `count_paths_before_index` and call it from `select_unisolated_substring`. The base implementation is what the old line did, so `MarkupText` is unaffected.
- `manimlib/mobject/svg/tex_mobject.py`: `Tex` overrides it to discount rules not yet drawn.
- `tests/tex_frac_indices.py`: new test, described below.

I went this way rather than having `Tex` auto-isolate `\frac` arguments, because auto-isolation would insert label groups into every `Tex` holding a fraction, changing `get_specified_substrings` and the grouping `TransformMatchingTex` builds on for existing scenes. This keeps the change to the counting that was actually wrong, and `isolate` continues to work as before.

Scope note: `TransformMatchingTex.matching_blocks` accumulates `substr_to_path_count` in source order as well (`sum(counts1[:match.a])`), so it shares this ordering assumption. I left it alone to keep this PR to the reported bug.

## Test

**Code**: `tests/tex_frac_indices.py` checks the mapping from string position to drawn glyph, which is the thing that was wrong; the picture only showed it. It builds no picture, so it needs neither latex nor a gpu.

```
python tests/tex_frac_indices.py
```

**Result**: 26 substrings across 9 strings, covering the report's case, spaces inside the arguments, fractions nested either side, `\frac12`, two fractions in a row, glyphs around a fraction, the infix `\over`, and a string with no fraction at all.

After this change:

```
PASS all 26 substrings across 9 strings land on their glyph
```

As a negative control, restoring the old source-order count (`Tex.count_paths_before_index = StringMobject.count_paths_before_index`) and rerunning the same cases fails on 9 of the 26, and every one of them is a numerator:

```
FAIL \frac{1}{2}: '1' should be glyph 0, counting found 1
FAIL \frac{ 1 }{ 2 }: '1' should be glyph 0, counting found 1
FAIL \frac{\frac{1}{2}}{3}: '1' should be glyph 0, counting found 2
FAIL \frac{\frac{1}{2}}{3}: '2' should be glyph 2, counting found 3
FAIL \frac{1}{\frac{2}{3}}: '1' should be glyph 0, counting found 1
FAIL \frac{1}{\frac{2}{3}}: '2' should be glyph 2, counting found 3
FAIL \frac{1}{2} + \frac{3}{4}: '3' should be glyph 4, counting found 5
FAIL \frac12: '1' should be glyph 0, counting found 1
FAIL p + \frac{q}{w} + z: 'q' should be glyph 2, counting found 3

9 of 26 substrings land on the wrong glyph
```

The denominators, the infix `\over`, and the fraction-free string pass both before and after, so the change moves the cases that were broken and leaves the rest where they were.

### What I could not verify

**I have no latex on this machine, so I have not rendered `\frac{1}{2}` and looked at the picture.** The install I attempted did not complete, and I would rather say so than imply a render I did not do. So the claim that the glyphs come out as numerator, rule, denominator rests on the reporter's rendered output in #2367 (selecting `"1"` colours the rule, which is glyph 1 by this count), on TeX shipping a fraction's vbox out in that order, and on the infix `\over` already working. The mapping itself is covered by the test above. A review that renders the repro would confirm the last step, and I would appreciate that check.