### PR TITLE
Fix updater in animation issue

### DIFF
--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -127,23 +127,26 @@ class Animation(object):
             for mob in self.get_all_mobjects()
         ])
 
-    def update_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
+    def update_reference_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
         """
         Updates things like starting_mobject, and (for
         Transforms) target_mobject.
         """
-        for mob in self.get_all_mobjects_to_update():
+        for mob in self.get_reference_mobjects():
             mob.update(dt, frame_rate=frame_rate)
 
-    def get_all_mobjects_to_update(self) -> list[Mobject]:
-        # The surrounding scene typically handles
-        # updating of self.mobject.
-        items = list(filter(
-            lambda m: m is not self.mobject,
-            self.get_all_mobjects()
-        ))
-        items = remove_list_redundancies(items)
-        return items
+    def get_reference_mobjects(self) -> list[Mobject]:
+        """
+        Returns mobjects the Animation tracks other than
+        self.mobject, e.g. the start and end points of
+        interpolation.
+        """
+        # Remove redundancies for cases like Transform where target and target_copy
+        # are the same, which happens when the already align.
+        return remove_list_redundancies([
+            mob for mob in self.get_all_mobjects()
+            if mob is not self.mobject
+        ])
 
     def copy(self):
         return deepcopy(self)

--- a/manimlib/animation/animation.py
+++ b/manimlib/animation/animation.py
@@ -127,13 +127,13 @@ class Animation(object):
             for mob in self.get_all_mobjects()
         ])
 
-    def update_mobjects(self, dt: float) -> None:
+    def update_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
         """
         Updates things like starting_mobject, and (for
         Transforms) target_mobject.
         """
         for mob in self.get_all_mobjects_to_update():
-            mob.update(dt)
+            mob.update(dt, frame_rate=frame_rate)
 
     def get_all_mobjects_to_update(self) -> list[Mobject]:
         # The surrounding scene typically handles

--- a/manimlib/animation/composition.py
+++ b/manimlib/animation/composition.py
@@ -75,9 +75,9 @@ class AnimationGroup(Animation):
         for anim in self.animations:
             anim.clean_up_from_scene(scene)
 
-    def update_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
+    def update_reference_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
         for anim in self.animations:
-            anim.update_mobjects(dt, frame_rate)
+            anim.update_reference_mobjects(dt, frame_rate)
 
     def calculate_max_end_time(self) -> None:
         self.max_end_time = max(
@@ -138,8 +138,10 @@ class Succession(AnimationGroup):
     def finish(self) -> None:
         self.active_animation.finish()
 
-    def update_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
-        self.active_animation.update_mobjects(dt, frame_rate)
+    def update_reference_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
+        # Only the active animation, since the rest are yet to begin, and so
+        # have no starting_mobject or target to speak of
+        self.active_animation.update_reference_mobjects(dt, frame_rate)
 
     def interpolate(self, alpha: float) -> None:
         index, subalpha = integer_interpolate(

--- a/manimlib/animation/composition.py
+++ b/manimlib/animation/composition.py
@@ -75,9 +75,9 @@ class AnimationGroup(Animation):
         for anim in self.animations:
             anim.clean_up_from_scene(scene)
 
-    def update_mobjects(self, dt: float) -> None:
+    def update_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
         for anim in self.animations:
-            anim.update_mobjects(dt)
+            anim.update_mobjects(dt, frame_rate)
 
     def calculate_max_end_time(self) -> None:
         self.max_end_time = max(
@@ -138,8 +138,8 @@ class Succession(AnimationGroup):
     def finish(self) -> None:
         self.active_animation.finish()
 
-    def update_mobjects(self, dt: float) -> None:
-        self.active_animation.update_mobjects(dt)
+    def update_mobjects(self, dt: float, frame_rate: float | None = None) -> None:
+        self.active_animation.update_mobjects(dt, frame_rate)
 
     def interpolate(self, alpha: float) -> None:
         index, subalpha = integer_interpolate(

--- a/manimlib/mobject/mobject_update_utils.py
+++ b/manimlib/mobject/mobject_update_utils.py
@@ -110,7 +110,7 @@ def turn_animation_into_updater(
                 m.remove_updater(update)
                 return
         animation.interpolate(alpha)
-        animation.update_mobjects(dt)
+        animation.update_reference_mobjects(dt)
         animation.total_time += dt
 
     mobject.add_updater(update)

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -546,9 +546,7 @@ class Scene(object):
             # based updaters are evaluated at the moment the frame stands for.
             self.increment_time(dt)
             for animation in animations:
-                # This reaches only the mobjects an animation holds privately, its
-                # starting_mobject and target.
-                animation.update_mobjects(dt, frame_rate=self.camera.fps)
+                animation.update_reference_mobjects(dt, frame_rate=self.camera.fps)
                 alpha = t / animation.run_time
                 animation.interpolate(alpha)
             # Updaters on the mobjects themselves have the last word, applied

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -234,6 +234,9 @@ class Scene(object):
     def update_frame(self, dt: float = 0, force_draw: bool = False) -> None:
         self.increment_time(dt)
         self.update_mobjects(dt)
+        self.draw_frame(dt, force_draw)
+
+    def draw_frame(self, dt: float = 0, force_draw: bool = False) -> None:
         if self.skip_animations and not force_draw:
             return
 
@@ -539,11 +542,19 @@ class Scene(object):
         for t in self.get_animation_time_progression(animations):
             dt = t - last_t
             last_t = t
+            # The clock moves before anything else in the frame, so that time
+            # based updaters are evaluated at the moment the frame stands for.
+            self.increment_time(dt)
             for animation in animations:
-                animation.update_mobjects(dt)
+                # This reaches only the mobjects an animation holds privately, its
+                # starting_mobject and target.
+                animation.update_mobjects(dt, frame_rate=self.camera.fps)
                 alpha = t / animation.run_time
                 animation.interpolate(alpha)
-            self.update_frame(dt)
+            # Updaters on the mobjects themselves have the last word, applied
+            # on top of whatever the animations just interpolated
+            self.update_mobjects(dt)
+            self.draw_frame(dt)
             self.emit_frame()
 
     def finish_animations(self, animations: Iterable[Animation]) -> None:
@@ -551,7 +562,8 @@ class Scene(object):
             animation.finish()
             animation.clean_up_from_scene(self)
         # Note that the passage of time during the animation, including
-        # for the case of skipped animations, is handled by update_frame
+        # for the case of skipped animations, is handled by
+        # progress_through_animations
         self.update_mobjects(0)
 
     @affects_mobject_list


### PR DESCRIPTION
An update to https://github.com/3b1b/manim/pull/2481 to ensure that when Animation updates reference mobject (like start_copy and target), it uses frame rate in cases of skipping ahead.