### PR TITLE
docs: correct custom_config keys and drop a dangling toctree entry

### DIFF
--- a/docs/source/documentation/custom_config.rst
+++ b/docs/source/documentation/custom_config.rst
@@ -120,18 +120,18 @@ Configuration specifying how files are written, e.g. what ffmpeg parameters to u
 
 
 ``scene``
--------
+---------
 Some default configuration for the Scene class
 
 
 ``text``
--------
+--------
 
 - ``font`` 
     Default font of Text
 
-- ``text_alignment``
-    Default text alignment for LaTeX
+- ``alignment``
+    Default alignment of Text, one of ``"LEFT"``, ``"CENTER"`` or ``"RIGHT"``
 
 ``tex``
 -------
@@ -145,17 +145,17 @@ Some default configuration for the Scene class
 ``sizes``
 ---------
 
-Valuess for various constants used in manimm to specify distances, like the height
+Values for various constants used in manim to specify distances, like the height
 of the frame, the value of SMALL_BUFF, LARGE_BUFF, etc.
 
 
 ``colors``
 ----------
 
-Color pallete to use, determining values of color constants like RED, BLUE_E, TEAL, etc.
+Color palette to use, determining values of color constants like RED, BLUE_E, TEAL, etc.
 
-``loglevel``
-------------
+``log_level``
+-------------
 
 Can be DEBUG / INFO / WARNING / ERROR / CRITICAL
 
@@ -163,7 +163,7 @@ Can be DEBUG / INFO / WARNING / ERROR / CRITICAL
 ``universal_import_line``
 -------------------------
 
-Import line that need to execute when entering interactive mode directly.
+Import line that is executed when entering interactive mode directly.
 
 
 ``ignore_manimlib_modules_on_reload``
@@ -171,6 +171,6 @@ Import line that need to execute when entering interactive mode directly.
 
 When calling ``reload`` during the interactive mode, imported modules are
 by default reloaded, in case the user writing a scene which pulls from various
-other files they have written. By default, modules withinn the manim library will
+other files they have written. By default, modules within the manim library will
 be ignored, but one developing manim may want to set this to be False so that 
 edits to the library are reloaded as well.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,6 @@ And here is a Chinese version of this documentation: https://docs.manim.org.cn/
    getting_started/quickstart
    getting_started/configuration
    getting_started/example_scenes
-   getting_started/config
    getting_started/structure
    getting_started/whatsnew
 


### PR DESCRIPTION
## Motivation

Partially addresses #2378, which reports that the [custom configuration page](https://3b1b.github.io/manim/documentation/custom_config.html) has drifted from the actual config format.

Two of the options it documents do not exist in `manimlib/default_config.yml`. Because an unrecognised key in `custom_config.yml` is simply ignored, someone following the page gets no error — the setting just never takes effect:

- The page calls it `loglevel`. The real key is `log_level` (`manimlib/default_config.yml`), read in `manimlib/config.py` as `config["log_level"]`.
- Under `text`, the page calls it `text_alignment` and describes it as "Default text alignment for LaTeX". The real key is `alignment`, and it is read in `MarkupText.__init__` as `text_config.alignment`, so it sets the default for `Text`, not for LaTeX. `text_alignment` does not appear anywhere in `manimlib/`.

Two smaller things showed up while building the docs:

- The `scene` and `text` title underlines are shorter than their titles, which Sphinx warns about.
- `docs/source/index.rst` still lists `getting_started/config` in the Getting Started toctree. That file was deleted in 44b7d33 (Dec 2022), so Sphinx warns on every build.

## Proposed changes

- `docs/source/documentation/custom_config.rst`
  - `loglevel` → `log_level`
  - `text_alignment` → `alignment`, with a description that matches what the key actually does
  - lengthen the `scene` and `text` title underlines
  - fix four typos in the surrounding prose (`Valuess`, `manimm`, `pallete`, `withinn`) and one ungrammatical sentence under `universal_import_line`
- `docs/source/index.rst`
  - drop the `getting_started/config` toctree entry

Deliberately **not** in this PR, to keep it easy to review:

- The `directories` section is also out of date, in a way that needs more than a rename: `output`, `raster_images`, `vector_images` and `sounds` are nested under `directories.subdirs` in the yml rather than directly under `directories`, and the two directory-tree examples still show separate `images/` and `videos/` folders. I would rather verify that against a real render and send it separately.
- The five sections with no documentation at all (`vmobject`, `mobject`, `embed`, `resolution_options`, `key_bindings`).
- The website ↔ GitHub cross-linking also asked for in #2378, which is a repository setting rather than a docs change.

## Test

**Code**: the same build CI runs, on `master` (5d107b1) and on this branch, with Python 3.12 and `docs/requirements.txt` (Sphinx 9.1.0):

```sh
pip install -r docs/requirements.txt
cd docs && make html
```

**Result**: `build succeeded` both times; warnings go from 9 to 6.

The three that disappear are exactly the ones this PR targets:

```
docs/source/documentation/custom_config.rst:123: WARNING: Title underline too short.
docs/source/documentation/custom_config.rst:128: WARNING: Title underline too short.
docs/source/index.rst:11: WARNING: toctree contains reference to nonexisting document 'getting_started/config' [toc.not_readable]
```

The remaining 6 are pre-existing `toc.not_included` warnings for the autodoc index pages under `documentation/`, untouched here.

Diffing the rendered `custom_config.html` between the two builds shows only the intended edits — the section structure is otherwise byte-identical, so the shorter underlines were not changing how the page rendered, only warning.

One consequence worth flagging: the heading anchor changes from `#loglevel` to `#log-level`. Nothing in this repository links to the old anchor, but an external deep link would break.
