### PR TITLE
docs: make the macOS install snippet runnable in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ sudo apt install python3.12-venv
     git clone https://github.com/3b1b/manim.git
     cd manim
     pip install -e .
-    manimgl example_scenes.py OpeningManimExample (make sure to add manimgl to path first.)
+    manimgl example_scenes.py OpeningManimExample
     ```
+    If the last command is not found, make sure the directory pip installed `manimgl` into is on your `PATH`.
 
 ## Anaconda Install
 


### PR DESCRIPTION
## Motivation

The last line of the macOS install step sits inside a ```` ```sh ```` block but
ends with a parenthetical note:

```sh
manimgl example_scenes.py OpeningManimExample (make sure to add manimgl to path first.)
```

Parentheses are not inert in shell. Copying the block with GitHub's copy button
and pasting it runs the note as a subshell, so the reader gets a syntax error
from the note rather than the example scene the step promises. It is also the
only code block in the README that cannot be pasted as written; every other one
contains commands only.

## Proposed changes

- Drop the parenthetical from the code block so the four lines run as-is.
- Keep the advice as prose under the block, phrased as the symptom the reader
  would actually hit: `If the last command is not found, make sure the directory
  pip installed manimgl into is on your PATH.`

## Test

**Code**: This is a README-only change with no build step, so the check is that
the block is now copy-paste clean and that the change does not collide with the
other open README PR.

```sh
git merge --no-commit --no-ff pr2445
```

**Result**:

```
Auto-merging README.md
Automatic merge went well; stopped before committing as requested
```

#2509 touches `docs/source/getting_started/installation.rst` only, and #2445
touches the "using these command" line four lines above this hunk. I merged
#2445 against this branch locally and it applies cleanly, so this can land in
any order relative to either one.

I deliberately left the wording of step 3 alone, since #2445 is already
correcting that line.
