### PR TITLE
Fix z-indexing

### DIFF
--- a/manimlib/renderer/renderer.py
+++ b/manimlib/renderer/renderer.py
@@ -182,10 +182,14 @@ class Renderer(object):
         A drawing for every member of every family which has anything to draw, in drawing
         order, keeping the one it had where it has one. A member holding no points, a group
         say, is passed over, as is one whose kind has no shader to be drawn by.
+
+        Mobjects asking to be drawn out of that order say so with a z_index.
         """
         held = self.drawings
         self.drawings = dict()
         drawn = []
+        ascending = True
+        prev_z = 0
         for mobject in mobjects:
             for mob in mobject.get_family():
                 drawing_class = mob.drawing_class
@@ -196,6 +200,12 @@ class Renderer(object):
                     drawing = drawing_class(self.material_for(mob, drawing_class), mob)
                 self.drawings[mob] = drawing
                 drawn.append(drawing)
+                z = mob.z_index
+                if z < prev_z:
+                    ascending = False
+                prev_z = z
+        if not ascending:
+            drawn.sort(key=lambda drawing: drawing.mobject.z_index)
         return drawn
 
     def material_for(self, mobject: Mobject, drawing_class: type) -> Material:

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -319,11 +319,9 @@ class Scene(object):
         """
         self.remove(*new_mobjects)
         self.mobjects += new_mobjects
-
-        # Reorder based on z_index
-        id_to_scene_order = {id(m): idx for idx, m in enumerate(self.mobjects)}
-        self.mobjects.sort(key=lambda m: (m.z_index, id_to_scene_order[id(m)]))
-
+        # No reordering by z_index here: this list stays in the order things were added, and
+        # the renderer settles what a z_index has to say about drawing order, see
+        # Renderer.resolve
         self.id_to_mobject_map.update({
             id(sm): sm
             for m in new_mobjects


### PR DESCRIPTION
Previously, Mobject.set_z_index only had an influence at the moment of adding a mobject to a scene, but any change to it after that silently changed an attribute with no effect.

This pushes the logic to the renderer, which considers z-indices as it creates the ordered list of draw.