### PR TITLE
Use monotonic clocks for frame pacing

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -149,7 +149,9 @@ class Scene(object):
 
     def run(self) -> None:
         self.virtual_animation_start_time: float = 0
-        self.real_animation_start_time: float = time.time()
+        # Frame pacing measures elapsed time, so it must not be affected by system-clock
+        # adjustments while an animation is playing.
+        self.real_animation_start_time: float = time.perf_counter()
         self.file_writer.begin()
 
         self.setup()
@@ -255,7 +257,7 @@ class Scene(object):
 
         if self.window and not self.skip_animations:
             vt = self.time - self.virtual_animation_start_time
-            rt = time.time() - self.real_animation_start_time
+            rt = time.perf_counter() - self.real_animation_start_time
             time.sleep(max(vt - rt, 0))
 
     def emit_frame(self) -> None:
@@ -444,7 +446,7 @@ class Scene(object):
 
     def stop_skipping(self) -> None:
         self.virtual_animation_start_time = self.time
-        self.real_animation_start_time = time.time()
+        self.real_animation_start_time = time.perf_counter()
         self.skip_animations = False
 
     # Methods associated with running animations
@@ -512,7 +514,7 @@ class Scene(object):
 
         if self.window:
             self.virtual_animation_start_time = self.time
-            self.real_animation_start_time = time.time()
+            self.real_animation_start_time = time.perf_counter()
 
     def post_play(self):
         if not self.skip_animations:

--- a/manimlib/scene/scene_embed.py
+++ b/manimlib/scene/scene_embed.py
@@ -90,9 +90,10 @@ class InteractiveSceneEmbed:
             while not context.input_is_ready():
                 if self.scene.is_window_closing():
                     break
-                start_time = time.time()
+                # A wall-clock adjustment must not turn the frame delay into a busy loop.
+                start_time = time.perf_counter()
                 self.scene.update_frame(dt=0)
-                time.sleep(max(frame_duration - (time.time() - start_time), 0))
+                time.sleep(max(frame_duration - (time.perf_counter() - start_time), 0))
             if self.scene.is_window_closing():
                 self.shell.ask_exit()
 


### PR DESCRIPTION
## Motivation

Frame pacing currently measures elapsed time with `time.time()`. Wall-clock
adjustments can make the calculated delay negative and skip the sleep used to
pace both preview and embedded interactive loops.

## Proposed changes

- Use `time.perf_counter()` for preview animation pacing.
- Use the same monotonic clock while the embedded IPython input hook redraws
  frames.

## Validation

- `git diff --check`
- Parsed both changed modules with Python AST without writing bytecode caches.

Full graphical regression testing was not run in this environment because it
has Python 3.9 and no project dependencies/display; the project requires
Python 3.10+ and a graphical backend.

Fixes #2471.
