### PR TITLE
docs: fix broken headings and wrong FFmpeg instructions in installation page

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -3,10 +3,10 @@ Installation
 
 Manim runs on Python 3.10 or higher.
 
-System requirements are：
+System requirements are:
 
 - `FFmpeg <https://ffmpeg.org/>`__
-- `OpenGL <https://www.opengl.org//>`__ (included in python package ``PyOpenGL``)
+- `OpenGL <https://www.opengl.org/>`__ (included in python package ``PyOpenGL``)
 - `LaTeX <https://www.latex-project.org>`__ (optional, if you want to use LaTeX)
 - `Pango <https://pango.org>`__ (only for Linux)
 
@@ -14,27 +14,30 @@ System requirements are：
 Install FFmpeg
 --------------
 
+Follow the instructions for your platform, then run ``ffmpeg -version`` to check
+that the installation succeeded.
 
+Windows
+^^^^^^^
 
-Install FFmpeg Windows
-------------------------
-.. code-block:: cmd
+.. code-block:: bat
 
    choco install ffmpeg
 
+Linux
+^^^^^
 
-# Install FFmepeg Linux
-----------------------------
 .. code-block:: sh
 
-   $ sudo apt update
-   $ sudo apt install ffmpeg
-   $ ffmpeg -version
-  
-# Install FFmpeg MacOS
-----------------------------
-- Download This ZIP file `https://www.gyan.dev/ffmpeg/builds/ffmpeg-git-full.7z`(if the link is not working download this zip file from there original website)
+   sudo apt update
+   sudo apt install ffmpeg
 
+macOS
+^^^^^
+
+.. code-block:: sh
+
+   brew install ffmpeg
 
 
 Directly
@@ -61,7 +64,7 @@ that directory execute:
    # or
    manim-render example_scenes.py OpeningManimExample
 
-If you run the above command and no error message appears, 
+If you run the above command and no error message appears,
 then you have successfully installed all the environments required by manim.
 
 Directly (Windows)
@@ -73,23 +76,23 @@ Directly (Windows)
    `TeXLive-full <http://tug.org/texlive/>`__ is recommended.
 3. Install the remaining Python packages.
 
-.. code-block:: sh  
+.. code-block:: sh
 
    git clone https://github.com/3b1b/manim.git
-   cd manim  
-   pip install -e . 
+   cd manim
+   pip install -e .
    manimgl example_scenes.py OpeningManimExample
 
 For Anaconda
 ------------
 
 -  Install FFmpeg and LaTeX as above.
--  Create a conda environment using
+-  Clone the repository and set up the environment using
 
 .. code-block:: sh
-   
+
    git clone https://github.com/3b1b/manim.git
-   cd manim 
+   cd manim
    conda create -n manim python=3.10
    conda activate manim
    pip install -e .


### PR DESCRIPTION
## Motivation

The FFmpeg part of the installation page has been broken on the published docs
since 71ab276 (May 2023). It was written with Markdown heading syntax inside an
RST file, so the `#` characters render literally at
[3b1b.github.io/manim/getting_started/installation.html](https://3b1b.github.io/manim/getting_started/installation.html):

```
Install FFmpeg
Install FFmpeg Windows
# Install FFmepeg Linux
# Install FFmpeg MacOS
```

Three separate problems follow from that section:

- The `#` leaks into the rendered heading text, and one heading spells the
  program `FFmepeg`.
- All three platform headings use the same underline level as `Install FFmpeg`,
  so they are siblings rather than children and the parent section renders with
  no body at all.
- The macOS step tells the reader to download
  `https://www.gyan.dev/ffmpeg/builds/ffmpeg-git-full.7z`. That site states
  "Builds require Windows 10 or later", so this hands macOS users a Windows
  binary, and it calls the `.7z` archive a ZIP file.

The section also emits two Sphinx warnings: the macOS link uses single
backticks, which docutils reads as an unterminated interpreted-text start-string,
and the Windows block declares `.. code-block:: cmd`, which is not a Pygments
lexer, so the block loses highlighting.

## Proposed changes

- Rewrite the FFmpeg headings as proper RST, nested one level under
  `Install FFmpeg` with the `^` underline this docs tree already uses for that
  level, and fix the `FFmepeg` spelling.
- Give `Install FFmpeg` a body, moving the `ffmpeg -version` check there so it
  applies to all three platforms instead of only Linux.
- Replace the Windows-only gyan.dev download in the macOS step with
  `brew install ffmpeg`, matching the Homebrew instructions already in the
  README.
- Change the `cmd` lexer to `bat`.
- Drop the `$` prompts from the Linux block. `sphinx_copybutton` is enabled and
  `copybutton_prompt_text` is not configured, so the copy button currently
  yields `$ sudo apt update`, which fails when pasted.
- Fix a full-width colon (U+FF1A) in `System requirements are:` and the doubled
  slash in `https://www.opengl.org//`.
- Reword the Anaconda lead-in from "Create a conda environment using" to match
  the block below it, which clones the repository before creating the
  environment.
- Strip trailing whitespace from the lines this change already touches.

No installation command changes behaviour apart from the macOS one, which was
pointing at the wrong platform.

## Test

**Code**:

```sh
pip install -r docs/requirements.txt
cd docs/
sphinx-build -E -b html source /tmp/out source/getting_started/installation.rst
```

**Result**:

Both warnings from this file are gone, taking the build from 12 warnings to 10.
The remaining 10 all come from other files and are untouched by this change:
six `toc.not_included` warnings under `documentation/`, two "Title underline too
short" warnings in `custom_config.rst`, one `toc.not_readable` for a missing
`getting_started/config`, and one search-index notice that only appears because
the command above builds a single page rather than the whole tree.

Before:

```
installation.rst:36: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
installation.rst:21: WARNING: Pygments lexer name 'cmd' is not known [misc.highlighting_failure]
build succeeded, 12 warnings.
```

After:

```
build succeeded, 10 warnings.
```

The rendered heading tree changes from eight flat sections to a nested one:

| Before | After |
| --- | --- |
| h1 Installation | h1 Installation |
| h2 Install FFmpeg | h2 Install FFmpeg |
| h2 Install FFmpeg Windows | &nbsp;&nbsp;h3 Windows |
| h2 `# Install FFmepeg Linux` | &nbsp;&nbsp;h3 Linux |
| h2 `# Install FFmpeg MacOS` | &nbsp;&nbsp;h3 macOS |
| h2 Directly | h2 Directly |
| h2 Directly (Windows) | h2 Directly (Windows) |
| h2 For Anaconda | h2 For Anaconda |

Built with Sphinx 9.1.0 and furo, per `docs/requirements.txt`.

One thing I left alone on purpose: this page recommends TeXLive-full for
Windows while the README recommends MiKTeX. That is a recommendation to make
rather than a rendering defect, so it seemed out of scope here. Happy to follow
up if you want them aligned.
