### PR TITLE
Add VideoMobject and Sprite

### DIFF
--- a/manimlib/__init__.py
+++ b/manimlib/__init__.py
@@ -63,6 +63,7 @@ from manimlib.mobject.types.dot_cloud import *
 from manimlib.mobject.types.image_mobject import *
 from manimlib.mobject.types.point_cloud_mobject import *
 from manimlib.mobject.types.surface import *
+from manimlib.mobject.types.video_mobject import *
 from manimlib.mobject.types.vectorized_mobject import *
 from manimlib.mobject.value_tracker import *
 from manimlib.mobject.vector_field import *

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -25,6 +25,7 @@ from manimlib.event_handler.event_type import EventType
 from manimlib.logger import log
 from manimlib.renderer.drawing import Drawing
 from manimlib.renderer.texture import TextureSource
+from manimlib.renderer.texture import check_texture_filter
 from manimlib.renderer.uniform_block import COMMON_UNIFORMS
 from manimlib.renderer.uniform_block import Uniforms
 from manimlib.renderer.uniform_block import uniform_block_dtype
@@ -81,6 +82,8 @@ class Mobject(object):
         ('point', np.float32, (3,)),
         ('rgba', np.float32, (4,)),
     ])
+    # How its images are read between their pixels, see renderer.gpu.Gpu.sampler
+    texture_filter: str = "linear"
     # One value each for the whole mobject, as opposed to one per point
     uniform_dtype: np.dtype = uniform_block_dtype(*COMMON_UNIFORMS)
     # Data holding a point, which transforms act on, and which a blend of two mobjects
@@ -98,6 +101,7 @@ class Mobject(object):
         opacity: float = 1.0,
         shading: Tuple[float, float, float] = (0.0, 0.0, 0.0),
         textures: dict[str, TextureSource] | None = None,
+        texture_filter: str | None = None,
         # If true, the mobject will not get rotated according to camera position
         is_fixed_in_frame: bool = False,
         depth_test: bool = False,
@@ -107,6 +111,8 @@ class Mobject(object):
         self.opacity = opacity
         self.shading = shading
         self.textures = textures or dict()
+        if texture_filter is not None:
+            self.set_texture_filter(texture_filter, recurse=False)
         self.depth_test = depth_test
         self.z_index = z_index
 
@@ -705,6 +711,7 @@ class Mobject(object):
             sm1.pointlike_uniform_keys = sm2.pointlike_uniform_keys
             sm1.shader_file = sm2.shader_file
             sm1.textures = {name: src.copy() for name, src in sm2.textures.items()}
+            sm1.texture_filter = sm2.texture_filter
             sm1.depth_test = sm2.depth_test
             sm1._needs_new_bounding_box = sm2._needs_new_bounding_box
         # Make sure named family members carry over
@@ -1386,6 +1393,17 @@ class Mobject(object):
         if recurse:
             for submob in self.submobjects:
                 submob.set_opacity(opacity, recurse=True)
+        return self
+
+    def set_texture_filter(self, texture_filter: str, recurse: bool = True) -> Self:
+        """
+        How the images this is drawn with are read between their pixels. The default is
+        "linear", but "nearest" can be used to take the nearest pixel, e.g. for scaled
+        up pixel art.
+        """
+        check_texture_filter(texture_filter)
+        for mob in self.get_family(recurse):
+            mob.texture_filter = texture_filter
         return self
 
     def get_color(self) -> str:

--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -24,6 +24,7 @@ from manimlib.event_handler.event_listner import EventListener
 from manimlib.event_handler.event_type import EventType
 from manimlib.logger import log
 from manimlib.renderer.drawing import Drawing
+from manimlib.renderer.texture import TextureSource
 from manimlib.renderer.uniform_block import COMMON_UNIFORMS
 from manimlib.renderer.uniform_block import Uniforms
 from manimlib.renderer.uniform_block import uniform_block_dtype
@@ -96,8 +97,7 @@ class Mobject(object):
         color: ManimColor = DEFAULT_MOBJECT_COLOR,
         opacity: float = 1.0,
         shading: Tuple[float, float, float] = (0.0, 0.0, 0.0),
-        # For shaders
-        texture_paths: dict[str, str] | None = None,
+        textures: dict[str, TextureSource] | None = None,
         # If true, the mobject will not get rotated according to camera position
         is_fixed_in_frame: bool = False,
         depth_test: bool = False,
@@ -106,7 +106,7 @@ class Mobject(object):
         self.color = color
         self.opacity = opacity
         self.shading = shading
-        self.texture_paths = texture_paths or dict()
+        self.textures = textures or dict()
         self.depth_test = depth_test
         self.z_index = z_index
 
@@ -651,6 +651,7 @@ class Mobject(object):
         # need to be further copied.
         result.data = self.data.copy()
         result.uniforms = self.uniforms.copy()
+        result.textures = {name: src.copy() for name, src in self.textures.items()}
 
         # Instead of adding using result.add, which does some checks for updating
         # updater statues and bounding box, just directly modify the family-related
@@ -703,7 +704,7 @@ class Mobject(object):
             sm1.bounding_box[:] = sm2.bounding_box
             sm1.pointlike_uniform_keys = sm2.pointlike_uniform_keys
             sm1.shader_file = sm2.shader_file
-            sm1.texture_paths = sm2.texture_paths
+            sm1.textures = {name: src.copy() for name, src in sm2.textures.items()}
             sm1.depth_test = sm2.depth_test
             sm1._needs_new_bounding_box = sm2._needs_new_bounding_box
         # Make sure named family members carry over

--- a/manimlib/mobject/types/image_mobject.py
+++ b/manimlib/mobject/types/image_mobject.py
@@ -5,6 +5,7 @@ from PIL import Image
 
 from manimlib.constants import DL, DR, UL, UR
 from manimlib.mobject.mobject import Mobject
+from manimlib.renderer.texture import ImageFile
 from manimlib.utils.bezier import inverse_interpolate
 from manimlib.utils.images import get_full_raster_image_path
 from manimlib.utils.iterables import listify
@@ -14,6 +15,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Sequence, Tuple
+    from manimlib.renderer.texture import TextureSource
     from manimlib.typing import Vect3
 
 
@@ -35,9 +37,17 @@ class ImageMobject(Mobject):
         **kwargs
     ):
         self.height = height
+        super().__init__(textures={"Texture": self.init_texture(filename)}, **kwargs)
+
+    def init_texture(self, filename: str) -> TextureSource:
+        """
+        Where the pixels drawn over the four corners come from, which for an image is the
+        file itself. Overridden by anything drawing the same quad from somewhere else, a
+        frame of a video say, see VideoMobject.
+        """
         self.image_path = get_full_raster_image_path(filename)
         self.image = Image.open(self.image_path)
-        super().__init__(texture_paths={"Texture": self.image_path}, **kwargs)
+        return ImageFile(self.image_path)
 
     def init_data(self) -> None:
         super().init_data(length=4)
@@ -45,9 +55,13 @@ class ImageMobject(Mobject):
         self.data["im_coords"] = [(0, 0), (0, 1), (1, 0), (1, 1)]
         self.data["opacity"] = self.opacity
 
+    def get_source_size(self) -> Tuple[int, int]:
+        """The pixel size of what is drawn, which is what fixes the aspect ratio"""
+        return self.image.size
+
     def init_points(self) -> None:
-        size = self.image.size
-        self.set_width(2 * size[0] / size[1], stretch=True)
+        width, height = self.get_source_size()
+        self.set_width(2 * width / height, stretch=True)
         self.set_height(self.height)
 
     def set_opacity(self, opacity: float, recurse: bool = True):

--- a/manimlib/mobject/types/surface.py
+++ b/manimlib/mobject/types/surface.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from manimlib.constants import GREY
 from manimlib.constants import OUT
 from manimlib.mobject.mobject import Mobject
+from manimlib.renderer.texture import ImageFile
 from manimlib.renderer.drawing import SurfaceDrawing
 from manimlib.mobject.mobject import Group
 from manimlib.utils.bezier import integer_interpolate
@@ -412,9 +413,9 @@ class TexturedSurface(Surface):
         else:
             self.num_textures = 2
 
-        texture_paths = {
-            "LightTexture": get_full_raster_image_path(image_file),
-            "DarkTexture": get_full_raster_image_path(dark_image_file),
+        textures = {
+            "LightTexture": ImageFile(get_full_raster_image_path(image_file)),
+            "DarkTexture": ImageFile(get_full_raster_image_path(dark_image_file)),
         }
 
         self.uv_surface = uv_surface
@@ -423,7 +424,7 @@ class TexturedSurface(Surface):
         self.v_range: Tuple[float, float] = uv_surface.v_range
         self.initial_resolution: Tuple[int, int] = uv_surface.get_resolution()
         super().__init__(
-            texture_paths=texture_paths,
+            textures=textures,
             shading=tuple(uv_surface.shading),
             **kwargs
         )
@@ -517,7 +518,7 @@ class TexturedGeometry(TexturedSurface):
         self.initial_resolution = (0, 0)
         Mobject.__init__(
             self,
-            texture_paths={"LightTexture": get_full_raster_image_path(texture_file)}
+            textures={"LightTexture": ImageFile(get_full_raster_image_path(texture_file))}
         )
 
     def init_points(self):

--- a/manimlib/mobject/types/video_mobject.py
+++ b/manimlib/mobject/types/video_mobject.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from fractions import Fraction
+
+import av
+import numpy as np
+from PIL import Image
+
+from manimlib.mobject.types.image_mobject import ImageMobject
+from manimlib.renderer.texture import LayeredPixels
+from manimlib.renderer.uniform_block import COMMON_UNIFORMS
+from manimlib.renderer.uniform_block import uniform_block_dtype
+from manimlib.utils.images import get_full_video_path
+from manimlib.utils.rate_functions import linear
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Self, Tuple
+
+
+# How many decoded frames one source keeps, where it has not read the whole video in
+DEFAULT_CACHE_SIZE: int = 32
+# Up to how many bytes of decoded frames a video is preloaded, held whole both in memory and
+# on the gpu rather than read a frame at a time, which for the short clips this is aimed at
+# is every one of them
+PRELOAD_LIMIT: int = 64_000_000
+
+
+class VideoSource(object):
+    """
+    The frames of one video file, decoded on demand and returned as straight rgba, alpha
+    included where the video carries one.
+
+    Shared by every mobject naming the file, so a grid of characters drawn from one clip
+    decodes each frame once between them.
+    """
+    _sources: dict[str, VideoSource] = dict()
+
+    @classmethod
+    def get(cls, path: str, preload: bool | None = None) -> VideoSource:
+        """
+        The source for this file, shared with everything else naming it, and so read one way
+        or the other for the whole of it: one asked for whole now is read in now, but one
+        already read in whole stays that way.
+        """
+        source = cls._sources.get(path)
+        if source is None:
+            source = cls._sources[path] = cls(path, preload)
+        elif preload and not source.preloaded:
+            source.read_all()
+        return source
+
+    def __deepcopy__(self, memo: dict) -> VideoSource:
+        """Shared rather than copied; the container behind it cannot be copied in any case."""
+        return self
+
+    def __init__(self, path: str, preload: bool | None = None):
+        self.path = path
+        self.container = av.open(path)
+        self.stream = self.container.streams.video[0]
+        self.stream.thread_type = "AUTO"
+
+        self.width = self.stream.codec_context.width
+        self.height = self.stream.codec_context.height
+        self.frame_rate = Fraction(self.stream.average_rate or self.stream.guessed_rate or 30)
+        self.num_frames = self.get_num_frames()
+        self.duration = float(self.num_frames / self.frame_rate)
+
+        # A window of decoded frames, where the whole clip is not held, see remember
+        self.cache: OrderedDict[int, np.ndarray] = OrderedDict()
+        # Where a sequential read has got to, so that the common case of asking for one frame
+        # after another never seeks
+        self.decoder = None
+        self.next_index = 0
+
+        # Every frame as one array, held only where the whole clip was read in
+        self.all_frames: np.ndarray | None = None
+        self.preloaded = False
+        if preload is None:
+            preload = self.fits_at_once()
+        if preload:
+            self.read_all()
+
+    def get_num_frames(self) -> int:
+        """
+        How many frames the video holds: what the container says, else the duration times
+        the frame rate, else a count from reading through.
+        """
+        if self.stream.frames:
+            return self.stream.frames
+        if self.stream.duration and self.stream.time_base:
+            seconds = float(self.stream.duration * self.stream.time_base)
+            return max(1, round(seconds * float(self.frame_rate)))
+        if self.container.duration:
+            seconds = self.container.duration / av.time_base
+            return max(1, round(seconds * float(self.frame_rate)))
+        return sum(1 for _ in self.container.decode(self.stream))
+
+    def fits_at_once(self) -> bool:
+        """Whether the whole clip is small enough to hold at once, see PRELOAD_LIMIT."""
+        return self.num_frames * self.width * self.height * 4 <= PRELOAD_LIMIT
+
+    def get_all_frames(self) -> np.ndarray:
+        """Every frame as one array of layers, decoded once and kept."""
+        if self.all_frames is None:
+            self.read_all()
+        return self.all_frames
+
+    def read_all(self) -> None:
+        """
+        Decode the whole clip, after which every frame is there to be read without any
+        further decoding, see get_frame.
+        """
+        self.container.seek(0, stream=self.stream)
+        frames = [self.to_rgba(frame) for frame in self.container.decode(self.stream)]
+        # What was decoded is what there is, whatever the container claimed
+        self.num_frames = max(1, len(frames))
+        self.duration = float(self.num_frames / self.frame_rate)
+        # Held as one array rather than a frame at a time: it is what an upload wants, and
+        # keeping the window as well would be keeping the clip twice over
+        self.all_frames = np.stack(frames or [self.blank_frame()])
+        self.cache.clear()
+        self.preloaded = True
+
+    def blank_frame(self) -> np.ndarray:
+        """A frame of nothing, the size of the video's own."""
+        return np.zeros((self.height, self.width, 4), dtype=np.uint8)
+
+    def to_rgba(self, frame) -> np.ndarray:
+        """One decoded frame as straight rgba bytes."""
+        return frame.to_ndarray(format="rgba")
+
+    def index_at_time(self, time: float) -> int:
+        """
+        Which frame shows at a given time: the nearest one, clamped at both ends.
+        """
+        index = round(time * float(self.frame_rate))
+        return int(np.clip(index, 0, self.num_frames - 1))
+
+    def seek(self, index: int) -> None:
+        """Put the read at the last keyframe at or before this frame."""
+        time_base = self.stream.time_base or Fraction(1, int(self.frame_rate))
+        offset = int(index / self.frame_rate / time_base)
+        self.container.seek(offset, stream=self.stream, backward=True, any_frame=False)
+        self.decoder = self.container.decode(self.stream)
+        self.next_index = None
+
+    def get_frame(self, index: int) -> np.ndarray:
+        """
+        The pixels of one frame, straight out of the whole clip where that was read in, and
+        otherwise decoded up to, see read_up_to.
+
+        Where the read runs off the end, the frame count having only been an estimate, what
+        was decodable is taken to be the whole video and its last frame stands in.
+        """
+        if self.preloaded:
+            return self.get_all_frames()[int(np.clip(index, 0, self.num_frames - 1))]
+        while True:
+            index = int(np.clip(index, 0, self.num_frames - 1))
+            pixels = self.cache.get(index)
+            if pixels is not None:
+                self.cache.move_to_end(index)
+                return pixels
+            pixels = self.read_up_to(index)
+            if pixels is not None:
+                return pixels
+            if index == 0:
+                # Nothing in the file decodes at all, so there is nothing to show of it
+                return self.blank_frame()
+            self.num_frames = index
+            index -= 1
+
+    def read_up_to(self, index: int) -> np.ndarray | None:
+        """
+        Decode forward to a frame from where the last read left off, seeking first where that
+        is already past it, so a jump backwards costs a keyframe seek and a jump forwards the
+        frames between. None where the read runs off the end before reaching it.
+        """
+        if self.decoder is None or self.next_index is None or index < self.next_index:
+            self.seek(index)
+        for frame in self.decoder:
+            at = self.index_of(frame)
+            self.next_index = at + 1
+            if at >= index:
+                pixels = self.to_rgba(frame)
+                self.remember(at, pixels)
+                # Under what was asked for too, where the video holds no frame there, so
+                # that asking again reads from the cache rather than seeking afresh
+                if at != index:
+                    self.remember(index, pixels)
+                return pixels
+        self.decoder = None
+        return None
+
+    def index_of(self, frame) -> int:
+        """Which frame of the video a decoded one is, from its timestamp."""
+        if frame.pts is None or self.stream.time_base is None:
+            return self.next_index or 0
+        seconds = float(frame.pts * self.stream.time_base)
+        return round(seconds * float(self.frame_rate))
+
+    def remember(self, index: int, pixels: np.ndarray) -> None:
+        self.cache[index] = pixels
+        self.cache.move_to_end(index)
+        while len(self.cache) > DEFAULT_CACHE_SIZE:
+            self.cache.popitem(last=False)
+
+
+class VideoFrames(LayeredPixels):
+    """
+    The frames of a video on the gpu, and which of them is showing.
+
+    A preloaded clip goes up once as a stack of every frame, shared by every mobject naming
+    the file, and changing frame is then just a change of layer: no decode, no upload. One
+    read a frame at a time keeps a single layer, rewritten as the frame changes.
+
+    The frame number is held here beside the pixels so the two survive a copy or a become.
+    """
+
+    def __init__(
+        self,
+        video: VideoSource,
+        loaded: int = -1,
+        layers: np.ndarray | None = None,
+    ):
+        self.video = video
+        # Which frame the single layer holds, where the clip is not preloaded. Only a record
+        # of what was uploaded; which frame is showing is the mobject's uniform
+        self.loaded = loaded
+        if video.preloaded:
+            super().__init__(video.get_all_frames(), key=video.path)
+        elif layers is not None:
+            super().__init__(layers)
+        else:
+            super().__init__(video.blank_frame()[np.newaxis])
+
+    @property
+    def preloaded(self) -> bool:
+        """
+        Whether every frame is up at once, and so shared with every other mobject naming the
+        file. Settled when these were made, whatever the source reads in later.
+        """
+        return self.key is not None
+
+    def copy(self) -> VideoFrames:
+        # A preloaded stack is read alike by everything holding it, so a copy holds that one
+        if self.preloaded:
+            return self
+        return VideoFrames(self.video, self.loaded, self.layers)
+
+    def load(self, index: int) -> None:
+        """Make the pixels of a frame available to be drawn."""
+        if self.preloaded or index == self.loaded:
+            return
+        self.loaded = index
+        self.set_layers(self.video.get_frame(index)[np.newaxis])
+
+    def get_pixels(self, index: int) -> np.ndarray:
+        """The straight rgba pixels of one frame."""
+        return self.layers[index if self.preloaded else 0]
+
+
+class VideoMobject(ImageMobject):
+    """
+    A video showing whichever frame set_time was last given, and otherwise an ImageMobject
+    in every respect.
+
+    Two of these drawn from one file may sit on different frames of it, sharing the decoding
+    and, where the clip is small enough to be preloaded, the frames on the gpu too, see
+    VideoFrames.
+    """
+
+    shader_file: str = "video.wgsl"
+    uniform_dtype: np.dtype = uniform_block_dtype(*COMMON_UNIFORMS, ("frame", 1))
+
+    def __init__(
+        self,
+        filename: str,
+        height: float = 4.0,
+        time: float = 0.0,
+        preload: bool | None = None,
+        **kwargs
+    ):
+        # Read by init_texture, which the constructor below reaches
+        self._preload = preload
+        super().__init__(filename, height=height, **kwargs)
+        self.set_time(time)
+
+    def init_texture(self, filename: str) -> VideoFrames:
+        """
+        A clip preloaded is decoded whole and goes up as one stack shared by everything
+        naming the file, moving between its frames costing no more than a uniform; one that
+        is not is read a frame at a time, which every mobject drawn from it needs its own
+        layer of. Small enough clips are preloaded by default, see PRELOAD_LIMIT.
+        """
+        path = str(get_full_video_path(filename))
+        return VideoFrames(VideoSource.get(path, self._preload))
+
+    @property
+    def frames(self) -> VideoFrames:
+        """
+        The frames this is drawn from, read from where the mobject holds its images rather
+        than kept alongside them, so that a copy reads its own rather than these.
+        """
+        return self.textures["Texture"]
+
+    @property
+    def source(self) -> VideoSource:
+        """The video the frames come from, which is likewise the frames' to say."""
+        return self.frames.video
+
+    @property
+    def video_path(self) -> str:
+        return self.source.path
+
+    @property
+    def preloaded(self) -> bool:
+        """
+        Whether the whole clip is held at once, and so shared with every other mobject
+        naming the file, rather than read a frame at a time.
+        """
+        return self.frames.preloaded
+
+    @property
+    def frame_index(self) -> int:
+        """
+        Which frame of the video is showing, which the uniform alone decides. Holding it
+        there and nowhere else is what lets it be interpolated, so that animating between
+        two frames scrubs through the ones between.
+
+        A blend landing between two frames shows the nearer, as the shader reads it, see
+        video.wgsl.
+        """
+        return int(round(float(self.uniforms["frame"])))
+
+    def get_source_size(self) -> Tuple[int, int]:
+        return (self.source.width, self.source.height)
+
+    # Which frame is showing
+
+    def set_time(self, time: float):
+        """
+        Show the frame at a given time in seconds, the nearest one to it rather than a blend
+        of the two either side, and the last frame for any time past the end.
+        """
+        return self.set_frame(self.source.index_at_time(time))
+
+    def animate_set_time(self, time: float, run_time=None, rate_func=linear, **kwargs):
+        """Play up to a given time, by default taking as long as the clip it covers."""
+        if run_time is None:
+            run_time = abs(time - self.get_time())
+        return self.animate(run_time=run_time, rate_func=rate_func).set_time(time)
+
+    def set_frame(self, index: int):
+        """Show a frame by its number rather than its time."""
+        index = int(np.clip(index, 0, self.source.num_frames - 1))
+        self.uniforms["frame"] = index
+        self.frames.load(index)
+        return self
+
+    def get_time(self) -> float:
+        """The time at which the frame now showing appears."""
+        return float(self.frame_index / self.source.frame_rate)
+
+    def get_duration(self) -> float:
+        return self.source.duration
+
+    def get_num_frames(self) -> int:
+        return self.source.num_frames
+
+    def get_frame_rate(self) -> float:
+        return float(self.source.frame_rate)
+
+    # Reading it
+
+    def get_pixels(self) -> np.ndarray:
+        """The straight rgba pixels of the frame now showing."""
+        return self.frames.get_pixels(self.frame_index)
+
+    def interpolate(self, mobject1, mobject2, alpha, *args, **kwargs) -> Self:
+        """
+        Blend as any mobject does, then make sure the pixels match the frame the blended
+        uniform now names, which for a preloaded clip is already so and otherwise is an upload.
+        """
+        super().interpolate(mobject1, mobject2, alpha, *args, **kwargs)
+        self.frames.load(self.frame_index)
+        return self
+
+    @property
+    def image(self) -> Image.Image:
+        """
+        The frame now showing, as an image, which is what ImageMobject reads pixels from.
+        Made when asked for rather than held, no drawing having any use for it.
+        """
+        return Image.fromarray(self.get_pixels(), mode="RGBA")
+
+
+class Sprite(VideoMobject):
+    """
+    A VideoMobject read nearest pixel rather than blended, keeping pixel art crisp however
+    far it is scaled up.
+
+    Scaled well down it will shimmer instead, there being no mipmaps to fall back on, so
+    linear is kinder there.
+    """
+    texture_filter: str = "nearest"

--- a/manimlib/mobject/types/video_mobject.py
+++ b/manimlib/mobject/types/video_mobject.py
@@ -132,13 +132,6 @@ class VideoSource(object):
         """One decoded frame as straight rgba bytes."""
         return frame.to_ndarray(format="rgba")
 
-    def index_at_time(self, time: float) -> int:
-        """
-        Which frame shows at a given time: the nearest one, clamped at both ends.
-        """
-        index = round(time * float(self.frame_rate))
-        return int(np.clip(index, 0, self.num_frames - 1))
-
     def seek(self, index: int) -> None:
         """Put the read at the last keyframe at or before this frame."""
         time_base = self.stream.time_base or Fraction(1, int(self.frame_rate))
@@ -345,7 +338,23 @@ class VideoMobject(ImageMobject):
         Show the frame at a given time in seconds, the nearest one to it rather than a blend
         of the two either side, and the last frame for any time past the end.
         """
-        return self.set_frame(self.source.index_at_time(time))
+        return self.set_frame(time * float(self.source.frame_rate))
+
+    def increment_time(self, dt: float):
+        """
+        Move on by a length of time, which where it is shorter than a frame shows the same
+        frame again: it is where the video has got to that is kept, not where it last
+        landed, so steps too small to reach the next frame still add up.
+        """
+        return self.set_time(self.get_time() + dt)
+
+    def play_from(self, time: float = 0.0):
+        """
+        Play on from a given time, a frame of video to a frame of animation, for as long as
+        the mobject is in the scene.
+        """
+        self.set_time(time)
+        return self.add_updater(lambda mob, dt: mob.increment_time(dt))
 
     def animate_set_time(self, time: float, run_time=None, rate_func=linear, **kwargs):
         """Play up to a given time, by default taking as long as the clip it covers."""
@@ -353,16 +362,21 @@ class VideoMobject(ImageMobject):
             run_time = abs(time - self.get_time())
         return self.animate(run_time=run_time, rate_func=rate_func).set_time(time)
 
-    def set_frame(self, index: int):
-        """Show a frame by its number rather than its time."""
-        index = int(np.clip(index, 0, self.source.num_frames - 1))
-        self.uniforms["frame"] = index
-        self.frames.load(index)
+    def set_frame(self, index: float):
+        """
+        Show a frame by its number rather than its time, the nearest one where it falls
+        between two, see frame_index.
+        """
+        self.uniforms["frame"] = np.clip(index, 0, self.source.num_frames - 1)
+        self.frames.load(self.frame_index)
         return self
 
     def get_time(self) -> float:
-        """The time at which the frame now showing appears."""
-        return float(self.frame_index / self.source.frame_rate)
+        """
+        Where the video has got to, in seconds, which is not quite the time of the frame
+        showing: a time between two frames is kept as it was given, see increment_time.
+        """
+        return float(self.uniforms["frame"] / self.source.frame_rate)
 
     def get_duration(self) -> float:
         return self.source.duration

--- a/manimlib/mobject/types/video_mobject.py
+++ b/manimlib/mobject/types/video_mobject.py
@@ -260,12 +260,8 @@ class VideoMobject(ImageMobject):
     A video showing whichever frame set_time was last given, and otherwise an ImageMobject
     in every respect.
 
-    Two of these drawn from one file may sit on different frames of it, sharing the decoding
-    and, where the clip is small enough to be preloaded, the frames on the gpu too, see
-    VideoFrames.
-
-    A time past the end holds on the last frame, or comes round to the beginning again where
-    it loops.
+    A time past the end either holds on the last frame, or comes round to the beginning
+    if loop is set to True
     """
 
     shader_file: str = "video.wgsl"
@@ -323,15 +319,7 @@ class VideoMobject(ImageMobject):
 
     @property
     def frame_index(self) -> int:
-        """
-        Which frame of the video is showing, which the uniform alone decides. Holding it
-        there and nowhere else is what lets it be interpolated, so that animating between
-        two frames scrubs through the ones between.
-
-        A blend landing between two frames shows the nearer, and a number past the end of
-        the clip comes round again where it loops and holds at the last frame where it does
-        not, both as the shader reads it too, see video.wgsl.
-        """
+        """ Which frame of the video is showing, which the uniform alone decides. """
         index = round(float(self.uniforms["frame"]))
         if self.loop:
             return index % self.source.num_frames
@@ -343,26 +331,15 @@ class VideoMobject(ImageMobject):
     # Which frame is showing
 
     def set_time(self, time: float):
-        """
-        Show the frame at a given time in seconds, the nearest one to it rather than a blend
-        of the two either side. A time past the end shows the last frame, or where the clip
-        loops the one that far into it again.
-        """
+        """ Show the frame at a given time in seconds. """
         return self.set_frame(time * float(self.source.frame_rate))
 
     def increment_time(self, dt: float):
-        """
-        Move on by a length of time, which where it is shorter than a frame shows the same
-        frame again: it is where the video has got to that is kept, not where it last
-        landed, so steps too small to reach the next frame still add up.
-        """
+        """ Move on by a length of time. """
         return self.set_time(self.get_time() + dt)
 
     def play_from(self, time: float = 0.0):
-        """
-        Play on from a given time, a frame of video to a frame of animation, for as long as
-        the mobject is in the scene.
-        """
+        """ Play on from a given time. """
         self.set_time(time)
         return self.add_updater(lambda mob, dt: mob.increment_time(dt))
 
@@ -373,14 +350,7 @@ class VideoMobject(ImageMobject):
         return self.animate(run_time=run_time, rate_func=rate_func).set_time(time)
 
     def set_frame(self, index: float):
-        """
-        Show a frame by its number rather than its time, the nearest one where it falls
-        between two, see frame_index.
-
-        A clip which loops keeps the number it was given, however far past the end it runs,
-        and comes round to a frame of the clip only in the reading: so playing on through a
-        loop, or animating across one, goes forwards rather than back to where it began.
-        """
+        """ Show a frame by its number rather than its time. """
         if not self.loop:
             index = np.clip(index, 0, self.source.num_frames - 1)
         self.uniforms["frame"] = index
@@ -421,10 +391,7 @@ class VideoMobject(ImageMobject):
 
     @property
     def image(self) -> Image.Image:
-        """
-        The frame now showing, as an image, which is what ImageMobject reads pixels from.
-        Made when asked for rather than held, no drawing having any use for it.
-        """
+        """ The frame now showing, as an image, which is what ImageMobject reads pixels from. """
         return Image.fromarray(self.get_pixels(), mode="RGBA")
 
 
@@ -432,8 +399,5 @@ class Sprite(VideoMobject):
     """
     A VideoMobject read nearest pixel rather than blended, keeping pixel art crisp however
     far it is scaled up.
-
-    Scaled well down it will shimmer instead, there being no mipmaps to fall back on, so
-    linear is kinder there.
     """
     texture_filter: str = "nearest"

--- a/manimlib/mobject/types/video_mobject.py
+++ b/manimlib/mobject/types/video_mobject.py
@@ -263,6 +263,9 @@ class VideoMobject(ImageMobject):
     Two of these drawn from one file may sit on different frames of it, sharing the decoding
     and, where the clip is small enough to be preloaded, the frames on the gpu too, see
     VideoFrames.
+
+    A time past the end holds on the last frame, or comes round to the beginning again where
+    it loops.
     """
 
     shader_file: str = "video.wgsl"
@@ -273,9 +276,11 @@ class VideoMobject(ImageMobject):
         filename: str,
         height: float = 4.0,
         time: float = 0.0,
+        loop: bool = False,
         preload: bool | None = None,
         **kwargs
     ):
+        self.loop = loop
         # Read by init_texture, which the constructor below reaches
         self._preload = preload
         super().__init__(filename, height=height, **kwargs)
@@ -323,10 +328,14 @@ class VideoMobject(ImageMobject):
         there and nowhere else is what lets it be interpolated, so that animating between
         two frames scrubs through the ones between.
 
-        A blend landing between two frames shows the nearer, as the shader reads it, see
-        video.wgsl.
+        A blend landing between two frames shows the nearer, and a number past the end of
+        the clip comes round again where it loops and holds at the last frame where it does
+        not, both as the shader reads it too, see video.wgsl.
         """
-        return int(round(float(self.uniforms["frame"])))
+        index = round(float(self.uniforms["frame"]))
+        if self.loop:
+            return index % self.source.num_frames
+        return int(np.clip(index, 0, self.source.num_frames - 1))
 
     def get_source_size(self) -> Tuple[int, int]:
         return (self.source.width, self.source.height)
@@ -336,7 +345,8 @@ class VideoMobject(ImageMobject):
     def set_time(self, time: float):
         """
         Show the frame at a given time in seconds, the nearest one to it rather than a blend
-        of the two either side, and the last frame for any time past the end.
+        of the two either side. A time past the end shows the last frame, or where the clip
+        loops the one that far into it again.
         """
         return self.set_frame(time * float(self.source.frame_rate))
 
@@ -366,15 +376,22 @@ class VideoMobject(ImageMobject):
         """
         Show a frame by its number rather than its time, the nearest one where it falls
         between two, see frame_index.
+
+        A clip which loops keeps the number it was given, however far past the end it runs,
+        and comes round to a frame of the clip only in the reading: so playing on through a
+        loop, or animating across one, goes forwards rather than back to where it began.
         """
-        self.uniforms["frame"] = np.clip(index, 0, self.source.num_frames - 1)
+        if not self.loop:
+            index = np.clip(index, 0, self.source.num_frames - 1)
+        self.uniforms["frame"] = index
         self.frames.load(self.frame_index)
         return self
 
     def get_time(self) -> float:
         """
         Where the video has got to, in seconds, which is not quite the time of the frame
-        showing: a time between two frames is kept as it was given, see increment_time.
+        showing: a time between two frames is kept as it was given, see increment_time, and
+        a clip which loops goes on counting past its own end rather than beginning again.
         """
         return float(self.uniforms["frame"] / self.source.frame_rate)
 

--- a/manimlib/renderer/drawing.py
+++ b/manimlib/renderer/drawing.py
@@ -92,6 +92,8 @@ class Drawing(object):
         # This mobject's images, in binding order, made on first draw, see realize_textures
         self.textures: dict[str, Texture] = dict()
         self.texture_views: list[Any] = []
+        # The sampler this mobject asked for, see Mobject.set_texture_filter
+        self.sampler: Any = None
         # Whether the writing found anything a bundled draw would have baked in to have moved,
         # which for a drawing nothing has drawn yet is everything, see Renderer.draw
         self.invalidated = True
@@ -231,7 +233,7 @@ class Drawing(object):
         frame's pass opens so that a replayed bundle draws what went up.
 
         Rewriting a texture's contents leaves the bind group valid, its views being the same
-        objects. Only a texture made afresh needs a new group.
+        objects. Only a texture or sampler made afresh needs a new group.
         """
         names = self.material.texture_names
         if not names:
@@ -247,8 +249,10 @@ class Drawing(object):
                 self.textures[name] = texture
                 remade = True
             texture.refresh()
-        if remade:
+        sampler = gpu.sampler(self.mobject.texture_filter)
+        if remade or sampler is not self.sampler:
             self.texture_views = [self.textures[name].view for name in names]
+            self.sampler = sampler
             self.own_bind_group = None
             # A bundle baked in the old group, so it has to be built again
             self.invalidated = True
@@ -264,7 +268,9 @@ class Drawing(object):
             return shared.bind_group
         if self.shared_bind_group is not shared.bind_group or self.own_bind_group is None:
             self.shared_bind_group = shared.bind_group
-            self.own_bind_group = self.material.make_resource_bind_group(self.texture_views)
+            self.own_bind_group = self.material.make_resource_bind_group(
+                self.texture_views, self.sampler,
+            )
         return self.own_bind_group
 
     def draw_passes(self, render_pass: RenderPass) -> None:

--- a/manimlib/renderer/drawing.py
+++ b/manimlib/renderer/drawing.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from manimlib.mobject.mobject import Mobject
     from manimlib.renderer.gpu import RenderPass
     from manimlib.renderer.material import Material, ModuleSpec
+    from manimlib.renderer.texture import Texture
 
 
 class Drawing(object):
@@ -50,7 +51,7 @@ class Drawing(object):
             mobject.shader_file,
             mobject.data.dtype,
             mobject.uniforms.dtype,
-            tuple(mobject.texture_paths.items()),
+            tuple(mobject.textures),
             tuple(mobject.shader_code_replacements.items()),
             mobject.verts_per_record,
         )
@@ -88,6 +89,9 @@ class Drawing(object):
         # Made only for a mobject with images of its own, the rest reading the shared one's
         self.own_bind_group: Any = None
         self.shared_bind_group: Any = None
+        # This mobject's images, in binding order, made on first draw, see realize_textures
+        self.textures: dict[str, Texture] = dict()
+        self.texture_views: list[Any] = []
         # Whether the writing found anything a bundled draw would have baked in to have moved,
         # which for a drawing nothing has drawn yet is everything, see Renderer.draw
         self.invalidated = True
@@ -221,18 +225,46 @@ class Drawing(object):
         )
         self.draw_passes(render_pass)
 
+    def realize_textures(self) -> None:
+        """
+        Make this mobject's images on the gpu and upload whatever has changed, before the
+        frame's pass opens so that a replayed bundle draws what went up.
+
+        Rewriting a texture's contents leaves the bind group valid, its views being the same
+        objects. Only a texture made afresh needs a new group.
+        """
+        names = self.material.texture_names
+        if not names:
+            return
+        gpu = self.material.gpu
+        sources = self.mobject.textures
+        remade = False
+        for name in names:
+            source = sources[name]
+            texture = self.textures.get(name)
+            if texture is None or not texture.accepts(source):
+                texture = source.realize(gpu)
+                self.textures[name] = texture
+                remade = True
+            texture.refresh()
+        if remade:
+            self.texture_views = [self.textures[name].view for name in names]
+            self.own_bind_group = None
+            # A bundle baked in the old group, so it has to be built again
+            self.invalidated = True
+
     def resource_bind_group(self) -> Any:
         """
-        What this mobject's records and images are read through. Without images of its own it
-        reads the shared group, which serves every mobject of its size; with them it needs one
-        of its own, made again whenever the shared one is.
+        What this mobject's records and images are read through. Without images it reads the
+        shared group, which serves every mobject of its size; with them it needs one of its
+        own, made again whenever the shared one is.
         """
         shared = self.material.data_buffer
-        if not self.material.textures:
+        if not self.texture_views:
             return shared.bind_group
-        if self.shared_bind_group is not shared.bind_group:
+        if self.shared_bind_group is not shared.bind_group or self.own_bind_group is None:
             self.shared_bind_group = shared.bind_group
-            self.own_bind_group = self.material.make_resource_bind_group()
+            self.own_bind_group = self.material.make_resource_bind_group(self.texture_views)
         return self.own_bind_group
 
     def draw_passes(self, render_pass: RenderPass) -> None:

--- a/manimlib/renderer/drawing.py
+++ b/manimlib/renderer/drawing.py
@@ -51,7 +51,10 @@ class Drawing(object):
             mobject.shader_file,
             mobject.data.dtype,
             mobject.uniforms.dtype,
-            tuple(mobject.textures),
+            # What the shader declares and the layout binds. Two mobjects agreeing about
+            # that share a material whatever their images are of, those belonging to the
+            # drawing rather than the material, see realize_textures
+            tuple((name, source.kind()) for name, source in mobject.textures.items()),
             tuple(mobject.shader_code_replacements.items()),
             mobject.verts_per_record,
         )

--- a/manimlib/renderer/gpu.py
+++ b/manimlib/renderer/gpu.py
@@ -13,9 +13,11 @@ from manimlib.renderer.shader_source import DATA_BINDING
 from manimlib.renderer.shader_source import FIRST_TEXTURE_BINDING
 from manimlib.renderer.shader_source import FRAME_GROUP
 from manimlib.renderer.shader_source import SAMPLER_BINDING
+from manimlib.renderer.shader_source import TEXTURE_KINDS
 from manimlib.renderer.shared_buffer import SharedBuffer
 from manimlib.renderer.texture import FILTER_MODES
 from manimlib.renderer.texture import check_texture_filter
+from manimlib.renderer.texture import stack_view
 from manimlib.renderer.uniform_block import Uniforms
 from manimlib.renderer.uniform_block import uniform_block_dtype
 
@@ -148,8 +150,10 @@ class Gpu(object):
         # references to, see Renderer.draw
         self.rebinds = 0
         self.modules: dict[str, Any] = dict()
-        self.textures: dict[str, Any] = dict()
-        self.layouts: dict[int, tuple[Any, Any]] = dict()
+        self.textures: dict[Any, Any] = dict()
+        # Views onto stacks of images, one per key, see texture_stack
+        self.stacks: dict[Any, Any] = dict()
+        self.layouts: dict[tuple[str, ...], tuple[Any, Any]] = dict()
         self.pipelines: dict[tuple, Any] = dict()
         self.shared_buffers: dict[tuple, SharedBuffer] = dict()
         self.samplers: dict[str, Any] = dict()
@@ -182,6 +186,38 @@ class Gpu(object):
             self.textures[path] = texture
         return self.textures[path]
 
+    def layer_texture(self, layers: np.ndarray) -> Any:
+        """A texture holding a stack of images the shape of these, with nothing in it yet"""
+        count, height, width = layers.shape[:3]
+        return self.device.create_texture(
+            size=(width, height, count),
+            dimension=wgpu.TextureDimension.d2,
+            format=wgpu.TextureFormat.rgba8unorm,
+            usage=wgpu.TextureUsage.TEXTURE_BINDING | wgpu.TextureUsage.COPY_DST,
+        )
+
+    def write_layers(self, texture: Any, layers: np.ndarray) -> None:
+        """Every layer of a stack into the texture it was made for"""
+        count, height, width = layers.shape[:3]
+        self.queue.write_texture(
+            {"texture": texture, "mip_level": 0, "origin": (0, 0, 0)},
+            np.ascontiguousarray(layers),
+            {"offset": 0, "bytes_per_row": 4 * width, "rows_per_image": height},
+            (width, height, count),
+        )
+
+    def texture_stack(self, key: Any, layers: np.ndarray) -> Any:
+        """
+        A 2d-array view of the layers uploaded under this key. Built once, so mobjects
+        reading the same frames share one copy, see texture.LayeredPixels.
+        """
+        if key not in self.stacks:
+            texture = self.layer_texture(layers)
+            self.write_layers(texture, layers)
+            # The view is cached too, so every reader shares one
+            self.stacks[key] = stack_view(texture)
+        return self.stacks[key]
+
     def sampler(self, texture_filter: str = "linear") -> Any:
         """
         How an image is read between its pixels: "linear" blends, "nearest" takes the nearest
@@ -194,16 +230,16 @@ class Gpu(object):
             )
         return self.samplers[texture_filter]
 
-    def bind_layouts(self, texture_count: int) -> tuple[Any, Any]:
+    def bind_layouts(self, texture_kinds: tuple[str, ...] = ()) -> tuple[Any, Any]:
         """
         What a shader may bind: the frame's values, the mobject's values, and its records along
-        with a texture for each image it names.
+        with a texture for each image it names, each held as whatever its kind says.
 
-        Made once for each number of textures rather than once per mobject: a pipeline is built
+        Made once for each run of kinds rather than once per mobject: a pipeline is built
         against these, so per mobject layouts would mean per mobject pipelines.
         """
-        if texture_count in self.layouts:
-            return self.layouts[texture_count]
+        if texture_kinds in self.layouts:
+            return self.layouts[texture_kinds]
 
         entries = [{
             "binding": DATA_BINDING,
@@ -214,7 +250,7 @@ class Gpu(object):
                 "has_dynamic_offset": True,
             },
         }]
-        if texture_count:
+        if texture_kinds:
             entries.append({
                 "binding": SAMPLER_BINDING,
                 "visibility": wgpu.ShaderStage.FRAGMENT,
@@ -223,15 +259,18 @@ class Gpu(object):
             entries += [{
                 "binding": FIRST_TEXTURE_BINDING + index,
                 "visibility": wgpu.ShaderStage.FRAGMENT,
-                "texture": {"sample_type": wgpu.TextureSampleType.float},
-            } for index in range(texture_count)]
+                "texture": {
+                    "sample_type": wgpu.TextureSampleType.float,
+                    "view_dimension": TEXTURE_KINDS[kind][1],
+                },
+            } for index, kind in enumerate(texture_kinds)]
 
         resource_layout = self.device.create_bind_group_layout(entries=entries)
         pipeline_layout = self.device.create_pipeline_layout(bind_group_layouts=[
             self.frame_layout, self.mobject_layout, resource_layout,
         ])
-        self.layouts[texture_count] = (resource_layout, pipeline_layout)
-        return self.layouts[texture_count]
+        self.layouts[texture_kinds] = (resource_layout, pipeline_layout)
+        return self.layouts[texture_kinds]
 
     def pipeline(self, layout: Any, module: Any, state: PipelineState) -> Any:
         """
@@ -257,7 +296,7 @@ class Gpu(object):
     def data_buffer(self, record_size: int) -> SharedBuffer:
         """Where the records of a mobject whose records are this size are gathered"""
         # A mobject with no images of its own reads through the layout with none
-        layout, _ = self.bind_layouts(0)
+        layout, _ = self.bind_layouts()
         return self.shared_buffer(
             ("records", record_size), layout, wgpu.BufferUsage.STORAGE,
             "min-storage-buffer-offset-alignment", RECORDS * record_size,

--- a/manimlib/renderer/gpu.py
+++ b/manimlib/renderer/gpu.py
@@ -14,6 +14,8 @@ from manimlib.renderer.shader_source import FIRST_TEXTURE_BINDING
 from manimlib.renderer.shader_source import FRAME_GROUP
 from manimlib.renderer.shader_source import SAMPLER_BINDING
 from manimlib.renderer.shared_buffer import SharedBuffer
+from manimlib.renderer.texture import FILTER_MODES
+from manimlib.renderer.texture import check_texture_filter
 from manimlib.renderer.uniform_block import Uniforms
 from manimlib.renderer.uniform_block import uniform_block_dtype
 
@@ -150,7 +152,7 @@ class Gpu(object):
         self.layouts: dict[int, tuple[Any, Any]] = dict()
         self.pipelines: dict[tuple, Any] = dict()
         self.shared_buffers: dict[tuple, SharedBuffer] = dict()
-        self.image_sampler = None
+        self.samplers: dict[str, Any] = dict()
 
     # What a shader is compiled to, and what it may read
 
@@ -180,13 +182,17 @@ class Gpu(object):
             self.textures[path] = texture
         return self.textures[path]
 
-    def sampler(self) -> Any:
-        """The one sampler every image is read through"""
-        if self.image_sampler is None:
-            self.image_sampler = self.device.create_sampler(
-                mag_filter=wgpu.FilterMode.linear, min_filter=wgpu.FilterMode.linear,
+    def sampler(self, texture_filter: str = "linear") -> Any:
+        """
+        How an image is read between its pixels: "linear" blends, "nearest" takes the nearest
+        pixel, keeping pixel art crisp when scaled up. One sampler per mode.
+        """
+        if texture_filter not in self.samplers:
+            mode = FILTER_MODES[check_texture_filter(texture_filter)]
+            self.samplers[texture_filter] = self.device.create_sampler(
+                mag_filter=mode, min_filter=mode,
             )
-        return self.image_sampler
+        return self.samplers[texture_filter]
 
     def bind_layouts(self, texture_count: int) -> tuple[Any, Any]:
         """

--- a/manimlib/renderer/material.py
+++ b/manimlib/renderer/material.py
@@ -35,15 +35,16 @@ class Material(object):
         self.gpu = gpu
         self.verts_per_record = mobject.verts_per_record
         self.record_size = mobject.data.dtype.itemsize
-        self.texture_paths = dict(mobject.texture_paths)
+        # In binding order, and so the order the shader declares them. The images themselves
+        # belong to each drawing, see Drawing.realize_textures
+        self.texture_names = tuple(mobject.textures)
 
-        self.resource_layout, self.pipeline_layout = gpu.bind_layouts(len(self.texture_paths))
+        self.resource_layout, self.pipeline_layout = gpu.bind_layouts(len(self.texture_names))
         # Where these mobjects' values go each frame, see SharedBuffer
         self.uniform_buffer = gpu.uniform_buffer(mobject.uniforms.array.nbytes)
         self.data_buffer = gpu.data_buffer(self.record_size)
 
-        self.textures = [gpu.texture(path) for path in self.texture_paths.values()]
-        self.sampler = gpu.sampler() if self.texture_paths else None
+        self.sampler = gpu.sampler() if self.texture_names else None
         self.modules = {
             name: gpu.module(self.get_code(mobject, filename, replacements))
             for name, filename, replacements in specs
@@ -55,7 +56,7 @@ class Material(object):
         it holds for the whole of itself, which is all the source depends on.
         """
         code = get_shader_code(
-            filename, mobject.data.dtype, mobject.uniforms.dtype, tuple(self.texture_paths),
+            filename, mobject.data.dtype, mobject.uniforms.dtype, self.texture_names,
         )
         for old, new in replacements.items():
             code = re.sub(old, new, code)
@@ -65,11 +66,13 @@ class Material(object):
         """The pipeline for one pass, naming the module by what the drawing asked for it as"""
         return self.gpu.pipeline(self.pipeline_layout, self.modules[module], state)
 
-    def make_resource_bind_group(self) -> Any:
+    def make_resource_bind_group(self, views: Sequence[Any]) -> Any:
         """
-        A group through which one mobject reads its records and its own images. Only a mobject
-        with images needs one; the rest read the shared group of the buffer they sit in, which
-        serves every mobject of their size, see Drawing.resource_bind_group.
+        A group through which one mobject reads its records and the images handed in, which
+        are that mobject's own however many of them stand for a file every mobject naming it
+        reads alike. Only a mobject with images needs one; the rest read the shared group of
+        the buffer they sit in, which serves every mobject of their size, see
+        Drawing.resource_bind_group.
         """
         shared = self.data_buffer
         entries = [{"binding": DATA_BINDING, "resource": {
@@ -77,7 +80,7 @@ class Material(object):
         }}]
         entries.append({"binding": SAMPLER_BINDING, "resource": self.sampler})
         entries += [
-            {"binding": FIRST_TEXTURE_BINDING + index, "resource": texture.create_view()}
-            for index, texture in enumerate(self.textures)
+            {"binding": FIRST_TEXTURE_BINDING + index, "resource": view}
+            for index, view in enumerate(views)
         ]
         return self.gpu.device.create_bind_group(layout=self.resource_layout, entries=entries)

--- a/manimlib/renderer/material.py
+++ b/manimlib/renderer/material.py
@@ -38,8 +38,9 @@ class Material(object):
         # In binding order, and so the order the shader declares them. The images themselves
         # belong to each drawing, see Drawing.realize_textures
         self.texture_names = tuple(mobject.textures)
+        self.texture_kinds = tuple(src.kind() for src in mobject.textures.values())
 
-        self.resource_layout, self.pipeline_layout = gpu.bind_layouts(len(self.texture_names))
+        self.resource_layout, self.pipeline_layout = gpu.bind_layouts(self.texture_kinds)
         # Where these mobjects' values go each frame, see SharedBuffer
         self.uniform_buffer = gpu.uniform_buffer(mobject.uniforms.array.nbytes)
         self.data_buffer = gpu.data_buffer(self.record_size)
@@ -55,7 +56,8 @@ class Material(object):
         it holds for the whole of itself, which is all the source depends on.
         """
         code = get_shader_code(
-            filename, mobject.data.dtype, mobject.uniforms.dtype, self.texture_names,
+            filename, mobject.data.dtype, mobject.uniforms.dtype,
+            self.texture_names, self.texture_kinds,
         )
         for old, new in replacements.items():
             code = re.sub(old, new, code)

--- a/manimlib/renderer/material.py
+++ b/manimlib/renderer/material.py
@@ -44,7 +44,6 @@ class Material(object):
         self.uniform_buffer = gpu.uniform_buffer(mobject.uniforms.array.nbytes)
         self.data_buffer = gpu.data_buffer(self.record_size)
 
-        self.sampler = gpu.sampler() if self.texture_names else None
         self.modules = {
             name: gpu.module(self.get_code(mobject, filename, replacements))
             for name, filename, replacements in specs
@@ -66,19 +65,19 @@ class Material(object):
         """The pipeline for one pass, naming the module by what the drawing asked for it as"""
         return self.gpu.pipeline(self.pipeline_layout, self.modules[module], state)
 
-    def make_resource_bind_group(self, views: Sequence[Any]) -> Any:
+    def make_resource_bind_group(self, views: Sequence[Any], sampler: Any) -> Any:
         """
         A group through which one mobject reads its records and the images handed in, which
         are that mobject's own however many of them stand for a file every mobject naming it
-        reads alike. Only a mobject with images needs one; the rest read the shared group of
-        the buffer they sit in, which serves every mobject of their size, see
-        Drawing.resource_bind_group.
+        reads alike, read through the sampler that mobject asked for. Only a mobject with
+        images needs one; the rest read the shared group of the buffer they sit in, which
+        serves every mobject of their size, see Drawing.resource_bind_group.
         """
         shared = self.data_buffer
         entries = [{"binding": DATA_BINDING, "resource": {
             "buffer": shared.buffer, "offset": 0, "size": shared.window,
         }}]
-        entries.append({"binding": SAMPLER_BINDING, "resource": self.sampler})
+        entries.append({"binding": SAMPLER_BINDING, "resource": sampler})
         entries += [
             {"binding": FIRST_TEXTURE_BINDING + index, "resource": view}
             for index, view in enumerate(views)

--- a/manimlib/renderer/renderer.py
+++ b/manimlib/renderer/renderer.py
@@ -103,6 +103,7 @@ class Renderer(object):
         for drawing in drawings:
             if drawing.write_uniforms():
                 regroup = True
+            drawing.realize_textures()
             if drawing.invalidated:
                 self.bundling.invalidate()
         # A frame where nothing which decides the runs moved keeps last frame's

--- a/manimlib/renderer/shader_source.py
+++ b/manimlib/renderer/shader_source.py
@@ -35,6 +35,7 @@ def get_shader_code(
     data_dtype: np.dtype,
     uniform_dtype: np.dtype,
     texture_names: tuple[str, ...] = (),
+    texture_kinds: tuple[str, ...] = (),
 ) -> str | None:
     """
     Reads a shader from file, filling in what its source depends on about the mobject it will
@@ -51,7 +52,7 @@ def get_shader_code(
         code
         .replace("// DATA_LAYOUT", data_layout_code(data_dtype))
         .replace("// MOBJECT_UNIFORMS", uniform_block_code(uniform_dtype))
-        .replace("// TEXTURES", texture_binding_code(texture_names))
+        .replace("// TEXTURES", texture_binding_code(texture_names, texture_kinds))
     )
 
 
@@ -70,19 +71,31 @@ def data_layout_code(dtype: np.dtype) -> str:
     ])
 
 
-def texture_binding_code(texture_names: tuple[str, ...]) -> str:
+# What an image is declared as in a shader, and how its view is bound, see
+# renderer.texture.TextureSource.kind
+TEXTURE_KINDS = {
+    "2d": ("texture_2d<f32>", "2d"),
+    "2d-array": ("texture_2d_array<f32>", "2d-array"),
+}
+
+
+def texture_binding_code(
+    texture_names: tuple[str, ...], texture_kinds: tuple[str, ...] = (),
+) -> str:
     """
     How a shader declares the images its kind of mobject named, and the sampler they share,
-    each from the binding it was actually put in.
+    each from the binding it was actually put in and as whatever its kind says: one image, or
+    a stack the shader picks from.
     """
     if not texture_names:
         return ""
+    kinds = texture_kinds or ("2d",) * len(texture_names)
     lines = [f"@group({RESOURCE_GROUP}) @binding({SAMPLER_BINDING}) "
              f"var image_sampler: sampler;"]
     lines += [
         f"@group({RESOURCE_GROUP}) @binding({FIRST_TEXTURE_BINDING + index}) "
-        f"var {name}: texture_2d<f32>;"
-        for index, name in enumerate(texture_names)
+        f"var {name}: {TEXTURE_KINDS[kind][0]};"
+        for index, (name, kind) in enumerate(zip(texture_names, kinds))
     ]
     return "\n".join(lines)
 

--- a/manimlib/renderer/texture.py
+++ b/manimlib/renderer/texture.py
@@ -1,10 +1,29 @@
 from __future__ import annotations
 
+import wgpu
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
     from manimlib.renderer.gpu import Gpu
+
+
+# How an image is read between its pixels, and what wgpu calls each, see Gpu.sampler
+FILTER_MODES = {
+    "linear": wgpu.FilterMode.linear,
+    "nearest": wgpu.FilterMode.nearest,
+}
+
+
+def check_texture_filter(texture_filter: str) -> str:
+    """The filter back again, where it is one there is, and otherwise an error saying so."""
+    if texture_filter not in FILTER_MODES:
+        raise ValueError(
+            f"No such texture filter {texture_filter!r}, "
+            f"expected one of {', '.join(map(repr, FILTER_MODES))}"
+        )
+    return texture_filter
 
 
 class TextureSource(object):

--- a/manimlib/renderer/texture.py
+++ b/manimlib/renderer/texture.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+    from manimlib.renderer.gpu import Gpu
+
+
+class TextureSource(object):
+    """
+    Inert description of where one of a mobject's images comes from. Realized on the gpu at
+    first draw, see Drawing.realize_textures.
+    """
+
+    def sharing_key(self) -> Any:
+        """Key the realized texture is shared under, or None to never share it."""
+        raise NotImplementedError
+
+    def realize(self, gpu: Gpu) -> Texture:
+        """Build the gpu texture for this source."""
+        raise NotImplementedError
+
+    def copy(self) -> TextureSource:
+        """
+        The source a copy of the holding mobject draws from. Immutable sources are reused,
+        writable ones duplicated.
+        """
+        return self
+
+
+class ImageFile(TextureSource):
+    """An image file, shared by every mobject naming that path."""
+
+    def __init__(self, path: str):
+        self.path = str(path)
+
+    def sharing_key(self) -> str:
+        return self.path
+
+    def realize(self, gpu: Gpu) -> Texture:
+        return Texture(self, gpu.texture(self.path).create_view())
+
+
+class Texture(object):
+    """A realized texture, held by the drawing that reads it."""
+
+    def __init__(self, source: TextureSource, view: Any):
+        self.source = source
+        self.view = view
+
+    def accepts(self, source: TextureSource) -> bool:
+        """Whether this still matches the mobject's current source."""
+        return source is self.source
+
+    def refresh(self) -> None:
+        """Upload whatever has changed, before the frame's pass. Static textures: nothing."""
+        pass

--- a/manimlib/renderer/texture.py
+++ b/manimlib/renderer/texture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import wgpu
 
 from typing import TYPE_CHECKING
@@ -36,6 +37,10 @@ class TextureSource(object):
         """Key the realized texture is shared under, or None to never share it."""
         raise NotImplementedError
 
+    def kind(self) -> str:
+        """How the image is declared and bound, see shader_source.TEXTURE_KINDS."""
+        return "2d"
+
     def realize(self, gpu: Gpu) -> Texture:
         """Build the gpu texture for this source."""
         raise NotImplementedError
@@ -61,6 +66,45 @@ class ImageFile(TextureSource):
         return Texture(self, gpu.texture(self.path).create_view())
 
 
+class LayeredPixels(TextureSource):
+    """
+    Pixels as a stack of layers, one picked per draw by the shader, which is how a video
+    holds its frames.
+
+    With a key the stack is uploaded once and shared by every mobject naming it; without
+    one it belongs to the holding mobject, which rewrites it.
+    """
+
+    def __init__(self, layers: np.ndarray, key: Any = None):
+        self.layers = layers
+        self.key = key
+        self.version = 0
+
+    def set_layers(self, layers: np.ndarray) -> None:
+        self.layers = layers
+        self.version += 1
+
+    def sharing_key(self) -> Any:
+        return self.key
+
+    def kind(self) -> str:
+        return "2d-array"
+
+    def copy(self) -> LayeredPixels:
+        # Shared stacks are read alike and reused; unshared ones are rewritten in place,
+        # so a copy needs its own
+        if self.key is not None:
+            return self
+        return LayeredPixels(self.layers)
+
+    def realize(self, gpu: Gpu) -> Texture:
+        # A keyed stack is uploaded once and every reader wraps that one view; an unkeyed
+        # one is the holding mobject's alone, and is rewritten as its layers change
+        if self.key is not None:
+            return Texture(self, gpu.texture_stack(self.key, self.layers))
+        return LayeredTexture(self, gpu)
+
+
 class Texture(object):
     """A realized texture, held by the drawing that reads it."""
 
@@ -75,3 +119,32 @@ class Texture(object):
     def refresh(self) -> None:
         """Upload whatever has changed, before the frame's pass. Static textures: nothing."""
         pass
+
+
+def stack_view(texture: Any) -> Any:
+    """
+    A 2d-array view, which must be asked for explicitly: the default view is 2d whatever the
+    texture holds, and a shader reading layers rejects it.
+    """
+    return texture.create_view(dimension=wgpu.TextureViewDimension.d2_array)
+
+
+class LayeredTexture(Texture):
+    """A stack the holding mobject rewrites, see LayeredPixels."""
+
+    def __init__(self, source: LayeredPixels, gpu: Gpu):
+        self.gpu = gpu
+        self.shape = source.layers.shape[:3]
+        self.texture = gpu.layer_texture(source.layers)
+        self.version = -1
+        super().__init__(source, stack_view(self.texture))
+
+    def accepts(self, source: TextureSource) -> bool:
+        return source is self.source and source.layers.shape[:3] == self.shape
+
+    def refresh(self) -> None:
+        source = self.source
+        if source.version == self.version:
+            return
+        self.version = source.version
+        self.gpu.write_layers(self.texture, source.layers)

--- a/manimlib/shaders/image.wgsl
+++ b/manimlib/shaders/image.wgsl
@@ -11,29 +11,7 @@ the shader does no shaping at all: it reads the corners, and reads the image at 
 
 // TEXTURES
 
-struct VertexOutput {
-    @builtin(position) position: vec4f,
-    @location(0) clip_distances: vec4f,
-    @location(1) im_coords: vec2f,
-    @location(2) opacity: f32,
-}
-
-@vertex
-fn vs_main(@builtin(vertex_index) index: u32) -> VertexOutput {
-    var out: VertexOutput;
-    if (index >= VERTS_PER_QUAD) {
-        out.position = vec4f(0.0, 0.0, 0.0, 1.0);
-        return out;
-    }
-    let corner = quad_corner(index);
-
-    let projection = project_point(read_vec3(corner, DATA_OFFSET_point));
-    out.position = projection.position;
-    out.clip_distances = projection.clip_distances;
-    out.im_coords = read_vec2(corner, DATA_OFFSET_im_coords);
-    out.opacity = read_float(corner, DATA_OFFSET_opacity);
-    return out;
-}
+#INSERT image_quad.wgsl
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {

--- a/manimlib/shaders/inserts/image_quad.wgsl
+++ b/manimlib/shaders/inserts/image_quad.wgsl
@@ -1,0 +1,28 @@
+/*
+The vertex stage shared by everything drawn as four corners with a texture stretched over
+them: it does no shaping at all, reading the corners and handing on where in the image each
+of them sits. What differs between such shaders is only how the fragment stage reads.
+*/
+struct VertexOutput {
+    @builtin(position) position: vec4f,
+    @location(0) clip_distances: vec4f,
+    @location(1) im_coords: vec2f,
+    @location(2) opacity: f32,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) index: u32) -> VertexOutput {
+    var out: VertexOutput;
+    if (index >= VERTS_PER_QUAD) {
+        out.position = vec4f(0.0, 0.0, 0.0, 1.0);
+        return out;
+    }
+    let corner = quad_corner(index);
+
+    let projection = project_point(read_vec3(corner, DATA_OFFSET_point));
+    out.position = projection.position;
+    out.clip_distances = projection.clip_distances;
+    out.im_coords = read_vec2(corner, DATA_OFFSET_im_coords);
+    out.opacity = read_float(corner, DATA_OFFSET_opacity);
+    return out;
+}

--- a/manimlib/shaders/video.wgsl
+++ b/manimlib/shaders/video.wgsl
@@ -19,8 +19,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     clip_test(in.clip_distances);
     // A preloaded clip has a layer per frame; one read a frame at a time has just the one,
     // whatever frame the mobject says it is showing. A blend landing between two frames
-    // shows the nearer, as VideoMobject.frame_index reads it too
-    let layer = min(u32(max(round(mob.frame), 0.0)), textureNumLayers(Texture) - 1u);
+    // shows the nearer, and one past either end comes round again, which is how a clip set
+    // to loop reads its first frame back, all as VideoMobject.frame_index reads it too
+    let count = f32(textureNumLayers(Texture));
+    var index = round(mob.frame) % count;
+    if (index < 0.0) {
+        index = index + count;
+    }
+    let layer = u32(index);
     var color = textureSample(Texture, image_sampler, in.im_coords, layer);
     color.a *= in.opacity;
     return color;

--- a/manimlib/shaders/video.wgsl
+++ b/manimlib/shaders/video.wgsl
@@ -1,0 +1,27 @@
+/*
+A video is drawn exactly as an image is, four corners with a texture stretched over them,
+except that the texture holds every frame of the clip at once and the mobject says which of
+them to read, see mobject/types/video_mobject.py.
+*/
+#INSERT mobject_uniforms.wgsl
+#INSERT frame_uniforms.wgsl
+#INSERT read_data.wgsl
+#INSERT project_point.wgsl
+#INSERT quad_corners.wgsl
+#INSERT clip_test.wgsl
+
+// TEXTURES
+
+#INSERT image_quad.wgsl
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+    clip_test(in.clip_distances);
+    // A preloaded clip has a layer per frame; one read a frame at a time has just the one,
+    // whatever frame the mobject says it is showing. A blend landing between two frames
+    // shows the nearer, as VideoMobject.frame_index reads it too
+    let layer = min(u32(max(round(mob.frame), 0.0)), textureNumLayers(Texture) - 1u);
+    var color = textureSample(Texture, image_sampler, in.im_coords, layer);
+    color.a *= in.opacity;
+    return color;
+}

--- a/manimlib/utils/images.py
+++ b/manimlib/utils/images.py
@@ -22,6 +22,14 @@ def get_full_raster_image_path(image_file_name: str) -> str:
     )
 
 
+def get_full_video_path(video_file_name: str) -> str:
+    return find_file(
+        video_file_name,
+        directories=[get_raster_image_dir()],
+        extensions=[".mp4", ".mov", ".webm", ".gif", ".mkv", ".avi", ""]
+    )
+
+
 def get_full_vector_image_path(image_file_name: str) -> str:
     return find_file(
         image_file_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 addict
 appdirs
 audioop-lts; python_version>='3.13'
+av
 colour
 diskcache
 ipython>=8.18.0

--- a/tests/render_compare.py
+++ b/tests/render_compare.py
@@ -64,6 +64,7 @@ CASES = [
     (SCENES, "TransparentSurfaces", "still"),
     (SCENES, "TexturedAndImages", "still"),
     (SCENES, "Videos", "still"),
+    (SCENES, "VideoPlayback", "video"),
     (SCENES, "Filtering", "still"),
     (SCENES, "DotsAndVectors", "still"),
     (SCENES, "FixedInFrame", "still"),

--- a/tests/render_compare.py
+++ b/tests/render_compare.py
@@ -63,6 +63,7 @@ CASES = [
     (SCENES, "Surfaces", "still"),
     (SCENES, "TransparentSurfaces", "still"),
     (SCENES, "TexturedAndImages", "still"),
+    (SCENES, "Videos", "still"),
     (SCENES, "Filtering", "still"),
     (SCENES, "DotsAndVectors", "still"),
     (SCENES, "FixedInFrame", "still"),

--- a/tests/render_compare.py
+++ b/tests/render_compare.py
@@ -63,6 +63,7 @@ CASES = [
     (SCENES, "Surfaces", "still"),
     (SCENES, "TransparentSurfaces", "still"),
     (SCENES, "TexturedAndImages", "still"),
+    (SCENES, "Filtering", "still"),
     (SCENES, "DotsAndVectors", "still"),
     (SCENES, "FixedInFrame", "still"),
     (SCENES, "Zoomed", "still"),

--- a/tests/scenes.py
+++ b/tests/scenes.py
@@ -324,6 +324,21 @@ class Videos(Scene):
         self.add(behind, rows)
 
 
+class VideoPlayback(Scene):
+    """
+    A clip playing on as the scene runs, beside one scrubbed through by animating the time
+    it shows. The playing one is read a frame at a time, so every frame of it is an upload.
+    """
+
+    def construct(self):
+        playing = VideoMobject(copy_of(checker_video()), height=2, preload=False)
+        scrubbed = VideoMobject(checker_video(), height=2)
+        Group(playing, scrubbed).arrange(RIGHT, buff=0.5)
+        self.add(playing, scrubbed)
+        playing.play_from(0)
+        self.play(scrubbed.animate_set_time(scrubbed.get_duration()))
+
+
 class Filtering(Scene):
     """
     The two ways an image is read between its pixels, both scaled far past their own size:

--- a/tests/scenes.py
+++ b/tests/scenes.py
@@ -19,16 +19,16 @@ from manimlib import *
 ASSETS = Path(__file__).parent / "assets"
 
 
-def checker_image(name: str = "checker.png", size: int = 64) -> str:
+def checker_image(size: int = 64) -> str:
     """
     An image to hang on things which take a texture, made here rather than committed, so
     that it is the same every time without a binary living in the repository.
     """
     ASSETS.mkdir(exist_ok=True)
-    path = ASSETS / name
+    path = ASSETS / f"checker{size}.png"
     if not path.exists():
         rows, cols = np.indices((size, size))
-        squares = ((rows // 8 + cols // 8) % 2).astype(np.uint8)
+        squares = ((rows // max(1, size // 8) + cols // max(1, size // 8)) % 2).astype(np.uint8)
         Image.fromarray(np.stack([
             255 * squares,
             (255 * rows / size).astype(np.uint8),
@@ -255,6 +255,23 @@ class TexturedAndImages(ThreeDScene):
         group = Group(surface, image).arrange(RIGHT, buff=0.8)
         self.add(group)
         self.frame.reorient(10, 70)
+
+
+class Filtering(Scene):
+    """
+    The two ways an image is read between its pixels, both scaled far past their own size:
+    blended on the left, nearest pixel on the right. The same file behind both, so what
+    differs is the sampler and nothing else.
+    """
+
+    def construct(self):
+        image = checker_image(size=8)
+        row = Group(
+            ImageMobject(image, height=2.4),
+            ImageMobject(image, height=2.4, texture_filter="nearest"),
+        )
+        row.arrange(RIGHT, buff=0.3)
+        self.add(row)
 
 
 class DotsAndVectors(Scene):

--- a/tests/scenes.py
+++ b/tests/scenes.py
@@ -8,7 +8,9 @@ renderer makes, and every uniform a shader reads.
 """
 from __future__ import annotations
 
+import av
 import itertools as it
+import shutil
 import numpy as np
 from pathlib import Path
 from PIL import Image
@@ -35,6 +37,42 @@ def checker_image(size: int = 64) -> str:
             (255 * cols / size).astype(np.uint8),
         ], axis=2)).save(path)
     return str(path)
+
+
+def checker_video(size: int = 48, frames: int = 12) -> str:
+    """
+    A short clip whose every frame differs and which carries an alpha channel, made here
+    rather than committed, as the checker image is. Written losslessly, so that what a
+    VideoMobject shows is what was put in rather than what a codec made of it.
+    """
+    ASSETS.mkdir(exist_ok=True)
+    path = ASSETS / f"checker{size}x{frames}.mov"
+    if not path.exists():
+        rows, cols = np.indices((size, size))
+        radius = np.hypot(rows - size / 2, cols - size / 2)
+        with av.open(str(path), mode="w") as container:
+            stream = container.add_stream("qtrle", rate=12)
+            stream.width, stream.height = size, size
+            stream.pix_fmt = "argb"
+            for index in range(frames):
+                pixels = np.zeros((size, size, 4), dtype=np.uint8)
+                pixels[..., 0] = 255 * (index + 1) // frames
+                pixels[..., 1] = (255 * rows / size).astype(np.uint8)
+                pixels[..., 2] = (255 * cols / size).astype(np.uint8)
+                # A disc which grows frame by frame, so the alpha differs frame by frame too
+                pixels[..., 3] = 255 * (radius < size / 12 + size * index / (2 * frames))
+                frame = av.VideoFrame.from_ndarray(pixels, format="rgba")
+                container.mux(stream.encode(frame))
+            container.mux(stream.encode())
+    return str(path)
+
+
+def copy_of(path: str) -> str:
+    """The same file under another name, so that it is read as a file of its own"""
+    other = Path(path).with_stem(Path(path).stem + "_again")
+    if not other.exists():
+        shutil.copyfile(path, other)
+    return str(other)
 
 
 def star_points(n: int = 5, turns: int = 2, radius: float = 1.0) -> np.ndarray:
@@ -257,19 +295,53 @@ class TexturedAndImages(ThreeDScene):
         self.frame.reorient(10, 70)
 
 
+class Videos(Scene):
+    """
+    Several video mobjects drawn from one clip, each sitting on a frame of its own. The
+    clip carries an alpha channel, so what is behind each of them shows through.
+    """
+
+    def construct(self):
+        # The same clip under two names, a file being read one way or the other for the
+        # whole of it, see VideoSource.get
+        paths = [checker_video(), copy_of(checker_video())]
+        behind = VGroup(*(
+            Line(2 * DOWN, 2 * UP).set_stroke(YELLOW, 3).shift(x * RIGHT)
+            for x in np.linspace(-3, 3, 7)
+        ))
+        # Both ways a video's frames are held: preloaded whole and shared by everything
+        # naming the file, and a frame at a time as a clip too big for that is, which look
+        # the same on screen
+        rows = Group(*(
+            Group(*(VideoMobject(path, height=1.2, preload=preload) for _ in range(4)))
+            for path, preload in zip(paths, [True, False])
+        ))
+        for row in rows:
+            row.arrange(RIGHT, buff=0.4)
+            for index, video in enumerate(row):
+                video.set_frame(3 * index)
+        rows.arrange(DOWN, buff=0.3)
+        self.add(behind, rows)
+
+
 class Filtering(Scene):
     """
     The two ways an image is read between its pixels, both scaled far past their own size:
-    blended on the left, nearest pixel on the right. The same file behind both, so what
-    differs is the sampler and nothing else.
+    blended on the left, nearest pixel on the right, which is what a Sprite takes. The
+    same file behind all four, so what differs is the sampler and nothing else.
     """
 
     def construct(self):
         image = checker_image(size=8)
+        video = checker_video(size=8, frames=4)
         row = Group(
             ImageMobject(image, height=2.4),
             ImageMobject(image, height=2.4, texture_filter="nearest"),
+            VideoMobject(video, height=2.4),
+            Sprite(video, height=2.4),
         )
+        for mob in row[2:]:
+            mob.set_frame(2)
         row.arrange(RIGHT, buff=0.3)
         self.add(row)
 

--- a/tests/scenes.py
+++ b/tests/scenes.py
@@ -326,16 +326,19 @@ class Videos(Scene):
 
 class VideoPlayback(Scene):
     """
-    A clip playing on as the scene runs, beside one scrubbed through by animating the time
-    it shows. The playing one is read a frame at a time, so every frame of it is an upload.
+    A clip playing on as the scene runs, beside one scrubbed through by animating the time it
+    shows. The playing one is read a frame at a time, so every frame of it is an upload, and
+    it loops, so it runs past the end of the clip and round to the beginning again.
     """
 
     def construct(self):
-        playing = VideoMobject(copy_of(checker_video()), height=2, preload=False)
+        playing = VideoMobject(
+            copy_of(checker_video()), height=2, loop=True, preload=False,
+        )
         scrubbed = VideoMobject(checker_video(), height=2)
         Group(playing, scrubbed).arrange(RIGHT, buff=0.5)
         self.add(playing, scrubbed)
-        playing.play_from(0)
+        playing.play_from(0.5)
         self.play(scrubbed.animate_set_time(scrubbed.get_duration()))
 
 


### PR DESCRIPTION
`VideoMobject` is an `ImageMobject` showing whichever frame of a clip it was last given, by time or by number. `Sprite` is one read nearest pixel, so pixel art stays crisp however far it is scaled.

```python
video = VideoMobject("clip.mov", height=3)
self.add(video)
self.play(video.animate_set_time(2.0))     # scrubs through the frames between
```

The frames of a file are decoded once between every mobject naming it. A clip small enough is preloaded, so moving between its frames costs no more than a uniform. A larger one is read a frame at a time, each mobject rewriting a layer of its own. Which frame is showing lives in a uniform and nowhere else, which is what lets set_time be animated.

Getting there took three changes to how images are held:

- Textures move from the material to the drawing. A material stands behind every mobject of a kind, so holding images there meant a material per image file and no way for a mobject to change what it draws from. A mobject now holds a TextureSource, realized on the gpu at first draw.
- A mobject can say how its images are filtered. texture_filter="nearest" takes the nearest pixel instead of blending; one sampler per mode, chosen per drawing, so two mobjects of one file may be read differently.
- A texture may be a stack the shader picks a layer from. Uploaded once and shared where it has a key, owned and rewritten where it does not.

av is a new dependency.